### PR TITLE
Add aaq quantization instruction and xmem.store_aaq_result (closes #24)

### DIFF
--- a/src/tools/ipu-common/src/ipu_common/instruction_spec.py
+++ b/src/tools/ipu-common/src/ipu_common/instruction_spec.py
@@ -254,6 +254,24 @@ INSTRUCTION_SPEC = {
             ),
             "execute_fn": "execute_xmem_nop",
         },
+        "xmem.store_aaq_result": {
+            "operands": [
+                {"name": "offset", "type": "LrIdx", "read": "live"},
+                {"name": "base", "type": "CrIdx", "read": "live"},
+            ],
+            "doc": InstructionDoc(
+                title="Store AAQ Result",
+                summary="Write the 128-byte AAQ quantization result register to external memory.",
+                syntax="xmem.store_aaq_result offset base",
+                operands=[
+                    "offset: Offset register (lr0-lr15)",
+                    "base: Base address register (cr0-cr15)",
+                ],
+                operation="Memory[offset + base] = aaq_result  # 128 bytes",
+                example="xmem.store_aaq_result lr0 cr0;;",
+            ),
+            "execute_fn": "execute_xmem_store_aaq_result",
+        },
     },
     
     # =========================================================================
@@ -659,6 +677,21 @@ INSTRUCTION_SPEC = {
                 example="agg sum value cr0 aaq0;;",
             ),
             "execute_fn": "execute_agg",
+        },
+        "aaq": {
+            "operands": [],
+            "doc": InstructionDoc(
+                title="AAQ Quantize",
+                summary="Quantize the 128-word accumulator from INT32 to INT8, storing clamped results in the aaq_result register. Requires INT8 mode.",
+                syntax="aaq",
+                operands=[],
+                operation=(
+                    "Requires INT8 mode (cr15 == DType.INT8). "
+                    "For i in [0, 128): aaq_result[i] = clamp(trunc(r_acc[i]), -128, 127)"
+                ),
+                example="aaq;;",
+            ),
+            "execute_fn": "execute_aaq",
         },
     },
 

--- a/src/tools/ipu-common/src/ipu_common/registers.py
+++ b/src/tools/ipu-common/src/ipu_common/registers.py
@@ -89,6 +89,14 @@ REGISTER_DEFINITIONS = {
         "assembler_values": [f"aaq{i}" for i in range(4)],
         "encoding_class": "AaqRegField",
     },
+    # AAQ quantization result — 128 × INT8 output of the aaq instruction
+    "aaq_result": {
+        "kind": RegKind.AAQ,
+        "vector": True,
+        "size_bytes": 128,
+        "count": 1,
+        "dtype": RegDtype.UINT8,
+    },
     # -----------------------------------------------------------------------
     # LR / CR scalar registers
     # -----------------------------------------------------------------------

--- a/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
@@ -17,6 +17,7 @@ Key Design:
 from __future__ import annotations
 
 import struct
+import warnings
 from enum import IntEnum
 from typing import Any
 
@@ -46,6 +47,14 @@ from ipu_common.acc_agg_enums import (
     get_post_fn,
 )
 from ipu_common.registers import get_register_sizes, get_mult_stage_map
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+class EmulatorError(RuntimeError):
+    """Raised when the emulator detects an invalid operation."""
+
 
 # ---------------------------------------------------------------------------
 # Constants — derived from the single source of truth in ipu-common
@@ -291,7 +300,12 @@ class Ipu:
         pass
 
     def execute_str_acc_reg(self, *, offset: int, base: int) -> None:
-        """Execute str_acc_reg: Store accumulator to memory."""
+        """Execute str_acc_reg: Store accumulator to memory (debug only)."""
+        warnings.warn(
+            "[DEBUG ONLY] str_acc_reg is not a hardware instruction and is available "
+            "for emulator debugging purposes only",
+            stacklevel=2,
+        )
         addr = offset + base
         acc_data = self.state.regfile.get_r_acc_bytes()
         self.state.xmem.write_address(addr, acc_data)
@@ -720,6 +734,32 @@ class Ipu:
 
         out_bits = struct.unpack("<I", struct.pack(fmt, result_val))[0]
         self.state.regfile.set_aaq(aaq_rf_idx, out_bits)
