### PR TITLE
Add agg.first instruction to fix RF register noise (fixes #32)

### DIFF
--- a/src/tools/ipu-common/src/ipu_common/instruction_spec.py
+++ b/src/tools/ipu-common/src/ipu_common/instruction_spec.py
@@ -636,7 +636,7 @@ INSTRUCTION_SPEC = {
 
     # =========================================================================
     # AAQ Slot (Activation and Quantization)
-    # Opcode = position: aaq_nop=0, agg=1
+    # Opcode = position: aaq_nop=0, agg=1, agg.first=2
     # =========================================================================
     "aaq": {
         "aaq_nop": {
@@ -675,6 +675,33 @@ INSTRUCTION_SPEC = {
                 example="agg sum value cr0 aaq0;;",
             ),
             "execute_fn": "execute_agg",
+        },
+        "agg.first": {
+            "operands": [
+                {"name": "agg_mode", "type": "AggMode"},
+                {"name": "post_fn", "type": "PostFn"},
+                {"name": "cr_idx", "type": "CrIdx"},
+                {"name": "aaq_rf_idx", "type": "AaqRegIdx"},
+            ],
+            "doc": InstructionDoc(
+                title="Accumulator Aggregate First",
+                summary="Like agg, but for MAX mode ignores the previous AAQ register value, avoiding contamination from uninitialized data.",
+                syntax="agg.first agg_mode post_fn cr_idx aaq_rf_idx",
+                operands=[
+                    "agg_mode: sum or max",
+                    "post_fn: value, value_cr, inv, or inv_sqrt",
+                    "cr_idx: CR register for value_cr post function (cr0-cr15)",
+                    "aaq_rf_idx: AAQ register to store result (aaq0-aaq3)",
+                ],
+                operation=(
+                    "If sum: v = sum(r_acc[0..127]). "
+                    "If max: v = max(r_acc[0..127]) (previous aaq value is NOT included). "
+                    "Apply post_fn(v): value→v, value_cr→v*cr[cr_idx], inv→1/v, inv_sqrt→1/sqrt(v). "
+                    "aaq[aaq_rf_idx] = result."
+                ),
+                example="agg.first max value cr0 aaq0;;",
+            ),
+            "execute_fn": "execute_agg_first",
         },
         "aaq": {
             "operands": [],

--- a/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
@@ -747,6 +747,62 @@ class Ipu:
         out_bits = struct.unpack("<I", struct.pack(fmt, result_val))[0]
         self.state.regfile.set_aaq(aaq_rf_idx, out_bits)
 
+    def execute_agg_first(
+        self,
+        *,
+        agg_mode: int,
+        post_fn: int,
+        cr_idx: int,
+        aaq_rf_idx: int,
+    ) -> None:
+        """Execute agg.first: like agg but for MAX mode ignores previous AAQ value."""
+        dtype = self.state.get_cr_dtype()
+        fmt = "<i" if dtype == DType.INT8 else "<f"
+        acc_buf = self.state.regfile.raw("r_acc")
+        n_words = R_ACC_SIZE // 4  # 128
+
+        values = []
+        for i in range(n_words):
+            val = struct.unpack_from(fmt, acc_buf, i * 4)[0]
+            values.append(val)
+
+        if get_agg_mode(agg_mode) == AGG_MODE_SUM:
+            raw_result = sum(values)
+        else:
+            # MAX: do NOT include previous AAQ value — this is the .first behaviour
+            raw_result = max(values)
+
+        fn = get_post_fn(post_fn)
+        if fn == POST_FN_VALUE:
+            result_val = raw_result
+        elif fn == POST_FN_VALUE_CR:
+            cr_val = self.state.regfile.get_cr(cr_idx) & 0xFFFFFFFF
+            cr_scalar = struct.unpack(fmt, struct.pack("<I", cr_val))[0]
+            result_val = raw_result * cr_scalar
+        elif fn == POST_FN_INV:
+            if dtype == DType.INT8:
+                f = float(raw_result)
+                result_val = 1.0 / f if f != 0 else 0.0
+                out_bits = struct.unpack("<I", struct.pack("<f", result_val))[0]
+                self.state.regfile.set_aaq(aaq_rf_idx, out_bits)
+                return
+            else:
+                result_val = 1.0 / raw_result if raw_result != 0 else 0.0
+        elif fn == POST_FN_INV_SQRT:
+            if dtype == DType.INT8:
+                f = float(raw_result)
+                result_val = 1.0 / (f ** 0.5) if f > 0 else 0.0
+                out_bits = struct.unpack("<I", struct.pack("<f", result_val))[0]
+                self.state.regfile.set_aaq(aaq_rf_idx, out_bits)
+                return
+            else:
+                result_val = 1.0 / (raw_result ** 0.5) if raw_result > 0 else 0.0
+        else:
+            result_val = raw_result
+
+        out_bits = struct.unpack("<I", struct.pack(fmt, result_val))[0]
+        self.state.regfile.set_aaq(aaq_rf_idx, out_bits)
+
     def execute_aaq(self) -> None:
         """Execute aaq: Quantize r_acc (128 × INT32) → aaq_result (128 × INT8).
 

--- a/src/tools/ipu-emu-py/test/test_execute.py
+++ b/src/tools/ipu-emu-py/test/test_execute.py
@@ -826,6 +826,64 @@ bkpt;;
         # sum = 128, 128 * 3 = 384
         assert state.regfile.get_aaq(2) == struct.unpack("<I", struct.pack("<i", 384))[0]
 
+    def test_agg_first_max_ignores_previous_aaq(self):
+        """agg.first max: ignores the previous (garbage) AAQ value, takes max of r_acc only."""
+        import struct
+
+        state = _make_state(
+            """\
+agg.first max value cr0 aaq0;;
+bkpt;;
+"""
+        )
+        state.regfile.set_cr(15, DType.INT8)
+        for i in range(128):
+            state.regfile.set_r_acc_word(i, struct.unpack("<I", struct.pack("<i", 10 + (i % 5)))[0])
+        # Set aaq0 to a large "garbage" value that would win against r_acc if included
+        state.regfile.set_aaq(0, struct.unpack("<I", struct.pack("<i", 9999))[0])
+
+        run_until_complete(state)
+        # Max of r_acc is 14; previous aaq (9999) must be ignored
+        assert state.regfile.get_aaq(0) == struct.unpack("<I", struct.pack("<i", 14))[0]
+
+    def test_agg_first_max_selects_correct_max(self):
+        """agg.first max: correctly selects the max value from r_acc words."""
+        import struct
+
+        state = _make_state(
+            """\
+agg.first max value cr0 aaq1;;
+bkpt;;
+"""
+        )
+        state.regfile.set_cr(15, DType.INT8)
+        for i in range(128):
+            state.regfile.set_r_acc_word(i, struct.unpack("<I", struct.pack("<i", 5))[0])
+        state.regfile.set_r_acc_word(63, struct.unpack("<I", struct.pack("<i", 77))[0])
+        state.regfile.set_aaq(1, struct.unpack("<I", struct.pack("<i", 0))[0])
+
+        run_until_complete(state)
+        assert state.regfile.get_aaq(1) == struct.unpack("<I", struct.pack("<i", 77))[0]
+
+    def test_agg_first_sum_same_as_agg_sum(self):
+        """agg.first sum: behaves identically to agg sum (previous aaq not involved in sum)."""
+        import struct
+
+        state = _make_state(
+            """\
+agg.first sum value cr0 aaq2;;
+bkpt;;
+"""
+        )
+        state.regfile.set_cr(15, DType.INT8)
+        for i in range(128):
+            state.regfile.set_r_acc_word(i, struct.unpack("<I", struct.pack("<i", 2))[0])
+        state.regfile.set_aaq(2, struct.unpack("<I", struct.pack("<i", 9999))[0])
+
+        run_until_complete(state)
+        # Sum of 128 twos = 256; previous aaq value irrelevant
+        assert state.regfile.get_aaq(2) == struct.unpack("<I", struct.pack("<i", 256))[0]
+
 
 # ============================================================================
 


### PR DESCRIPTION
## Summary

Fixes #32 — RF/AAQ registers could contain uninitialized "noise" that corrupted the first `agg max` operation, because `agg max` always includes the current AAQ register value in the comparison.

- **Added `agg.first` instruction** in the `aaq` slot of `instruction_spec.py` — same operands as `agg`, but for MAX mode the previous AAQ register value is **not** included in the comparison (analogous to how `acc.first` ignores the previous accumulator).
- **Added `execute_agg_first()` handler** in `ipu.py` — identical to `execute_agg` except MAX computes `max(r_acc[0..127])` only, skipping the existing AAQ value.
- **Added 3 tests** in `test_execute.py` covering: garbage AAQ value is ignored on first max, correct max is selected from `r_acc`, and sum behavior is unchanged.

## Usage

Replace the first `agg max` in a sequence with `agg.first max` to safely initialize an AAQ register without being contaminated by its previous contents:

```asm
agg.first max value cr0 aaq0;;   ; first tile — ignores whatever was in aaq0
agg       max value cr0 aaq0;;   ; subsequent tiles — correctly accumulates running max
```

## Test plan

- [x] `test_agg_first_max_ignores_previous_aaq` — large garbage value in AAQ is not included in result
- [x] `test_agg_first_max_selects_correct_max` — correct max element from `r_acc` is selected
- [x] `test_agg_first_sum_same_as_agg_sum` — sum mode behaves identically to `agg sum`
- [x] All 72 existing emulator tests pass
- [x] All assembler tests pass

https://claude.ai/code/session_01YJsZpXRsr4Y5rvjJRsnqsu

---
_Generated by [Claude Code](https://claude.ai/code/session_01YJsZpXRsr4Y5rvjJRsnqsu)_