### PR TITLE
Replace bitwise stride decoding with lookup tables

### DIFF
--- a/src/tools/ipu-common/src/ipu_common/acc_stride_enums.py
+++ b/src/tools/ipu-common/src/ipu_common/acc_stride_enums.py
@@ -6,8 +6,12 @@ Used by:
 
 Encoding convention:
 - elements_in_row: index 0..3 → 8, 16, 32, 64 elements per row.
-- horizontal_stride: 3 bits → (enabled, inverted, expand) = (bit0, bit1, bit2).
-- vertical_stride: 2 bits → (enabled, inverted) = (bit0, bit1).
+- horizontal_stride: semantic enum 0..4 → (enabled, inverted, expand) via lookup table.
+- vertical_stride: semantic enum 0..2 → (enabled, inverted) via lookup table.
+
+Note: horizontal/vertical stride values are NOT a packed bit-field; they are a
+sequential enum. Decoding is done via explicit lookup tables to avoid silent
+mis-decoding (e.g. treating encoded=2 as enabled=False because bit0 is clear).
 """
 
 from __future__ import annotations
@@ -26,7 +30,7 @@ def get_elements_per_row(encoded: int) -> int:
 
 
 # ---------------------------------------------------------------------------
-# Horizontal stride (enabled=bit0, inverted=bit1, expand=bit2)
+# Horizontal stride (semantic enum: 0=off, 1=on, 2=on_inv, 3=on_expand, 4=on_inv_expand)
 # ---------------------------------------------------------------------------
 
 HORIZONTAL_STRIDE_NAMES: tuple[str, ...] = (
@@ -41,17 +45,22 @@ HORIZONTAL_STRIDE_NAMES: tuple[str, ...] = (
 )
 
 
+_HORIZONTAL_STRIDE_DECODE: dict[int, tuple[bool, bool, bool]] = {
+    0: (False, False, False),  # off
+    1: (True,  False, False),  # on
+    2: (True,  True,  False),  # on_inv
+    3: (True,  False, True),   # on_expand
+    4: (True,  True,  True),   # on_inv_expand
+}
+
+
 def get_horizontal_stride_bits(encoded: int) -> tuple[bool, bool, bool]:
-    """Return (enabled, inverted, expand) for encoded horizontal stride 0..7."""
-    return (
-        bool(encoded & 1),
-        bool(encoded & 2),
-        bool(encoded & 4),
-    )
+    """Return (enabled, inverted, expand) for encoded horizontal stride 0..4."""
+    return _HORIZONTAL_STRIDE_DECODE[encoded]
 
 
 # ---------------------------------------------------------------------------
-# Vertical stride (enabled=bit0, inverted=bit1)
+# Vertical stride (semantic enum: 0=off, 1=on, 2=on_inv)
 # ---------------------------------------------------------------------------
 
 VERTICAL_STRIDE_NAMES: tuple[str, ...] = (
@@ -62,9 +71,13 @@ VERTICAL_STRIDE_NAMES: tuple[str, ...] = (
 )
 
 
+_VERTICAL_STRIDE_DECODE: dict[int, tuple[bool, bool]] = {
+    0: (False, False),  # off
+    1: (True,  False),  # on
+    2: (True,  True),   # on_inv
+}
+
+
 def get_vertical_stride_bits(encoded: int) -> tuple[bool, bool]:
-    """Return (enabled, inverted) for encoded vertical stride 0..3."""
-    return (
-        bool(encoded & 1),
-        bool(encoded & 2),
-    )
+    """Return (enabled, inverted) for encoded vertical stride 0..2."""
+    return _VERTICAL_STRIDE_DECODE[encoded]


### PR DESCRIPTION
Closes #29

## What changed

`src/tools/ipu-common/src/ipu_common/acc_stride_enums.py`

Replaced `get_horizontal_stride_bits` and `get_vertical_stride_bits` with explicit
lookup tables (`_HORIZONTAL_STRIDE_DECODE`, `_VERTICAL_STRIDE_DECODE`). Also corrected
the module docstring and section comments, which incorrectly described the encoding as a
packed bit-field.

## Why

The encoded stride values are a **sequential semantic enum**, not a packed bit-field.
The previous bitwise decode (`encoded & 1`, `encoded & 2`, `encoded & 4`) produced
wrong results for several valid encoded values:

| encoded | name            | old `enabled` | old `inverted` | old `expand` | correct |
|---------|-----------------|:---:|:---:|:---:|:---:|
| 2       | `on_inv`        | **False** ❌ | True  | False | enabled=True |
| 3       | `on_expand`     | True  | **True** ❌  | False | inverted=False |
| 4       | `on_inv_expand` | **False** ❌ | False | True  | enabled=True |

Same issue in vertical stride: `on_inv` (encoded=2) returned `enabled=False`.

These bugs were dormant because existing tests only exercised `off` (0) and `on` (1),
which happen to decode correctly under both schemes.

## How the lookup tables fix it

Each row maps one named enum value to its exact semantic flags — no arithmetic, no risk
of a new value silently misdecoding. Invalid encoded values now raise `KeyError`
immediately instead of returning garbage flags.

```python
_HORIZONTAL_STRIDE_DECODE: dict[int, tuple[bool, bool, bool]] = {
    0: (False, False, False),  # off
    1: (True,  False, False),  # on
    2: (True,  True,  False),  # on_inv          ← was (False, True, False)
    3: (True,  False, True),   # on_expand        ← was (True,  True,  False)
    4: (True,  True,  True),   # on_inv_expand    ← was (False, False, True)
}

_VERTICAL_STRIDE_DECODE: dict[int, tuple[bool, bool]] = {
    0: (False, False),  # off
    1: (True,  False),  # on
    2: (True,  True),   # on_inv               ← was (False, True)
}
```

## Test results

```
bazel test //src/tools/ipu-emu-py:test_execute
# 60 passing, 0 failing
```