+
+    def execute_aaq(self) -> None:
+        """Execute aaq: Quantize r_acc (128 × INT32) → aaq_result (128 × INT8).
+
+        Requires INT8 mode. Each 32-bit word is truncated (top 8 bits taken via
+        arithmetic right-shift by 24) then clamped to [-128, 127] and stored as
+        a signed byte in the aaq_result register.
+        """
+        dtype = self.state.get_cr_dtype()
+        if dtype != DType.INT8:
+            raise EmulatorError("AAQ instruction requires INT8 mode")
+
+        acc_buf = self.state.regfile.raw("r_acc")
+        result = bytearray(128)
+        for i in range(128):
+            val = struct.unpack_from("<i", acc_buf, i * 4)[0]
+            truncated = val >> 24  # arithmetic right-shift: keeps top 8 bits, range [-128, 127]
+            clamped = max(-128, min(127, truncated))
+            result[i] = clamped & 0xFF
+        self.state.regfile.set_aaq_result(result)
+
+    def execute_xmem_store_aaq_result(self, *, offset: int, base: int) -> None:
+        """Execute xmem.store_aaq_result: Write 128-byte aaq_result to xmem."""
+        addr = offset + base
+        data = self.state.regfile.get_aaq_result()
+        self.state.xmem.write_address(addr, data)
 
     # -----------------------------------------------------------------------
     # COND Instruction Handlers

--- a/src/tools/ipu-emu-py/test/test_execute.py
+++ b/src/tools/ipu-emu-py/test/test_execute.py
@@ -1191,3 +1191,139 @@ bkpt;;
         for i in range(128):
             val = struct.unpack_from("<i", acc_raw, i * 4)[0]
             assert val == 18, f"acc word {i}: expected 18, got {val}"
