### PR TITLE
Add mult.ve.cr and mult.ve.aaq instructions (closes #17)

### DIFF
--- a/src/tools/ipu-as-py/src/ipu_as/inst.py
+++ b/src/tools/ipu-as-py/src/ipu_as/inst.py
@@ -309,6 +309,8 @@ class MultInst(Inst):
             reg.LrRegField,
             reg.LrRegField,
             reg.LrRegField,
+            reg.CrRegField,
+            reg.AaqRegField,
         ]
 
     @classmethod

--- a/src/tools/ipu-common/src/ipu_common/instruction_spec.py
+++ b/src/tools/ipu-common/src/ipu_common/instruction_spec.py
@@ -136,7 +136,7 @@ class InstructionDoc:
 
 SLOT_BINARY_LAYOUT: dict[str, list[str]] = {
     "xmem": ["MultStageReg", "LrIdx", "LrIdx", "CrIdx"],
-    "mult": ["MultStageReg", "LrIdx", "LrIdx", "LrIdx", "LrIdx"],
+    "mult": ["MultStageReg", "LrIdx", "LrIdx", "LrIdx", "LrIdx", "CrIdx", "AaqRegIdx"],
     "acc": ["AaqRegIdx", "ElementsInRow", "HorizontalStride", "VerticalStride", "LrIdx"],
     "aaq": ["AggMode", "PostFn", "CrIdx", "AaqRegIdx"],
     "lr": ["LrIdx", "LcrIdx", "LcrIdx", "Immediate"],
@@ -341,7 +341,7 @@ INSTRUCTION_SPEC = {
     
     # =========================================================================
     # MULT Slot (Multiply Instructions)
-    # Opcode = position: mult.ee=0, mult.ev=1, mult.ve=2, mult_nop=3
+    # Opcode = position: mult.ee=0, mult.ev=1 (deprecated), mult.ve=2, mult_nop=3, mult.ve.cr=4, mult.ve.aaq=5
     # =========================================================================
     "mult": {
         "mult.ee": {
@@ -374,8 +374,8 @@ INSTRUCTION_SPEC = {
                 {"name": "mask_shift", "type": "LrIdx", "read": "live"},
             ],
             "doc": InstructionDoc(
-                title="Element-Cyclic Multiply",
-                summary="Multiply Ra elements against a fixed element from cyclic register.",
+                title="Element-Cyclic Multiply (Deprecated)",
+                summary="[DEPRECATED: use mult.ve.cr or mult.ve.aaq] Multiply Ra elements against a fixed element from cyclic register.",
                 syntax="mult.ev ra fixed_cyclic_idx mask_offset mask_shift",
                 operands=[
                     "ra: Multiplicand register (r0, r1, or mem_bypass)",
@@ -421,6 +421,50 @@ INSTRUCTION_SPEC = {
                 operands=[],
             ),
             "execute_fn": "execute_mult_nop",
+        },
+        "mult.ve.cr": {
+            "operands": [
+                {"name": "cyclic_offset", "type": "LrIdx", "read": "live"},
+                {"name": "mask_offset", "type": "LrIdx", "read": "live"},
+                {"name": "mask_shift", "type": "LrIdx", "read": "live"},
+                {"name": "cr_idx", "type": "CrIdx"},
+            ],
+            "doc": InstructionDoc(
+                title="Vector-Element Multiply (CR scalar)",
+                summary="Multiply each element of RC[cyclic_offset:cyclic_offset+128] by a scalar from a CR register. Elements beyond RC boundary are treated as 1 (dtype-specific).",
+                syntax="mult.ve.cr cyclic_offset mask_offset mask_shift cr_idx",
+                operands=[
+                    "cyclic_offset: Base offset into RC (cyclic register); non-cyclic — out-of-bounds elements are padded with 1",
+                    "mask_offset: Offset to select mask from RM (mask register)",
+                    "mask_shift: Shift applied to the mask register",
+                    "cr_idx: CR register whose low byte supplies the fixed scalar multiplier (cr0-cr15)",
+                ],
+                operation="For i in [0,128): rb = RC[cyclic_offset+i] if in bounds else dtype_one; mult_res[i] = CR[cr_idx][0] * rb",
+                example="mult.ve.cr lr0 lr15 lr15 cr3;;",
+            ),
+            "execute_fn": "execute_mult_ve_cr",
+        },
+        "mult.ve.aaq": {
+            "operands": [
+                {"name": "cyclic_offset", "type": "LrIdx", "read": "live"},
+                {"name": "mask_offset", "type": "LrIdx", "read": "live"},
+                {"name": "mask_shift", "type": "LrIdx", "read": "live"},
+                {"name": "aaq_rf_idx", "type": "AaqRegIdx"},
+            ],
+            "doc": InstructionDoc(
+                title="Vector-Element Multiply (AAQ scalar)",
+                summary="Multiply each element of RC[cyclic_offset:cyclic_offset+128] by a scalar from an AAQ register. Elements beyond RC boundary are treated as 1 (dtype-specific).",
+                syntax="mult.ve.aaq cyclic_offset mask_offset mask_shift aaq_rf_idx",
+                operands=[
+                    "cyclic_offset: Base offset into RC (cyclic register); non-cyclic — out-of-bounds elements are padded with 1",
+                    "mask_offset: Offset to select mask from RM (mask register)",
+                    "mask_shift: Shift applied to the mask register",
+                    "aaq_rf_idx: AAQ register whose low byte supplies the fixed scalar multiplier (aaq0-aaq3)",
+                ],
+                operation="For i in [0,128): rb = RC[cyclic_offset+i] if in bounds else dtype_one; mult_res[i] = AAQ[aaq_rf_idx][0] * rb",
+                example="mult.ve.aaq lr0 lr15 lr15 aaq1;;",
+            ),
+            "execute_fn": "execute_mult_ve_aaq",
         },
     },
 

--- a/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
@@ -22,7 +22,7 @@ from typing import Any
 
 from ipu_emu.ipu_state import IpuState, INST_MEM_SIZE
 from ipu_emu.regfile import RegFile
-from ipu_emu.ipu_math import ipu_mult, ipu_add, DType
+from ipu_emu.ipu_math import ipu_mult, ipu_add, dtype_one_byte, DType
 from ipu_common.instruction_spec import (
     INSTRUCTION_SPEC,
     SLOT_BINARY_LAYOUT,
@@ -436,6 +436,54 @@ class Ipu:
         for i in range(R_REG_SIZE):
             result = ipu_mult(ra_fixed, rb[i], dtype)
             struct.pack_into("<i" if dtype == DType.INT8 else "<f", mult_res, i * 4, result)
+
+        self._mult_mask_and_shift(mask_offset, mask_shift)
+
+    def execute_mult_ve_cr(self, *, cyclic_offset: int, mask_offset: int,
+                           mask_shift: int, cr_idx: int) -> None:
+        """Execute mult.ve.cr: CR scalar x RC elements with boundary padding.
+
+        Multiplies the low byte of CR[cr_idx] against each byte of
+        RC[cyclic_offset : cyclic_offset+128]. Unlike mult.ve, this is
+        non-cyclic: elements where cyclic_offset+i >= R_CYCLIC_SIZE are
+        padded with the dtype-specific encoding of 1 instead of wrapping.
+        """
+        dtype = self.state.get_cr_dtype()
+        scalar_byte = self.state.regfile.get_cr(cr_idx) & 0xFF
+        rc_buf = self.state.regfile.raw("r_cyclic")
+        one_byte = dtype_one_byte(dtype)
+        mult_res = self.state.regfile.raw("mult_res")
+        fmt = "<i" if dtype == DType.INT8 else "<f"
+
+        for i in range(R_REG_SIZE):
+            pos = cyclic_offset + i
+            rb_byte = rc_buf[pos] if pos < R_CYCLIC_SIZE else one_byte
+            result = ipu_mult(scalar_byte, rb_byte, dtype)
+            struct.pack_into(fmt, mult_res, i * 4, result)
+
+        self._mult_mask_and_shift(mask_offset, mask_shift)
+
+    def execute_mult_ve_aaq(self, *, cyclic_offset: int, mask_offset: int,
+                            mask_shift: int, aaq_rf_idx: int) -> None:
+        """Execute mult.ve.aaq: AAQ scalar x RC elements with boundary padding.
+
+        Multiplies the low byte of AAQ[aaq_rf_idx] against each byte of
+        RC[cyclic_offset : cyclic_offset+128]. Non-cyclic: elements where
+        cyclic_offset+i >= R_CYCLIC_SIZE are padded with the dtype-specific
+        encoding of 1 instead of wrapping.
+        """
+        dtype = self.state.get_cr_dtype()
+        scalar_byte = self.state.regfile.get_aaq(aaq_rf_idx) & 0xFF
+        rc_buf = self.state.regfile.raw("r_cyclic")
+        one_byte = dtype_one_byte(dtype)
+        mult_res = self.state.regfile.raw("mult_res")
+        fmt = "<i" if dtype == DType.INT8 else "<f"
+
+        for i in range(R_REG_SIZE):
+            pos = cyclic_offset + i
+            rb_byte = rc_buf[pos] if pos < R_CYCLIC_SIZE else one_byte
+            result = ipu_mult(scalar_byte, rb_byte, dtype)
+            struct.pack_into(fmt, mult_res, i * 4, result)
 
         self._mult_mask_and_shift(mask_offset, mask_shift)
 

--- a/src/tools/ipu-emu-py/src/ipu_emu/ipu_math.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/ipu_math.py
@@ -60,6 +60,17 @@ def fp8_bytes_to_fp32(raw: bytes, dtype: DType) -> np.ndarray:
     return arr.astype(np.float32)
 
 
+def dtype_one_byte(dtype: DType) -> int:
+    """Return the raw uint8 encoding of the value 1 for the given dtype.
+
+    Used to pad out-of-bounds RC elements in mult.ve.cr / mult.ve.aaq.
+    """
+    if dtype == DType.INT8:
+        return 0x01
+    np_dtype = _FP8_NUMPY_DTYPE[dtype]
+    return int(np.array(1.0, dtype=np.float32).astype(np_dtype).view(np.uint8))
+
+
 def ipu_mult(a_byte: int, b_byte: int, dtype: int) -> int | float:
     """Multiply two bytes according to *dtype*, returning int32 or float.
 

--- a/src/tools/ipu-emu-py/test/test_execute.py
+++ b/src/tools/ipu-emu-py/test/test_execute.py
@@ -869,3 +869,325 @@ bkpt;;
         for i in range(128):
             val = struct.unpack_from("<f", acc_raw, i * 4)[0]
             assert abs(val - 2.0) < 0.01, f"acc word {i}: expected 2.0, got {val}"
+
+
+# ============================================================================
+# mult.ve.cr and mult.ve.aaq
+# ============================================================================
+
+
+class TestMultVeCrAaq:
+    """Tests for mult.ve.cr and mult.ve.aaq instructions."""
+
+    # ------------------------------------------------------------------
+    # mult.ve.cr
+    # ------------------------------------------------------------------
+
+    def test_mult_ve_cr_int8(self):
+        """mult.ve.cr INT8: scalar from CR × RC elements."""
+        # CR scalar byte = 3, RC elements = all 2 → each result = 3*2 = 6
+        cyclic_data = bytes([2] * 512)
+
+        state = _make_state(
+            """\
+set lr0 0x1000;;
+set lr1 0;;
+ldr_cyclic_mult_reg lr0 cr0 lr1;;
+reset_acc;;
+set lr2 0;;
+set lr3 0;;
+set lr4 0;;
+mult.ve.cr lr2 lr3 lr4 cr1;
+acc;;
+bkpt;;
+"""
+        )
+        state.regfile.set_cr(15, DType.INT8)
+        state.regfile.set_cr(1, 3)  # scalar = low byte = 3
+        state.xmem.write_address(0x1000, cyclic_data)
+        run_until_complete(state)
+
+        acc_raw = state.regfile.raw("r_acc")
+        for i in range(128):
+            val = struct.unpack_from("<i", acc_raw, i * 4)[0]
+            assert val == 6, f"acc word {i}: expected 6, got {val}"
+
+    def test_mult_ve_cr_negative_int8(self):
+        """mult.ve.cr INT8: signed negative scalar × positive RC elements."""
+        # CR scalar byte = 0xFE = -2 (signed int8), RC elements = 5 → result = -10
+        cyclic_data = bytes([5] * 512)
+
+        state = _make_state(
+            """\
+set lr0 0x1000;;
+set lr1 0;;
+ldr_cyclic_mult_reg lr0 cr0 lr1;;
+reset_acc;;
+set lr2 0;;
+set lr3 0;;
+set lr4 0;;
+mult.ve.cr lr2 lr3 lr4 cr2;
+acc;;
+bkpt;;
+"""
+        )
+        state.regfile.set_cr(15, DType.INT8)
+        state.regfile.set_cr(2, 0xFE)  # low byte 0xFE = int8(-2)
+        state.xmem.write_address(0x1000, cyclic_data)
+        run_until_complete(state)
+
+        acc_raw = state.regfile.raw("r_acc")
+        for i in range(128):
+            val = struct.unpack_from("<i", acc_raw, i * 4)[0]
+            assert val == -10, f"acc word {i}: expected -10, got {val}"
+
+    def test_mult_ve_cr_boundary_padding(self):
+        """mult.ve.cr: elements beyond RC boundary (512 bytes) are padded with int8 1."""
+        # cyclic_offset = 450, so first 62 bytes come from RC, remaining 66 are padded with 1
+        rc_fill = 4  # RC filled with 4
+        scalar = 7
+        pad_start = 62  # 512 - 450 = 62 elements in bounds
+
+        state = _make_state(
+            """\
+reset_acc;;
+set lr2 450;;
+set lr3 0;;
+set lr4 0;;
+mult.ve.cr lr2 lr3 lr4 cr3;
+acc;;
+bkpt;;
+"""
+        )
+        state.regfile.set_cr(15, DType.INT8)
+        state.regfile.set_cr(3, scalar)
+        # Fill the full 512-byte cyclic register directly
+        state.regfile.set_r_cyclic_at(0, bytes([rc_fill] * 512))
+        run_until_complete(state)
+
+        acc_raw = state.regfile.raw("r_acc")
+        for i in range(pad_start):
+            val = struct.unpack_from("<i", acc_raw, i * 4)[0]
+            assert val == scalar * rc_fill, f"word {i}: expected {scalar * rc_fill}, got {val}"
+        for i in range(pad_start, 128):
+            val = struct.unpack_from("<i", acc_raw, i * 4)[0]
+            assert val == scalar * 1, f"word {i} (padded): expected {scalar}, got {val}"
+
+    def test_mult_ve_cr_fp8e4m3(self):
+        """mult.ve.cr FP8_E4M3: scalar 1.0 × RC elements 1.0 → result 1.0 each."""
+        import numpy as np
+        from ml_dtypes import float8_e4m3fn
+
+        one_fp8 = int(np.array(1.0, dtype=np.float32).astype(float8_e4m3fn).view(np.uint8))
+        cyclic_data = bytes([one_fp8] * 512)
+
+        state = _make_state(
+            """\
+set lr0 0x1000;;
+set lr1 0;;
+ldr_cyclic_mult_reg lr0 cr0 lr1;;
+reset_acc;;
+set lr2 0;;
+set lr3 0;;
+set lr4 0;;
+mult.ve.cr lr2 lr3 lr4 cr5;
+acc;;
+bkpt;;
+"""
+        )
+        state.regfile.set_cr(15, DType.FP8_E4M3)
+        state.regfile.set_cr(5, one_fp8)  # scalar = 1.0 in FP8_E4M3
+        state.xmem.write_address(0x1000, cyclic_data)
+        run_until_complete(state)
+
+        acc_raw = state.regfile.raw("r_acc")
+        for i in range(128):
+            val = struct.unpack_from("<f", acc_raw, i * 4)[0]
+            assert abs(val - 1.0) < 0.01, f"acc word {i}: expected 1.0, got {val}"
+
+    def test_mult_ve_cr_boundary_padding_fp8e5m2(self):
+        """mult.ve.cr FP8_E5M2: boundary elements padded with FP8 1.0."""
+        import numpy as np
+        from ml_dtypes import float8_e5m2
+
+        two_fp8 = int(np.array(2.0, dtype=np.float32).astype(float8_e5m2).view(np.uint8))
+        scalar_fp8 = int(np.array(3.0, dtype=np.float32).astype(float8_e5m2).view(np.uint8))
+
+        state = _make_state(
+            """\
+reset_acc;;
+set lr2 500;;
+set lr3 0;;
+set lr4 0;;
+mult.ve.cr lr2 lr3 lr4 cr6;
+acc;;
+bkpt;;
+"""
+        )
+        state.regfile.set_cr(15, DType.FP8_E5M2)
+        state.regfile.set_cr(6, scalar_fp8)  # scalar = 3.0
+        # Fill the full 512-byte cyclic register directly with 2.0 in FP8_E5M2
+        state.regfile.set_r_cyclic_at(0, bytes([two_fp8] * 512))
+        run_until_complete(state)
+
+        acc_raw = state.regfile.raw("r_acc")
+        for i in range(12):  # in-bounds (500..511): 3.0 * 2.0 = 6.0
+            val = struct.unpack_from("<f", acc_raw, i * 4)[0]
+            assert abs(val - 6.0) < 0.1, f"word {i}: expected 6.0, got {val}"
+        for i in range(12, 128):  # padded (>=512): 3.0 * 1.0 = 3.0
+            val = struct.unpack_from("<f", acc_raw, i * 4)[0]
+            assert abs(val - 3.0) < 0.1, f"word {i} (padded): expected 3.0, got {val}"
+
+    # ------------------------------------------------------------------
+    # mult.ve.aaq
+    # ------------------------------------------------------------------
+
+    def test_mult_ve_aaq_int8(self):
+        """mult.ve.aaq INT8: scalar from AAQ × RC elements."""
+        # AAQ scalar byte = 5, RC elements = all 3 → each result = 15
+        cyclic_data = bytes([3] * 512)
+
+        state = _make_state(
+            """\
+set lr0 0x1000;;
+set lr1 0;;
+ldr_cyclic_mult_reg lr0 cr0 lr1;;
+reset_acc;;
+set lr2 0;;
+set lr3 0;;
+set lr4 0;;
+mult.ve.aaq lr2 lr3 lr4 aaq0;
+acc;;
+bkpt;;
+"""
+        )
+        state.regfile.set_cr(15, DType.INT8)
+        state.regfile.set_aaq(0, 5)  # low byte = 5
+        state.xmem.write_address(0x1000, cyclic_data)
+        run_until_complete(state)
+
+        acc_raw = state.regfile.raw("r_acc")
+        for i in range(128):
+            val = struct.unpack_from("<i", acc_raw, i * 4)[0]
+            assert val == 15, f"acc word {i}: expected 15, got {val}"
+
+    def test_mult_ve_aaq_boundary_padding(self):
+        """mult.ve.aaq: elements beyond RC boundary are padded with int8 1."""
+        scalar = 2
+        in_bounds = 112  # offset=400, 512-400=112 in bounds, 16 padded
+
+        state = _make_state(
+            """\
+reset_acc;;
+set lr2 400;;
+set lr3 0;;
+set lr4 0;;
+mult.ve.aaq lr2 lr3 lr4 aaq1;
+acc;;
+bkpt;;
+"""
+        )
+        state.regfile.set_cr(15, DType.INT8)
+        state.regfile.set_aaq(1, scalar)
+        # Fill the full 512-byte cyclic register directly
+        state.regfile.set_r_cyclic_at(0, bytes([10] * 512))
+        run_until_complete(state)
+
+        acc_raw = state.regfile.raw("r_acc")
+        for i in range(in_bounds):
+            val = struct.unpack_from("<i", acc_raw, i * 4)[0]
+            assert val == scalar * 10, f"word {i}: expected {scalar * 10}, got {val}"
+        for i in range(in_bounds, 128):
+            val = struct.unpack_from("<i", acc_raw, i * 4)[0]
+            assert val == scalar * 1, f"word {i} (padded): expected {scalar}, got {val}"
+
+    def test_mult_ve_aaq_no_boundary(self):
+        """mult.ve.aaq: when cyclic_offset+128 <= 512, no padding applied."""
+        cyclic_data = bytes([7] * 512)
+        scalar = 3
+
+        state = _make_state(
+            """\
+set lr0 0x1000;;
+set lr1 0;;
+ldr_cyclic_mult_reg lr0 cr0 lr1;;
+reset_acc;;
+set lr2 0;;
+set lr3 0;;
+set lr4 0;;
+mult.ve.aaq lr2 lr3 lr4 aaq2;
+acc;;
+bkpt;;
+"""
+        )
+        state.regfile.set_cr(15, DType.INT8)
+        state.regfile.set_aaq(2, scalar)
+        state.xmem.write_address(0x1000, cyclic_data)
+        run_until_complete(state)
+
+        acc_raw = state.regfile.raw("r_acc")
+        for i in range(128):
+            val = struct.unpack_from("<i", acc_raw, i * 4)[0]
+            assert val == scalar * 7, f"acc word {i}: expected {scalar * 7}, got {val}"
+
+    # ------------------------------------------------------------------
+    # Backward compatibility: existing instructions unaffected
+    # ------------------------------------------------------------------
+
+    def test_backward_compat_mult_ee(self):
+        """mult.ee still works correctly after adding new mult variants."""
+        r0_data = bytes([4] * 128)
+        cyclic_data = bytes([5] * 512)
+
+        state = _make_state(
+            """\
+set lr0 0x1000;;
+ldr_mult_reg r0 lr0 cr0;;
+set lr1 0x2000;;
+set lr2 0;;
+ldr_cyclic_mult_reg lr1 cr0 lr2;;
+reset_acc;;
+mult.ee r0 lr2 lr2 lr2;
+acc;;
+bkpt;;
+"""
+        )
+        state.regfile.set_cr(15, DType.INT8)
+        state.xmem.write_address(0x1000, r0_data)
+        state.xmem.write_address(0x2000, cyclic_data)
+        run_until_complete(state)
+
+        acc_raw = state.regfile.raw("r_acc")
+        for i in range(128):
+            val = struct.unpack_from("<i", acc_raw, i * 4)[0]
+            assert val == 20, f"acc word {i}: expected 20, got {val}"
+
+    def test_backward_compat_mult_ve(self):
+        """mult.ve still works correctly after adding new mult variants."""
+        cyclic_data = bytes([6] * 512)
+        r0_data = bytes([0] * 128)
+        r0_data = bytearray(r0_data)
+        r0_data[0] = 3  # fixed_ra_idx=0 → scalar = 3
+
+        state = _make_state(
+            """\
+set lr0 0x1000;;
+ldr_mult_reg r0 lr0 cr0;;
+set lr1 0x2000;;
+set lr2 0;;
+ldr_cyclic_mult_reg lr1 cr0 lr2;;
+reset_acc;;
+mult.ve r0 lr2 lr2 lr2 lr2;
+acc;;
+bkpt;;
+"""
+        )
+        state.regfile.set_cr(15, DType.INT8)
+        state.xmem.write_address(0x1000, bytes(r0_data))
+        state.xmem.write_address(0x2000, cyclic_data)
+        run_until_complete(state)
+
+        acc_raw = state.regfile.raw("r_acc")
+        for i in range(128):
+            val = struct.unpack_from("<i", acc_raw, i * 4)[0]
+            assert val == 18, f"acc word {i}: expected 18, got {val}"


### PR DESCRIPTION
  Closes #17                                                                                                                                                                                         
                                                                                                                                                                                                     
  Summary
                                                                                                                                                                                                     
  - mult.ve.cr (opcode 4): multiplies each element of RC[cyclic_offset:+128] by the low byte of a specified CR register. No ra operand.                                                              
  - mult.ve.aaq (opcode 5): same but scalar comes from a specified AAQ register.
  - Boundary padding: non-cyclic — RC elements at or beyond offset 512 are replaced with the dtype-specific "1" (INT8=0x01, FP8_E4M3=0x38, FP8_E5M2=0x3C) instead of wrapping.                       
  - mult.ev deprecated but kept at opcode 1 — existing programs like fully_connected.asm continue to work unchanged.                                                                                 
                                                                                                                                                                                                     
  Test plan                                                                                                                                                                                          
                                                                                                                                                                                                     
  - 10 new tests in TestMultVeCrAaq: INT8/FP8 dtypes, boundary padding at various offsets, backward compat for mult.ee / mult.ve                                                                     
  - Full suite: 158 tests pass