+
+
+# ============================================================================
+# AAQ Quantization (aaq instruction + xmem.store_aaq_result)
+# ============================================================================
+
+
+class TestAaqQuantize:
+    """Tests for the aaq quantization instruction and xmem.store_aaq_result."""
+
+    def _set_acc_words(self, state: IpuState, values: list[int]) -> None:
+        """Write a list of 128 signed INT32 values into r_acc."""
+        assert len(values) == 128
+        buf = bytearray(512)
+        struct.pack_into("<128i", buf, 0, *values)
+        state.regfile.set_r_acc_bytes(buf)
+
+    def test_aaq_basic_truncation(self):
+        """Values that fit in int8 after >> 24: e.g. 1 << 24 → byte 1."""
+        state = IpuState()
+        state.regfile.set_cr(15, DType.INT8)
+        self._set_acc_words(state, [i << 24 for i in range(128)])
+
+        encoded = assemble("aaq;;\nbkpt;;")
+        from ipu_emu.execute import decode_instruction_word
+        from ipu_emu.emulator import load_program, run_until_complete
+        decoded = [decode_instruction_word(w) for w in encoded]
+        load_program(state, decoded)
+        run_until_complete(state)
+
+        result = state.regfile.get_aaq_result()
+        for i in range(128):
+            expected = i if i < 128 else i - 256
+            assert result[i] == (expected & 0xFF), f"byte {i}: expected {expected & 0xFF}, got {result[i]}"
+
+    def test_aaq_all_zeros(self):
+        """All-zero accumulator quantizes to all-zero bytes."""
+        state = IpuState()
+        state.regfile.set_cr(15, DType.INT8)
+        self._set_acc_words(state, [0] * 128)
+
+        encoded = assemble("aaq;;\nbkpt;;")
+        from ipu_emu.execute import decode_instruction_word
+        from ipu_emu.emulator import load_program, run_until_complete
+        decoded = [decode_instruction_word(w) for w in encoded]
+        load_program(state, decoded)
+        run_until_complete(state)
+
+        assert state.regfile.get_aaq_result() == bytearray(128)
+
+    def test_aaq_positive_clamp(self):
+        """Large positive values clamp to 127 after truncation."""
+        # 0x7FFFFFFF >> 24 = 127, which is already at the boundary — no clamp needed.
+        # Use 0x7F000000 (127 << 24) and 0x80000000 (-128 << 24 in signed) for boundary.
+        state = IpuState()
+        state.regfile.set_cr(15, DType.INT8)
+        values = [0x7F000000] * 64 + [0x7FFFFFFF] * 64
+        self._set_acc_words(state, values)
+
+        encoded = assemble("aaq;;\nbkpt;;")
+        from ipu_emu.execute import decode_instruction_word
+        from ipu_emu.emulator import load_program, run_until_complete
+        decoded = [decode_instruction_word(w) for w in encoded]
+        load_program(state, decoded)
+        run_until_complete(state)
+
+        result = state.regfile.get_aaq_result()
+        for i in range(64):
+            assert result[i] == 127, f"byte {i}: expected 127, got {result[i]}"
+        for i in range(64, 128):
+            assert result[i] == 127, f"byte {i}: expected 127, got {result[i]}"
+
+    def test_aaq_negative_values(self):
+        """Negative accumulator values truncate correctly."""
+        # -1 << 24 = 0xFF000000 (signed int32: -16777216); >> 24 = -1 → 0xFF as byte
+        state = IpuState()
+        state.regfile.set_cr(15, DType.INT8)
+        self._set_acc_words(state, [(-1) << 24] * 128)
+
+        encoded = assemble("aaq;;\nbkpt;;")
+        from ipu_emu.execute import decode_instruction_word
+        from ipu_emu.emulator import load_program, run_until_complete
+        decoded = [decode_instruction_word(w) for w in encoded]
+        load_program(state, decoded)
+        run_until_complete(state)
+
+        result = state.regfile.get_aaq_result()
+        for i in range(128):
+            assert result[i] == 0xFF, f"byte {i}: expected 0xFF (-1), got {result[i]}"
+
+    def test_aaq_requires_int8_mode(self):
+        """aaq raises EmulatorError when not in INT8 mode."""
+        from ipu_emu.ipu import EmulatorError
+        state = _make_state("aaq;;\nbkpt;;")
+        state.set_cr_dtype(DType.FP8_E4M3)
+        with pytest.raises(EmulatorError, match="INT8 mode"):
+            run_until_complete(state)
+
+    def test_aaq_result_written_to_xmem(self):
+        """xmem.store_aaq_result writes exactly 128 bytes to the given address."""
+        state = IpuState()
+        state.regfile.set_cr(15, DType.INT8)
+        # Set r_acc: each word = i << 24 so byte i = i (for i < 128)
+        self._set_acc_words(state, [i << 24 for i in range(128)])
+
+        encoded = assemble(
+            """\
+aaq;;
+set lr0 0x4000;;
+xmem.store_aaq_result lr0 cr0;;
+bkpt;;
+"""
+        )
+        from ipu_emu.execute import decode_instruction_word
+        from ipu_emu.emulator import load_program, run_until_complete
+        decoded = [decode_instruction_word(w) for w in encoded]
+        load_program(state, decoded)
+        run_until_complete(state)
+
+        stored = state.xmem.read_address(0x4000, 128)
+        for i in range(128):
+            assert stored[i] == i, f"xmem byte {i}: expected {i}, got {stored[i]}"
+
+    def test_str_acc_reg_emits_warning(self):
+        """str_acc_reg emits a UserWarning about being debug-only."""
+        state = IpuState()
+        state.regfile.set_cr(15, DType.INT8)
+
+        encoded = assemble("str_acc_reg lr0 cr0;;\nbkpt;;")
+        from ipu_emu.execute import decode_instruction_word
+        from ipu_emu.emulator import load_program, run_until_complete
+        decoded = [decode_instruction_word(w) for w in encoded]
+        load_program(state, decoded)
+
+        with pytest.warns(UserWarning, match="DEBUG ONLY"):
+            run_until_complete(state)


### PR DESCRIPTION
## Summary

- New `aaq` instruction (AAQ slot): truncates `r_acc` INT32 words via `>> 24`, clamps to [-128, 127], stores in new `aaq_result` register; raises `EmulatorError` if not in INT8 mode
- New `aaq_result` register (128-byte INT8 vector)
- New `xmem.store_aaq_result` instruction: writes `aaq_result` (128 bytes) to external memory
- `str_acc_reg` demoted to debug-only: emits a `UserWarning` on execution

## Test plan

- [ ] `test_aaq_basic_truncation` — `>> 24` truncation produces correct bytes
- [ ] `test_aaq_all_zeros` — zero accumulator → zero result
- [ ] `test_aaq_positive_clamp` — values at int8 boundary clamp to 127
- [ ] `test_aaq_negative_values` — negative INT32 truncates correctly
- [ ] `test_aaq_requires_int8_mode` — `EmulatorError` raised outside INT8 mode
- [ ] `test_aaq_result_written_to_xmem` — `xmem.store_aaq_result` writes 128 bytes
- [ ] `test_str_acc_reg_emits_warning` — `UserWarning` with "DEBUG ONLY" message

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)