### PR TITLE
Wide-vector debug mode (32-bit lanes, issue #33)

### DIFF
--- a/docs/building-applications.md
+++ b/docs/building-applications.md
@@ -14,6 +14,10 @@ Each IPU application is a subpackage under `ipu_apps/` containing:
 
 Everything lives together in one directory.
 
+## Wide-vector debug mode (optional)
+
+The emulator can run multiply/accumulate paths with **128×32-bit lanes** (FP32 or INT32) instead of 8-bit vectors, for debugging without quantization on that path. XMEM addresses stay the same; load sizes and alignment rules change. See **[Wide-vector debug mode](wide-vector-debug-mode.md)** for how to construct `IpuState`, prepare 512-byte loads, and use `aaq` / `str_acc_reg` in that mode.
+
 ## Step 1: Write the Assembly Program
 
 Create your IPU assembly program (e.g., `fully_connected.asm`). The assembly program contains the compute logic that runs on the IPU. See the [Assembly Syntax Guide](assembly-syntax.md) for details on writing IPU assembly code with Jinja2 preprocessing.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -51,6 +51,7 @@ nav:
       - Debugging: debugging.md
   - Programming the IPU:
       - Building Applications: building-applications.md
+      - Wide-vector debug mode: wide-vector-debug-mode.md
   - Contributing:
       - Adding Instructions: adding-instruction.md
   - Assembly:

--- a/docs/wide-vector-debug-mode.md
+++ b/docs/wide-vector-debug-mode.md
@@ -1,0 +1,75 @@
+# Wide-vector debug mode (emulator only)
+
+The Python emulator can run in an optional **wide-vector debug mode** so multiply-stage vectors are treated as **128 lanes of 32-bit values** (float or integer) instead of 128 bytes of INT8/FP8. This is intended for debugging and analysis without 8-bit quantization on the multiply path.
+
+Hardware behaviour is unchanged; this mode exists only in `ipu_emu`.
+
+## When to use it
+
+- Compare a model or kernel against a **full-precision** reference (FP32 lanes) or a **wider integer** path (INT32 lanes with 32-bit wrap on multiply/add).
+- Keep the **same assembly** and **same XMEM byte addresses**; only how loads are sized and how mult/acc interpret data changes.
+
+See [GitHub issue #33](https://github.com/rechefe/ipu-emulator/issues/33) for the original requirements.
+
+## Enabling the mode
+
+Construct [`IpuState`](https://github.com/rechefe/ipu-emulator/blob/master/src/tools/ipu-emu-py/src/ipu_emu/ipu_state.py) with keyword arguments:
+
+| Parameter | Default | Meaning |
+|-----------|---------|---------|
+| `wide_vector_debug` | `False` | Turn wide-vector mode on. |
+| `wide_vector_arithmetic` | `WideVectorArithmetic.FP32` | `FP32` or `INT32` lane arithmetic. |
+| `wide_vector_quantize_output` | `False` | If `True`, the `aaq` instruction writes `aaq_result` from wide lanes for comparison with the real quantized path. If `False`, `aaq` does nothing in wide mode (results stay in `r_acc`). |
+
+```python
+from ipu_emu.ipu_state import IpuState, WideVectorArithmetic
+from ipu_emu.emulator import load_program, run_until_complete
+from ipu_emu.execute import decode_instruction_word
+from ipu_as.lark_tree import assemble
+
+state = IpuState(
+    wide_vector_debug=True,
+    wide_vector_arithmetic=WideVectorArithmetic.FP32,
+    wide_vector_quantize_output=False,
+)
+# load program, set cr15 / XMEM as usual, then:
+run_until_complete(state)
+```
+
+`WideVectorArithmetic` is re-exported from `ipu_emu` for convenience:
+
+```python
+from ipu_emu import IpuState, WideVectorArithmetic
+```
+
+The high-level helper [`run_test`](https://github.com/rechefe/ipu-emulator/blob/master/src/tools/ipu-emu-py/src/ipu_emu/emulator.py) always builds a default `IpuState()`. To use wide-vector mode with your own harness, create the state as above, then use `load_program_from_binary` / `load_program` and `run_until_complete` or `run_with_debug` the same way tests do.
+
+## XMEM layout in wide mode
+
+While **addresses are still byte addresses**, wide mode changes how much data some loads consume per instruction:
+
+- **`ldr_mult_reg`** reads **512 bytes** from XMEM (128×FP32 or 128×INT32, depending on `wide_vector_arithmetic`) into internal staging for `r0`, `r1`, or `mem_bypass`. The architectural 128-byte `r` register bytes in the regfile are not the source for mult operands in this mode.
+- **`ldr_cyclic_mult_reg`** reads **512 bytes** into `r_cyclic` at the given **`index`**, which must be **aligned to 512** (same rule as 128-byte alignment in normal mode, scaled to the wide chunk).
+
+Prepare XMEM accordingly (e.g. raw `float32` or `int32` little-endian blobs).
+
+## Alignment rules
+
+Wide mode unpacks `r_cyclic` as 128 consecutive 32-bit lanes starting at a **byte offset**:
+
+- **`cyclic_offset`** and **`fixed_cyclic_idx`** passed to mult instructions must be **4-byte aligned**. Unaligned values raise `EmulatorError` so you do not silently mis-read lane boundaries.
+
+## Semantics that differ from normal mode
+
+- **Multiply masks** (`mask_offset` / `mask_shift`): mask-and-shift on `mult_res` is **disabled** in wide mode, because the 128-bit mask layout does not map to 128 FP32/INT32 lanes.
+- **`aaq`**: unless `wide_vector_quantize_output=True`, **`aaq` is a no-op** in wide mode; full lane results remain in **`r_acc`**. Use the existing debug-only **`str_acc_reg`** instruction (or read `r_acc` in Python) to dump 512 bytes of accumulator data.
+- **LR and CR** are **not** widened; scalars such as `mult.ve.cr` still use the **low byte** of a CR as a signed value in the wide path.
+
+## INT32 vs FP32
+
+- **`WideVectorArithmetic.FP32`**: lane multiply and accumulate-add use IEEE float; good for spotting FP8/INT8 quantization effects.
+- **`WideVectorArithmetic.INT32`**: lane multiply uses 32-bit signed wrap; add matches INT8-mode wrap semantics per lane. `agg` post-functions that need integer results use integer-friendly paths when the lane format is INT32.
+
+## Related documentation
+
+- [Debugging IPU Programs](debugging.md) — interactive `break` / `debug_prompt` workflow (orthogonal to wide-vector mode; you can combine them by passing a state created with `wide_vector_debug=True` into `run_with_debug`).

--- a/src/tools/ipu-emu-py/BUILD.bazel
+++ b/src/tools/ipu-emu-py/BUILD.bazel
@@ -69,3 +69,13 @@ py_pytest_test(
         requirement("pytest"),
     ],
 )
+
+py_pytest_test(
+    name = "test_wide_vector_debug",
+    srcs = ["test/test_wide_vector_debug.py"],
+    imports = ["src"],
+    deps = [
+        ":ipu_emu_lib",
+        requirement("pytest"),
+    ],
+)

--- a/src/tools/ipu-emu-py/src/ipu_emu/__init__.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/__init__.py
@@ -3,7 +3,7 @@
 from ipu_emu.xmem import XMem
 from ipu_emu.descriptors import RegDescriptor, REGFILE_SCHEMA
 from ipu_emu.regfile import RegFile
-from ipu_emu.ipu_state import IpuState
+from ipu_emu.ipu_state import IpuState, WideVectorArithmetic
 from ipu_emu.ipu_math import DType, ipu_mult, ipu_add, fp32_to_fp8_bytes, fp8_bytes_to_fp32
 from ipu_emu.execute import (
     decode_instruction_word,
@@ -37,6 +37,7 @@ __all__ = [
     "REGFILE_SCHEMA",
     "RegFile",
     "IpuState",
+    "WideVectorArithmetic",
     "DType",
     "ipu_mult",
     "ipu_add",

--- a/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
@@ -408,6 +408,9 @@ class Ipu:
     def execute_ldr_cyclic_mult_reg(self, *, offset: int, base: int, index: int) -> None:
         """Execute ldr_cyclic_mult_reg: Load with cyclic addressing into r_cyclic."""
         addr = offset + base
+        assert index % R_REG_SIZE == 0, (
+            f"LR index for cyclic load must be aligned to {R_REG_SIZE}: got {index}"
+        )
         if self._wide_vector_active():
             assert index % R_CYCLIC_SIZE == 0, (
                 f"Wide-vector debug: cyclic load index must be aligned to {R_CYCLIC_SIZE}, "
@@ -418,9 +421,6 @@ class Ipu:
             return
 
         data = self.state.xmem.read_address(addr, R_REG_SIZE)
-        assert index % R_REG_SIZE == 0, (
-            f"LR index for cyclic load must be aligned to {R_REG_SIZE}: got {index}"
-        )
         self.state.regfile.set_r_cyclic_at(index, data)
 
     def execute_ldr_mult_mask_reg(self, *, offset: int, base: int) -> None:

--- a/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
@@ -21,7 +21,7 @@ import warnings
 from enum import IntEnum
 from typing import Any
 
-from ipu_emu.ipu_state import IpuState, INST_MEM_SIZE
+from ipu_emu.ipu_state import IpuState, INST_MEM_SIZE, WideVectorArithmetic
 from ipu_emu.regfile import RegFile
 from ipu_emu.ipu_math import ipu_mult, ipu_add, dtype_one_byte, DType
 from ipu_common.instruction_spec import (
@@ -223,6 +223,56 @@ class Ipu:
         self.snapshot: RegFile | None = None
 
     # -----------------------------------------------------------------------
+    # Wide-vector debug mode (emulator-only; GitHub issue #33)
+    # -----------------------------------------------------------------------
+
+    def _wide_vector_active(self) -> bool:
+        return self.state.wide_vector_debug
+
+    def _wide_unpack_lane_tuple(self, buf: bytes | bytearray) -> tuple[float, ...] | tuple[int, ...]:
+        if self.state.wide_vector_arithmetic == WideVectorArithmetic.FP32:
+            return struct.unpack_from("<128f", buf, 0)
+        return struct.unpack_from("<128i", buf, 0)
+
+    def _wide_imult32(self, a: int, b: int) -> int:
+        p = int(a) * int(b)
+        p &= 0xFFFFFFFF
+        return p - 0x100000000 if p >= 0x80000000 else p
+
+    def _wide_add_lane(self, a: float | int, b: float | int) -> float | int:
+        if self.state.wide_vector_arithmetic == WideVectorArithmetic.FP32:
+            return float(a) + float(b)
+        return ipu_add(int(a), int(b), DType.INT8)
+
+    def _wide_aaq_scalar(self, aaq_rf_idx: int) -> float | int:
+        raw = self.state.regfile.get_aaq(aaq_rf_idx) & 0xFFFFFFFF
+        if self.state.wide_vector_arithmetic == WideVectorArithmetic.FP32:
+            return struct.unpack("<f", struct.pack("<I", raw))[0]
+        return struct.unpack("<i", struct.pack("<I", raw))[0]
+
+    def _wide_cr_scalar_byte_as_int32(self, cr_idx: int) -> int:
+        """Low byte of CR as signed int32 lane (CR itself is not widened)."""
+        b = self.state.regfile.get_cr(cr_idx) & 0xFF
+        return b if b < 128 else b - 256
+
+    def _debug_ra_lane_vals(self, mult_stage_enc: int) -> list[float | int]:
+        snap = self.state._debug_mult_stage_vectors_snap
+        if mult_stage_enc in snap:
+            return list(snap[mult_stage_enc])
+        return [0.0 if self.state.wide_vector_arithmetic == WideVectorArithmetic.FP32 else 0] * R_REG_SIZE
+
+    def _debug_rb_lane_vals(self, cyclic_offset: int, source: RegFile) -> tuple[float, ...] | tuple[int, ...]:
+        buf = source.get_r_cyclic_at(cyclic_offset, R_CYCLIC_SIZE)
+        return self._wide_unpack_lane_tuple(buf)
+
+    def _acc_agg_lane_fmt(self) -> str:
+        """Struct format for r_acc / agg when wide-vector debug is on."""
+        if self._wide_vector_active():
+            return "<f" if self.state.wide_vector_arithmetic == WideVectorArithmetic.FP32 else "<i"
+        dtype = self.state.get_cr_dtype()
+        return "<i" if dtype == DType.INT8 else "<f"
+
+    # -----------------------------------------------------------------------
     # Helper Methods
     # -----------------------------------------------------------------------
 
@@ -253,6 +303,10 @@ class Ipu:
             else:
                 return source.get_cr(raw_value - LR_REG_COUNT)
         elif op_type == "MultStageReg":
+            if self._wide_vector_active():
+                # Mult handlers read wide lanes from _debug_mult_stage_vectors_snap
+                # keyed by MultStageReg encoding index (0=r0, 1=r1, 2=mem_bypass).
+                return raw_value
             reg_name, elem_idx = _MULT_STAGE_MAP[raw_value]
             return source.get_register_bytes(reg_name, elem_idx)
         else:
@@ -265,6 +319,9 @@ class Ipu:
             mask_idx: Mask slot selector value (already resolved from LR)
             shift: Shift amount value (already resolved from LR)
         """
+        if self._wide_vector_active():
+            return
+
         # Interpret shift as signed int32
         if shift >= 0x80000000:
             shift = shift - 0x100000000
@@ -313,16 +370,31 @@ class Ipu:
     def execute_ldr_mult_reg(self, *, dest: int, offset: int, base: int) -> None:
         """Execute ldr_mult_reg: Load data from memory into a mult stage register."""
         addr = offset + base
-        data = self.state.xmem.read_address(addr, R_REG_SIZE)
+        if self._wide_vector_active():
+            data = self.state.xmem.read_address(addr, R_CYCLIC_SIZE)
+            if self.state.wide_vector_arithmetic == WideVectorArithmetic.FP32:
+                self.state._debug_mult_stage_vectors[dest] = list(
+                    struct.unpack_from("<128f", data, 0)
+                )
+            else:
+                self.state._debug_mult_stage_vectors[dest] = list(
+                    struct.unpack_from("<128i", data, 0)
+                )
+            return
 
+        data = self.state.xmem.read_address(addr, R_REG_SIZE)
         reg_name, elem_idx = _MULT_STAGE_MAP[dest]
         self.state.regfile.set_register_bytes(reg_name, elem_idx, data)
 
     def execute_ldr_cyclic_mult_reg(self, *, offset: int, base: int, index: int) -> None:
         """Execute ldr_cyclic_mult_reg: Load with cyclic addressing into r_cyclic."""
         addr = offset + base
-        data = self.state.xmem.read_address(addr, R_REG_SIZE)
+        if self._wide_vector_active():
+            data = self.state.xmem.read_address(addr, R_CYCLIC_SIZE)
+            self.state.regfile.set_r_cyclic_at(0, data)
+            return
 
+        data = self.state.xmem.read_address(addr, R_REG_SIZE)
         assert index % R_REG_SIZE == 0, (
             f"LR index for cyclic load must be aligned to {R_REG_SIZE}: got {index}"
         )
@@ -412,12 +484,27 @@ class Ipu:
         """Execute mult_nop: No operation."""
         pass
 
-    def execute_mult_ee(self, *, ra: bytearray, cyclic_offset: int,
+    def execute_mult_ee(self, *, ra: bytearray | int, cyclic_offset: int,
                         mask_offset: int, mask_shift: int) -> None:
         """Execute mult_ee: Element-wise multiplication."""
+        mult_res = self.state.regfile.raw("mult_res")
+
+        if self._wide_vector_active():
+            ra_vals = self._debug_ra_lane_vals(ra)
+            rb_vals = self._debug_rb_lane_vals(cyclic_offset, self.state.regfile)
+            if self.state.wide_vector_arithmetic == WideVectorArithmetic.FP32:
+                for i in range(R_REG_SIZE):
+                    struct.pack_into("<f", mult_res, i * 4, float(ra_vals[i]) * float(rb_vals[i]))
+            else:
+                for i in range(R_REG_SIZE):
+                    struct.pack_into(
+                        "<i", mult_res, i * 4, self._wide_imult32(int(ra_vals[i]), int(rb_vals[i]))
+                    )
+            self._mult_mask_and_shift(mask_offset, mask_shift)
+            return
+
         dtype = self.state.get_cr_dtype()
         rb = self.state.regfile.get_r_cyclic_at(cyclic_offset, R_REG_SIZE)
-        mult_res = self.state.regfile.raw("mult_res")
 
         for i in range(R_REG_SIZE):
             result = ipu_mult(ra[i], rb[i], dtype)
@@ -425,12 +512,28 @@ class Ipu:
 
         self._mult_mask_and_shift(mask_offset, mask_shift)
 
-    def execute_mult_ev(self, *, ra: bytearray, fixed_cyclic_idx: int,
+    def execute_mult_ev(self, *, ra: bytearray | int, fixed_cyclic_idx: int,
                         mask_offset: int, mask_shift: int) -> None:
         """Execute mult_ev: Element x fixed cyclic multiplication."""
+        mult_res = self.state.regfile.raw("mult_res")
+
+        if self._wide_vector_active():
+            ra_vals = self._debug_ra_lane_vals(ra)
+            rb_vals = self._debug_rb_lane_vals(fixed_cyclic_idx, self.state.regfile)
+            rb0 = rb_vals[0]
+            if self.state.wide_vector_arithmetic == WideVectorArithmetic.FP32:
+                for i in range(R_REG_SIZE):
+                    struct.pack_into("<f", mult_res, i * 4, float(ra_vals[i]) * float(rb0))
+            else:
+                for i in range(R_REG_SIZE):
+                    struct.pack_into(
+                        "<i", mult_res, i * 4, self._wide_imult32(int(ra_vals[i]), int(rb0))
+                    )
+            self._mult_mask_and_shift(mask_offset, mask_shift)
+            return
+
         dtype = self.state.get_cr_dtype()
         rb = self.state.regfile.get_r_cyclic_at(fixed_cyclic_idx, R_REG_SIZE)
-        mult_res = self.state.regfile.raw("mult_res")
 
         for i in range(R_REG_SIZE):
             result = ipu_mult(ra[i], rb[0], dtype)
@@ -448,11 +551,37 @@ class Ipu:
         elements where cyclic_offset+i >= R_CYCLIC_SIZE are padded with the
         dtype-specific encoding of 1 instead of wrapping.
         """
+        mult_res = self.state.regfile.raw("mult_res")
+
+        if self._wide_vector_active():
+            r0_vals = self._debug_ra_lane_vals(0)
+            r1_vals = self._debug_ra_lane_vals(1)
+            rb_vals = self._debug_rb_lane_vals(cyclic_offset, self.state.regfile)
+            if fixed_idx < R_REG_SIZE:
+                ra_fixed = r0_vals[fixed_idx % R_REG_SIZE]
+            else:
+                ra_fixed = r1_vals[(fixed_idx - R_REG_SIZE) % R_REG_SIZE]
+            if self.state.wide_vector_arithmetic == WideVectorArithmetic.FP32:
+                one = 1.0
+                for i in range(R_REG_SIZE):
+                    pos = cyclic_offset + i
+                    rb_lane = float(rb_vals[i]) if pos < R_CYCLIC_SIZE else one
+                    struct.pack_into("<f", mult_res, i * 4, float(ra_fixed) * rb_lane)
+            else:
+                one = 1
+                for i in range(R_REG_SIZE):
+                    pos = cyclic_offset + i
+                    rb_lane = int(rb_vals[i]) if pos < R_CYCLIC_SIZE else one
+                    struct.pack_into(
+                        "<i", mult_res, i * 4, self._wide_imult32(int(ra_fixed), rb_lane)
+                    )
+            self._mult_mask_and_shift(mask_offset, mask_shift)
+            return
+
         dtype = self.state.get_cr_dtype()
         r_buf = self.state.regfile.raw("r")  # 256 bytes: [0:128]=r0, [128:256]=r1
         rc_buf = self.state.regfile.raw("r_cyclic")
         one_byte = dtype_one_byte(dtype)
-        mult_res = self.state.regfile.raw("mult_res")
         fmt = "<i" if dtype == DType.INT8 else "<f"
 
         ra_fixed = r_buf[fixed_idx % (2 * R_REG_SIZE)]
@@ -475,10 +604,32 @@ class Ipu:
         padded with the dtype-specific encoding of 1 instead of wrapping.
         """
         dtype = self.state.get_cr_dtype()
+        mult_res = self.state.regfile.raw("mult_res")
+
+        if self._wide_vector_active():
+            cr_scalar = self._wide_cr_scalar_byte_as_int32(cr_idx)
+            rb_vals = self._debug_rb_lane_vals(cyclic_offset, self.state.regfile)
+            if self.state.wide_vector_arithmetic == WideVectorArithmetic.FP32:
+                scalar_f = float(cr_scalar)
+                one = 1.0
+                for i in range(R_REG_SIZE):
+                    pos = cyclic_offset + i
+                    rb_lane = float(rb_vals[i]) if pos < R_CYCLIC_SIZE else one
+                    struct.pack_into("<f", mult_res, i * 4, scalar_f * rb_lane)
+            else:
+                one = 1
+                for i in range(R_REG_SIZE):
+                    pos = cyclic_offset + i
+                    rb_lane = int(rb_vals[i]) if pos < R_CYCLIC_SIZE else one
+                    struct.pack_into(
+                        "<i", mult_res, i * 4, self._wide_imult32(cr_scalar, rb_lane)
+                    )
+            self._mult_mask_and_shift(mask_offset, mask_shift)
+            return
+
         scalar_byte = self.state.regfile.get_cr(cr_idx) & 0xFF
         rc_buf = self.state.regfile.raw("r_cyclic")
         one_byte = dtype_one_byte(dtype)
-        mult_res = self.state.regfile.raw("mult_res")
         fmt = "<i" if dtype == DType.INT8 else "<f"
 
         for i in range(R_REG_SIZE):
@@ -499,10 +650,31 @@ class Ipu:
         encoding of 1 instead of wrapping.
         """
         dtype = self.state.get_cr_dtype()
+        mult_res = self.state.regfile.raw("mult_res")
+
+        if self._wide_vector_active():
+            aaq_lane = self._wide_aaq_scalar(aaq_rf_idx)
+            rb_vals = self._debug_rb_lane_vals(cyclic_offset, self.state.regfile)
+            if self.state.wide_vector_arithmetic == WideVectorArithmetic.FP32:
+                one = 1.0
+                for i in range(R_REG_SIZE):
+                    pos = cyclic_offset + i
+                    rb_lane = float(rb_vals[i]) if pos < R_CYCLIC_SIZE else one
+                    struct.pack_into("<f", mult_res, i * 4, float(aaq_lane) * rb_lane)
+            else:
+                one = 1
+                for i in range(R_REG_SIZE):
+                    pos = cyclic_offset + i
+                    rb_lane = int(rb_vals[i]) if pos < R_CYCLIC_SIZE else one
+                    struct.pack_into(
+                        "<i", mult_res, i * 4, self._wide_imult32(int(aaq_lane), rb_lane)
+                    )
+            self._mult_mask_and_shift(mask_offset, mask_shift)
+            return
+
         scalar_byte = self.state.regfile.get_aaq(aaq_rf_idx) & 0xFF
         rc_buf = self.state.regfile.raw("r_cyclic")
         one_byte = dtype_one_byte(dtype)
-        mult_res = self.state.regfile.raw("mult_res")
         fmt = "<i" if dtype == DType.INT8 else "<f"
 
         for i in range(R_REG_SIZE):
@@ -531,12 +703,15 @@ class Ipu:
         acc_buf = self.state.regfile.raw("r_acc")
         mult_res = self.state.regfile.raw("mult_res")
         snap_acc = self.snapshot.raw("r_acc")
-        fmt = "<i" if dtype == DType.INT8 else "<f"
+        fmt = self._acc_agg_lane_fmt()
 
         for i in range(R_REG_SIZE):
             acc_val = struct.unpack_from(fmt, snap_acc, i * 4)[0]
             mult_val = struct.unpack_from(fmt, mult_res, i * 4)[0]
-            result = ipu_add(acc_val, mult_val, dtype)
+            if self._wide_vector_active():
+                result = self._wide_add_lane(acc_val, mult_val)
+            else:
+                result = ipu_add(acc_val, mult_val, dtype)
             struct.pack_into(fmt, acc_buf, i * 4, result)
 
     def execute_acc_first(self) -> None:
@@ -544,7 +719,7 @@ class Ipu:
         dtype = self.state.get_cr_dtype()
         acc_buf = self.state.regfile.raw("r_acc")
         mult_res = self.state.regfile.raw("mult_res")
-        fmt = "<i" if dtype == DType.INT8 else "<f"
+        fmt = self._acc_agg_lane_fmt()
 
         for i in range(R_REG_SIZE):
             mult_val = struct.unpack_from(fmt, mult_res, i * 4)[0]
@@ -556,13 +731,19 @@ class Ipu:
         acc_buf = self.state.regfile.raw("r_acc")
         mult_res = self.state.regfile.raw("mult_res")
         snap_acc = self.snapshot.raw("r_acc")
-        aaq_val = self.state.regfile.get_aaq(aaq_rf_idx)
-        fmt = "<i" if dtype == DType.INT8 else "<f"
+        fmt = self._acc_agg_lane_fmt()
+        if self._wide_vector_active():
+            aaq_lane = self._wide_aaq_scalar(aaq_rf_idx)
+        else:
+            aaq_lane = self.state.regfile.get_aaq(aaq_rf_idx)
 
         for i in range(R_REG_SIZE):
             acc_val = struct.unpack_from(fmt, snap_acc, i * 4)[0]
             mult_val = struct.unpack_from(fmt, mult_res, i * 4)[0]
-            result = ipu_add(ipu_add(acc_val, mult_val, dtype), aaq_val, dtype)
+            if self._wide_vector_active():
+                result = self._wide_add_lane(self._wide_add_lane(acc_val, mult_val), aaq_lane)
+            else:
+                result = ipu_add(ipu_add(acc_val, mult_val, dtype), aaq_lane, dtype)
             struct.pack_into(fmt, acc_buf, i * 4, result)
 
     def execute_acc_add_aaq_first(self, *, aaq_rf_idx: int) -> None:
@@ -570,12 +751,18 @@ class Ipu:
         dtype = self.state.get_cr_dtype()
         acc_buf = self.state.regfile.raw("r_acc")
         mult_res = self.state.regfile.raw("mult_res")
-        aaq_val = self.state.regfile.get_aaq(aaq_rf_idx)
-        fmt = "<i" if dtype == DType.INT8 else "<f"
+        fmt = self._acc_agg_lane_fmt()
+        if self._wide_vector_active():
+            aaq_lane = self._wide_aaq_scalar(aaq_rf_idx)
+        else:
+            aaq_lane = self.state.regfile.get_aaq(aaq_rf_idx)
 
         for i in range(R_REG_SIZE):
             mult_val = struct.unpack_from(fmt, mult_res, i * 4)[0]
-            result = ipu_add(mult_val, aaq_val, dtype)
+            if self._wide_vector_active():
+                result = self._wide_add_lane(mult_val, aaq_lane)
+            else:
+                result = ipu_add(mult_val, aaq_lane, dtype)
             struct.pack_into(fmt, acc_buf, i * 4, result)
 
     def execute_acc_max(self, *, aaq_rf_idx: int) -> None:
@@ -588,8 +775,7 @@ class Ipu:
         mult_res = self.state.regfile.raw("mult_res")
         snap_acc = self.snapshot.raw("r_acc")
         aaq_raw = self.state.regfile.get_aaq(aaq_rf_idx) & 0xFFFFFFFF
-        # Signed interpretation: "<i" = int32, "<f" = float32 (signed)
-        fmt = "<i" if dtype == DType.INT8 else "<f"
+        fmt = self._acc_agg_lane_fmt()
         aaq_val = struct.unpack(fmt, struct.pack("<I", aaq_raw))[0]
 
         for i in range(R_REG_SIZE):
@@ -607,8 +793,7 @@ class Ipu:
         acc_buf = self.state.regfile.raw("r_acc")
         mult_res = self.state.regfile.raw("mult_res")
         aaq_raw = self.state.regfile.get_aaq(aaq_rf_idx) & 0xFFFFFFFF
-        # Signed interpretation: "<i" = int32, "<f" = float32 (signed)
-        fmt = "<i" if dtype == DType.INT8 else "<f"
+        fmt = self._acc_agg_lane_fmt()
         aaq_val = struct.unpack(fmt, struct.pack("<I", aaq_raw))[0]
 
         for i in range(R_REG_SIZE):
@@ -667,7 +852,7 @@ class Ipu:
 
         base = (offset % 4) * 32
         dtype = self.state.get_cr_dtype()
-        fmt = "<i" if dtype == DType.INT8 else "<f"
+        fmt = self._acc_agg_lane_fmt()
         acc_buf = self.state.regfile.raw("r_acc")
         mult_res = self.state.regfile.raw("mult_res")
 
@@ -675,7 +860,7 @@ class Ipu:
             if idx >= 0:
                 val = struct.unpack_from(fmt, mult_res, idx * 4)[0]
             else:
-                val = 0
+                val = 0.0 if fmt == "<f" else 0
             struct.pack_into(fmt, acc_buf, (base + i) * 4, val)
 
     def execute_aaq_nop(self) -> None:
@@ -695,7 +880,7 @@ class Ipu:
         For MAX, the current value of the target AAQ register is included in the max (no update if already max).
         """
         dtype = self.state.get_cr_dtype()
-        fmt = "<i" if dtype == DType.INT8 else "<f"
+        fmt = self._acc_agg_lane_fmt()
         acc_buf = self.state.regfile.raw("r_acc")
         n_words = R_ACC_SIZE // 4  # 128
 
@@ -722,7 +907,7 @@ class Ipu:
             cr_scalar = struct.unpack(fmt, struct.pack("<I", cr_val))[0]
             result_val = raw_result * cr_scalar
         elif fn == POST_FN_INV:
-            if dtype == DType.INT8:
+            if dtype == DType.INT8 and not self._wide_vector_active():
                 # Integer path: avoid div by zero; use float then store as float bits
                 f = float(raw_result)
                 result_val = 1.0 / f if f != 0 else 0.0
@@ -757,7 +942,7 @@ class Ipu:
     ) -> None:
         """Execute agg.first: like agg but for MAX mode ignores previous AAQ value."""
         dtype = self.state.get_cr_dtype()
-        fmt = "<i" if dtype == DType.INT8 else "<f"
+        fmt = self._acc_agg_lane_fmt()
         acc_buf = self.state.regfile.raw("r_acc")
         n_words = R_ACC_SIZE // 4  # 128
 
@@ -780,7 +965,7 @@ class Ipu:
             cr_scalar = struct.unpack(fmt, struct.pack("<I", cr_val))[0]
             result_val = raw_result * cr_scalar
         elif fn == POST_FN_INV:
-            if dtype == DType.INT8:
+            if dtype == DType.INT8 and not self._wide_vector_active():
                 f = float(raw_result)
                 result_val = 1.0 / f if f != 0 else 0.0
                 out_bits = struct.unpack("<I", struct.pack("<f", result_val))[0]
@@ -809,10 +994,34 @@ class Ipu:
         Requires INT8 mode. Each 32-bit word is truncated (top 8 bits taken via
         arithmetic right-shift by 24) then clamped to [-128, 127] and stored as
         a signed byte in the aaq_result register.
+
+        In wide-vector debug mode, ``aaq`` is normally a no-op (results stay in
+        ``r_acc`` as 32-bit lanes; use ``str_acc_reg`` to dump them). Set
+        ``state.wide_vector_quantize_output`` to re-run INT8-style quantization
+        from wide lanes for comparison with the real path.
         """
         dtype = self.state.get_cr_dtype()
         if dtype != DType.INT8:
             raise EmulatorError("AAQ instruction requires INT8 mode")
+
+        if self._wide_vector_active():
+            if not self.state.wide_vector_quantize_output:
+                return
+            acc_buf = self.state.regfile.raw("r_acc")
+            result = bytearray(128)
+            if self.state.wide_vector_arithmetic == WideVectorArithmetic.FP32:
+                for i in range(128):
+                    val = struct.unpack_from("<f", acc_buf, i * 4)[0]
+                    clamped = max(-128, min(127, int(round(val))))
+                    result[i] = clamped & 0xFF
+            else:
+                for i in range(128):
+                    val = struct.unpack_from("<i", acc_buf, i * 4)[0]
+                    truncated = val >> 24
+                    clamped = max(-128, min(127, truncated))
+                    result[i] = clamped & 0xFF
+            self.state.regfile.set_aaq_result(result)
+            return
 
         acc_buf = self.state.regfile.raw("r_acc")
         result = bytearray(128)
@@ -956,6 +1165,10 @@ class Ipu:
             return BreakResult.CONTINUE
 
         self.snapshot = self.state.regfile.snapshot()
+        if self._wide_vector_active():
+            self.state._debug_mult_stage_vectors_snap = {
+                k: list(v) for k, v in self.state._debug_mult_stage_vectors.items()
+            }
 
         # Break runs first — may halt before side effects
         result = self.dispatch_instruction("break", inst)
@@ -983,6 +1196,10 @@ class Ipu:
             return
 
         self.snapshot = self.state.regfile.snapshot()
+        if self._wide_vector_active():
+            self.state._debug_mult_stage_vectors_snap = {
+                k: list(v) for k, v in self.state._debug_mult_stage_vectors.items()
+            }
 
         # Execute all slots except break
         self._dispatch_lr_slots(inst)

--- a/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
@@ -229,6 +229,24 @@ class Ipu:
     def _wide_vector_active(self) -> bool:
         return self.state.wide_vector_debug
 
+    def _wide_assert_lane_aligned_byte_offset(self, name: str, byte_off: int) -> None:
+        """Wide-vector mode treats r_cyclic in 4-byte lanes; misaligned offsets corrupt unpacking."""
+        if byte_off % 4 != 0:
+            raise EmulatorError(
+                f"Wide-vector debug: {name} must be 4-byte aligned, got {byte_off}"
+            )
+
+    def _wide_pack_aaq_bits(self, fmt: str, result_val: float | int) -> int:
+        """Pack agg/aaq scalar result for ``set_aaq`` (uint32 bit pattern)."""
+        if fmt == "<f":
+            return struct.unpack("<I", struct.pack("<f", float(result_val)))[0]
+        if isinstance(result_val, float):
+            ri = int(round(result_val))
+        else:
+            ri = int(result_val)
+        ri = max(-0x80000000, min(0x7FFFFFFF, ri))
+        return ri & 0xFFFFFFFF
+
     def _wide_unpack_lane_tuple(self, buf: bytes | bytearray) -> tuple[float, ...] | tuple[int, ...]:
         if self.state.wide_vector_arithmetic == WideVectorArithmetic.FP32:
             return struct.unpack_from("<128f", buf, 0)
@@ -262,6 +280,7 @@ class Ipu:
         return [0.0 if self.state.wide_vector_arithmetic == WideVectorArithmetic.FP32 else 0] * R_REG_SIZE
 
     def _debug_rb_lane_vals(self, cyclic_offset: int, source: RegFile) -> tuple[float, ...] | tuple[int, ...]:
+        self._wide_assert_lane_aligned_byte_offset("cyclic_offset", cyclic_offset)
         buf = source.get_r_cyclic_at(cyclic_offset, R_CYCLIC_SIZE)
         return self._wide_unpack_lane_tuple(buf)
 
@@ -390,8 +409,12 @@ class Ipu:
         """Execute ldr_cyclic_mult_reg: Load with cyclic addressing into r_cyclic."""
         addr = offset + base
         if self._wide_vector_active():
+            assert index % R_CYCLIC_SIZE == 0, (
+                f"Wide-vector debug: cyclic load index must be aligned to {R_CYCLIC_SIZE}, "
+                f"got {index}"
+            )
             data = self.state.xmem.read_address(addr, R_CYCLIC_SIZE)
-            self.state.regfile.set_r_cyclic_at(0, data)
+            self.state.regfile.set_r_cyclic_at(index, data)
             return
 
         data = self.state.xmem.read_address(addr, R_REG_SIZE)
@@ -490,6 +513,7 @@ class Ipu:
         mult_res = self.state.regfile.raw("mult_res")
 
         if self._wide_vector_active():
+            self._wide_assert_lane_aligned_byte_offset("cyclic_offset", cyclic_offset)
             ra_vals = self._debug_ra_lane_vals(ra)
             rb_vals = self._debug_rb_lane_vals(cyclic_offset, self.state.regfile)
             if self.state.wide_vector_arithmetic == WideVectorArithmetic.FP32:
@@ -518,6 +542,7 @@ class Ipu:
         mult_res = self.state.regfile.raw("mult_res")
 
         if self._wide_vector_active():
+            self._wide_assert_lane_aligned_byte_offset("fixed_cyclic_idx", fixed_cyclic_idx)
             ra_vals = self._debug_ra_lane_vals(ra)
             rb_vals = self._debug_rb_lane_vals(fixed_cyclic_idx, self.state.regfile)
             rb0 = rb_vals[0]
@@ -554,6 +579,7 @@ class Ipu:
         mult_res = self.state.regfile.raw("mult_res")
 
         if self._wide_vector_active():
+            self._wide_assert_lane_aligned_byte_offset("cyclic_offset", cyclic_offset)
             r0_vals = self._debug_ra_lane_vals(0)
             r1_vals = self._debug_ra_lane_vals(1)
             rb_vals = self._debug_rb_lane_vals(cyclic_offset, self.state.regfile)
@@ -564,14 +590,14 @@ class Ipu:
             if self.state.wide_vector_arithmetic == WideVectorArithmetic.FP32:
                 one = 1.0
                 for i in range(R_REG_SIZE):
-                    pos = cyclic_offset + i
-                    rb_lane = float(rb_vals[i]) if pos < R_CYCLIC_SIZE else one
+                    pos = cyclic_offset + i * 4
+                    rb_lane = float(rb_vals[i]) if pos + 4 <= R_CYCLIC_SIZE else one
                     struct.pack_into("<f", mult_res, i * 4, float(ra_fixed) * rb_lane)
             else:
                 one = 1
                 for i in range(R_REG_SIZE):
-                    pos = cyclic_offset + i
-                    rb_lane = int(rb_vals[i]) if pos < R_CYCLIC_SIZE else one
+                    pos = cyclic_offset + i * 4
+                    rb_lane = int(rb_vals[i]) if pos + 4 <= R_CYCLIC_SIZE else one
                     struct.pack_into(
                         "<i", mult_res, i * 4, self._wide_imult32(int(ra_fixed), rb_lane)
                     )
@@ -607,20 +633,21 @@ class Ipu:
         mult_res = self.state.regfile.raw("mult_res")
 
         if self._wide_vector_active():
+            self._wide_assert_lane_aligned_byte_offset("cyclic_offset", cyclic_offset)
             cr_scalar = self._wide_cr_scalar_byte_as_int32(cr_idx)
             rb_vals = self._debug_rb_lane_vals(cyclic_offset, self.state.regfile)
             if self.state.wide_vector_arithmetic == WideVectorArithmetic.FP32:
                 scalar_f = float(cr_scalar)
                 one = 1.0
                 for i in range(R_REG_SIZE):
-                    pos = cyclic_offset + i
-                    rb_lane = float(rb_vals[i]) if pos < R_CYCLIC_SIZE else one
+                    pos = cyclic_offset + i * 4
+                    rb_lane = float(rb_vals[i]) if pos + 4 <= R_CYCLIC_SIZE else one
                     struct.pack_into("<f", mult_res, i * 4, scalar_f * rb_lane)
             else:
                 one = 1
                 for i in range(R_REG_SIZE):
-                    pos = cyclic_offset + i
-                    rb_lane = int(rb_vals[i]) if pos < R_CYCLIC_SIZE else one
+                    pos = cyclic_offset + i * 4
+                    rb_lane = int(rb_vals[i]) if pos + 4 <= R_CYCLIC_SIZE else one
                     struct.pack_into(
                         "<i", mult_res, i * 4, self._wide_imult32(cr_scalar, rb_lane)
                     )
@@ -653,19 +680,20 @@ class Ipu:
         mult_res = self.state.regfile.raw("mult_res")
 
         if self._wide_vector_active():
+            self._wide_assert_lane_aligned_byte_offset("cyclic_offset", cyclic_offset)
             aaq_lane = self._wide_aaq_scalar(aaq_rf_idx)
             rb_vals = self._debug_rb_lane_vals(cyclic_offset, self.state.regfile)
             if self.state.wide_vector_arithmetic == WideVectorArithmetic.FP32:
                 one = 1.0
                 for i in range(R_REG_SIZE):
-                    pos = cyclic_offset + i
-                    rb_lane = float(rb_vals[i]) if pos < R_CYCLIC_SIZE else one
+                    pos = cyclic_offset + i * 4
+                    rb_lane = float(rb_vals[i]) if pos + 4 <= R_CYCLIC_SIZE else one
                     struct.pack_into("<f", mult_res, i * 4, float(aaq_lane) * rb_lane)
             else:
                 one = 1
                 for i in range(R_REG_SIZE):
-                    pos = cyclic_offset + i
-                    rb_lane = int(rb_vals[i]) if pos < R_CYCLIC_SIZE else one
+                    pos = cyclic_offset + i * 4
+                    rb_lane = int(rb_vals[i]) if pos + 4 <= R_CYCLIC_SIZE else one
                     struct.pack_into(
                         "<i", mult_res, i * 4, self._wide_imult32(int(aaq_lane), rb_lane)
                     )
@@ -905,7 +933,12 @@ class Ipu:
         elif fn == POST_FN_VALUE_CR:
             cr_val = self.state.regfile.get_cr(cr_idx) & 0xFFFFFFFF
             cr_scalar = struct.unpack(fmt, struct.pack("<I", cr_val))[0]
-            result_val = raw_result * cr_scalar
+            if fmt == "<i":
+                result_val = int(raw_result) * int(cr_scalar)
+                p = result_val & 0xFFFFFFFF
+                result_val = p - 0x100000000 if p >= 0x80000000 else p
+            else:
+                result_val = raw_result * cr_scalar
         elif fn == POST_FN_INV:
             if dtype == DType.INT8 and not self._wide_vector_active():
                 # Integer path: avoid div by zero; use float then store as float bits
@@ -916,21 +949,30 @@ class Ipu:
                 self.state.regfile.set_aaq(aaq_rf_idx, out_bits)
                 return
             else:
-                result_val = 1.0 / raw_result if raw_result != 0 else 0.0
+                if fmt == "<i":
+                    ri = int(raw_result)
+                    result_val = 0 if ri == 0 else int(round(1.0 / float(ri)))
+                else:
+                    result_val = 1.0 / raw_result if raw_result != 0 else 0.0
         elif fn == POST_FN_INV_SQRT:
-            if dtype == DType.INT8:
+            if dtype == DType.INT8 and not self._wide_vector_active():
                 f = float(raw_result)
                 result_val = 1.0 / (f ** 0.5) if f > 0 else 0.0
                 out_bits = struct.unpack("<I", struct.pack("<f", result_val))[0]
                 self.state.regfile.set_aaq(aaq_rf_idx, out_bits)
                 return
             else:
-                result_val = 1.0 / (raw_result ** 0.5) if raw_result > 0 else 0.0
+                if fmt == "<i":
+                    ri = int(raw_result)
+                    result_val = (
+                        int(round(1.0 / (float(ri) ** 0.5))) if ri > 0 else 0
+                    )
+                else:
+                    result_val = 1.0 / (raw_result ** 0.5) if raw_result > 0 else 0.0
         else:
             result_val = raw_result
 
-        out_bits = struct.unpack("<I", struct.pack(fmt, result_val))[0]
-        self.state.regfile.set_aaq(aaq_rf_idx, out_bits)
+        self.state.regfile.set_aaq(aaq_rf_idx, self._wide_pack_aaq_bits(fmt, result_val))
 
     def execute_agg_first(
         self,
@@ -963,7 +1005,12 @@ class Ipu:
         elif fn == POST_FN_VALUE_CR:
             cr_val = self.state.regfile.get_cr(cr_idx) & 0xFFFFFFFF
             cr_scalar = struct.unpack(fmt, struct.pack("<I", cr_val))[0]
-            result_val = raw_result * cr_scalar
+            if fmt == "<i":
+                result_val = int(raw_result) * int(cr_scalar)
+                p = result_val & 0xFFFFFFFF
+                result_val = p - 0x100000000 if p >= 0x80000000 else p
+            else:
+                result_val = raw_result * cr_scalar
         elif fn == POST_FN_INV:
             if dtype == DType.INT8 and not self._wide_vector_active():
                 f = float(raw_result)
@@ -972,21 +1019,30 @@ class Ipu:
                 self.state.regfile.set_aaq(aaq_rf_idx, out_bits)
                 return
             else:
-                result_val = 1.0 / raw_result if raw_result != 0 else 0.0
+                if fmt == "<i":
+                    ri = int(raw_result)
+                    result_val = 0 if ri == 0 else int(round(1.0 / float(ri)))
+                else:
+                    result_val = 1.0 / raw_result if raw_result != 0 else 0.0
         elif fn == POST_FN_INV_SQRT:
-            if dtype == DType.INT8:
+            if dtype == DType.INT8 and not self._wide_vector_active():
                 f = float(raw_result)
                 result_val = 1.0 / (f ** 0.5) if f > 0 else 0.0
                 out_bits = struct.unpack("<I", struct.pack("<f", result_val))[0]
                 self.state.regfile.set_aaq(aaq_rf_idx, out_bits)
                 return
             else:
-                result_val = 1.0 / (raw_result ** 0.5) if raw_result > 0 else 0.0
+                if fmt == "<i":
+                    ri = int(raw_result)
+                    result_val = (
+                        int(round(1.0 / (float(ri) ** 0.5))) if ri > 0 else 0
+                    )
+                else:
+                    result_val = 1.0 / (raw_result ** 0.5) if raw_result > 0 else 0.0
         else:
             result_val = raw_result
 
-        out_bits = struct.unpack("<I", struct.pack(fmt, result_val))[0]
-        self.state.regfile.set_aaq(aaq_rf_idx, out_bits)
+        self.state.regfile.set_aaq(aaq_rf_idx, self._wide_pack_aaq_bits(fmt, result_val))
 
     def execute_aaq(self) -> None:
         """Execute aaq: Quantize r_acc (128 × INT32) → aaq_result (128 × INT8).

--- a/src/tools/ipu-emu-py/src/ipu_emu/ipu_state.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/ipu_state.py
@@ -6,7 +6,7 @@ memory into a single object — the Python equivalent of ``ipu__obj_t``.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from enum import Enum
 from typing import Any
 
 from ipu_emu.regfile import RegFile
@@ -19,6 +19,17 @@ INST_MEM_SIZE = 1024
 CR_DTYPE_REG = 15
 
 
+class WideVectorArithmetic(str, Enum):
+    """How 128-lane wide-vector debug math is performed (emulator-only; issue #33).
+
+    FP32: each lane is IEEE float32 (default for “no quantization” FP analysis).
+    INT32: each lane is signed int32 with wrap semantics matching INT8-mode acc ops.
+    """
+
+    FP32 = "fp32"
+    INT32 = "int32"
+
+
 class IpuState:
     """Complete IPU processor state.
 
@@ -29,13 +40,31 @@ class IpuState:
         inst_mem:        Instruction memory (list of decoded instruction dicts).
     """
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        wide_vector_debug: bool = False,
+        wide_vector_arithmetic: WideVectorArithmetic = WideVectorArithmetic.FP32,
+        wide_vector_quantize_output: bool = False,
+    ) -> None:
         self.regfile = RegFile()
         self.xmem = XMem()
         self.program_counter: int = 0
         # Instruction memory — each entry will be a decoded instruction dict
         # (populated when loading a binary or assembling).
         self.inst_mem: list[dict[str, Any] | None] = [None] * INST_MEM_SIZE
+
+        # --- Emulator-only wide-vector debug mode (GitHub issue #33) ------------
+        # XMEM addresses and architectural byte counts are unchanged; r/r_cyclic
+        # operands are staged as 128×32-bit lanes while mult/acc use that width.
+        # LR/CR are not widened. Keys are MultStageReg *encoding indices* (0=r0,
+        # 1=r1, 2=mem_bypass), not r-array element indices, so r0 and mem_bypass
+        # do not collide.
+        self.wide_vector_debug: bool = wide_vector_debug
+        self.wide_vector_arithmetic: WideVectorArithmetic = wide_vector_arithmetic
+        self.wide_vector_quantize_output: bool = wide_vector_quantize_output
+        self._debug_mult_stage_vectors: dict[int, list[float | int]] = {}
+        self._debug_mult_stage_vectors_snap: dict[int, list[float | int]] = {}
 
     # -- CR dtype convenience (mirrors ipu__set_cr_dtype / ipu__get_cr_dtype) --
 

--- a/src/tools/ipu-emu-py/test/test_wide_vector_debug.py
+++ b/src/tools/ipu-emu-py/test/test_wide_vector_debug.py
@@ -13,6 +13,7 @@ import pytest
 
 from ipu_emu.emulator import load_program, run_until_complete
 from ipu_emu.execute import decode_instruction_word
+from ipu_emu.ipu import EmulatorError
 from ipu_emu.ipu_math import DType
 from ipu_emu.ipu_state import IpuState, WideVectorArithmetic
 
@@ -179,3 +180,110 @@ bkpt;;
 
         assert run_mult("r0") == pytest.approx(2.0)
         assert run_mult("mem_bypass") == pytest.approx(198.0)
+
+
+class TestWideVectorCyclicIndex:
+    """``ldr_cyclic_mult_reg`` must honour ``index`` in wide mode (512-byte chunk)."""
+
+    def test_ldr_cyclic_nonzero_index_fp32(self) -> None:
+        zeros = struct.pack("<128f", *([0.0] * 128))
+        nines = struct.pack("<128f", *([9.0] * 128))
+        twos = struct.pack("<128f", *([2.0] * 128))
+        st = IpuState(wide_vector_debug=True, wide_vector_arithmetic=WideVectorArithmetic.FP32)
+        st.regfile.set_cr(15, DType.INT8)
+        st.xmem.write_address(0x2000, zeros)
+        st.xmem.write_address(0x2200, nines)
+        st.xmem.write_address(0x1000, twos)
+        asm = """\
+set lr0 0x2000;;
+set lr1 0;;
+ldr_cyclic_mult_reg lr0 cr0 lr1;;
+set lr2 0x2200;;
+set lr3 512;;
+ldr_cyclic_mult_reg lr2 cr0 lr3;;
+set lr4 0x1000;;
+ldr_mult_reg r0 lr4 cr0;;
+set lr5 512;;
+reset_acc;;
+mult.ee r0 lr5 lr5 lr5;;
+acc.first;;
+bkpt;;
+"""
+        encoded = assemble(asm)
+        load_program(st, [decode_instruction_word(w) for w in encoded])
+        run_until_complete(st)
+        acc = st.regfile.raw("r_acc")
+        for i in range(128):
+            assert struct.unpack_from("<f", acc, i * 4)[0] == pytest.approx(18.0), f"lane {i}"
+
+
+class TestWideVectorPadding:
+    """Lanes past the r_cyclic byte window use padding (×1) in wide FP32 mode."""
+
+    def test_mult_ve_cr_fp32_boundary_padding(self) -> None:
+        # cyclic_offset=384 (aligned): lane 31 ends at byte 508; lane 32 starts at 512 → pad.
+        buf = bytearray(512)
+        for k in range(32):
+            struct.pack_into("<f", buf, 384 + k * 4, 3.0)
+        st = IpuState(wide_vector_debug=True, wide_vector_arithmetic=WideVectorArithmetic.FP32)
+        st.regfile.set_cr(15, DType.INT8)
+        st.regfile.set_cr(1, 2)  # low byte 2 → scalar 2.0 in wide FP32 path
+        st.regfile.set_r_cyclic_at(0, buf)
+        asm = """\
+set lr0 384;;
+set lr1 0;;
+set lr2 0;;
+mult.ve.cr lr0 lr1 lr2 cr1;;
+reset_acc;;
+acc.first;;
+bkpt;;
+"""
+        encoded = assemble(asm)
+        load_program(st, [decode_instruction_word(w) for w in encoded])
+        run_until_complete(st)
+        mult_res = st.regfile.raw("mult_res")
+        for i in range(32):
+            assert struct.unpack_from("<f", mult_res, i * 4)[0] == pytest.approx(6.0), f"lane {i}"
+        for i in range(32, 128):
+            assert struct.unpack_from("<f", mult_res, i * 4)[0] == pytest.approx(2.0), f"lane {i}"
+
+
+class TestWideVectorAggInt32:
+    def test_agg_sum_inv_int32_wide(self) -> None:
+        """agg sum inv with INT32 wide lanes: 128×4 = 512 → inv rounds to int32 bits."""
+        acc = bytearray(512)
+        struct.pack_into("<128i", acc, 0, *([4] * 128))
+        st = IpuState(wide_vector_debug=True, wide_vector_arithmetic=WideVectorArithmetic.INT32)
+        st.regfile.set_cr(15, DType.INT8)
+        st.regfile.set_r_acc_bytes(acc)
+        asm = """\
+agg sum inv cr0 aaq0;;
+bkpt;;
+"""
+        encoded = assemble(asm)
+        load_program(st, [decode_instruction_word(w) for w in encoded])
+        run_until_complete(st)
+        assert st.regfile.get_aaq(0) == 0  # 1/512 rounds to 0 as int32
+
+
+class TestWideVectorAlignment:
+    def test_misaligned_cyclic_offset_raises(self) -> None:
+        st = IpuState(wide_vector_debug=True, wide_vector_arithmetic=WideVectorArithmetic.FP32)
+        st.regfile.set_cr(15, DType.INT8)
+        st.xmem.write_address(0x1000, struct.pack("<128f", *([1.0] * 128)))
+        st.xmem.write_address(0x2000, struct.pack("<128f", *([2.0] * 128)))
+        asm = """\
+set lr0 0x1000;;
+set lr1 0x2000;;
+set lr2 0;;
+ldr_mult_reg r0 lr0 cr0;;
+ldr_cyclic_mult_reg lr1 cr0 lr2;;
+set lr3 1;;
+reset_acc;;
+mult.ee r0 lr3 lr3 lr3;;
+bkpt;;
+"""
+        encoded = assemble(asm)
+        load_program(st, [decode_instruction_word(w) for w in encoded])
+        with pytest.raises(EmulatorError, match="4-byte aligned"):
+            run_until_complete(st)

--- a/src/tools/ipu-emu-py/test/test_wide_vector_debug.py
+++ b/src/tools/ipu-emu-py/test/test_wide_vector_debug.py
@@ -1,0 +1,181 @@
+"""Wide-vector debug mode (GitHub issue #33).
+
+XMEM transfer sizes stay architectural (128-byte loads for r in normal mode);
+in wide-vector mode ``ldr_mult_reg`` / ``ldr_cyclic_mult_reg`` consume 512 bytes
+per transfer as 128×32-bit lanes. LR/CR are unchanged.
+"""
+
+from __future__ import annotations
+
+import struct
+
+import pytest
+
+from ipu_emu.emulator import load_program, run_until_complete
+from ipu_emu.execute import decode_instruction_word
+from ipu_emu.ipu_math import DType
+from ipu_emu.ipu_state import IpuState, WideVectorArithmetic
+
+from ipu_as.lark_tree import assemble
+
+
+def _run_wide(
+    asm: str,
+    *,
+    arithmetic: WideVectorArithmetic = WideVectorArithmetic.FP32,
+    quantize_output: bool = False,
+) -> IpuState:
+    encoded = assemble(asm)
+    decoded = [decode_instruction_word(w) for w in encoded]
+    state = IpuState(
+        wide_vector_debug=True,
+        wide_vector_arithmetic=arithmetic,
+        wide_vector_quantize_output=quantize_output,
+    )
+    state.regfile.set_cr(15, DType.INT8)
+    load_program(state, decoded)
+    run_until_complete(state)
+    return state
+
+
+class TestWideVectorFp32:
+    def test_mult_ee_fp32_no_quantization_in_acc(self) -> None:
+        """128 float lanes multiply element-wise; acc holds float products."""
+        r0 = struct.pack("<128f", *([2.0] * 128))
+        rc = struct.pack("<128f", *([3.0] * 128))
+        state = IpuState(wide_vector_debug=True, wide_vector_arithmetic=WideVectorArithmetic.FP32)
+        state.regfile.set_cr(15, DType.INT8)
+        state.xmem.write_address(0x1000, r0)
+        state.xmem.write_address(0x2000, rc)
+        asm = """\
+set lr0 0x1000;;
+set lr1 0x2000;;
+set lr2 0;;
+ldr_mult_reg r0 lr0 cr0;;
+ldr_cyclic_mult_reg lr1 cr0 lr2;;
+reset_acc;;
+mult.ee r0 lr2 lr2 lr2;;
+acc.first;;
+bkpt;;
+"""
+        encoded = assemble(asm)
+        load_program(state, [decode_instruction_word(w) for w in encoded])
+        run_until_complete(state)
+        acc = state.regfile.raw("r_acc")
+        for i in range(128):
+            v = struct.unpack_from("<f", acc, i * 4)[0]
+            assert v == pytest.approx(6.0), f"lane {i}"
+
+    def test_aaq_noop_unless_quantize_flag(self) -> None:
+        state = _run_wide(
+            """\
+set lr0 0x1000;;
+set lr1 0x2000;;
+set lr2 0;;
+ldr_mult_reg r0 lr0 cr0;;
+ldr_cyclic_mult_reg lr1 cr0 lr2;;
+reset_acc;;
+mult.ee r0 lr2 lr2 lr2;;
+acc.first;;
+aaq;;
+bkpt;;
+""",
+        )
+        assert state.regfile.get_aaq_result() == bytearray(128)
+
+    def test_aaq_quantize_fp32_acc_for_comparison(self) -> None:
+        # Use exact float product 3.0 so rounding is unambiguous (round-half-even).
+        r0 = struct.pack("<128f", *([1.5] * 128))
+        rc = struct.pack("<128f", *([2.0] * 128))
+        state = IpuState(
+            wide_vector_debug=True,
+            wide_vector_arithmetic=WideVectorArithmetic.FP32,
+            wide_vector_quantize_output=True,
+        )
+        state.regfile.set_cr(15, DType.INT8)
+        state.xmem.write_address(0x1000, r0)
+        state.xmem.write_address(0x2000, rc)
+        asm = """\
+set lr0 0x1000;;
+set lr1 0x2000;;
+set lr2 0;;
+ldr_mult_reg r0 lr0 cr0;;
+ldr_cyclic_mult_reg lr1 cr0 lr2;;
+reset_acc;;
+mult.ee r0 lr2 lr2 lr2;;
+acc.first;;
+aaq;;
+bkpt;;
+"""
+        encoded = assemble(asm)
+        load_program(state, [decode_instruction_word(w) for w in encoded])
+        run_until_complete(state)
+        out = state.regfile.get_aaq_result()
+        assert all(b == 3 for b in out)
+
+
+class TestWideVectorInt32:
+    def test_mult_ee_int32_wrap_multiply(self) -> None:
+        r0 = struct.pack("<128i", *([70000] * 128))
+        rc = struct.pack("<128i", *([70000] * 128))
+        state = IpuState(wide_vector_debug=True, wide_vector_arithmetic=WideVectorArithmetic.INT32)
+        state.regfile.set_cr(15, DType.INT8)
+        state.xmem.write_address(0x1000, r0)
+        state.xmem.write_address(0x2000, rc)
+        asm = """\
+set lr0 0x1000;;
+set lr1 0x2000;;
+set lr2 0;;
+ldr_mult_reg r0 lr0 cr0;;
+ldr_cyclic_mult_reg lr1 cr0 lr2;;
+reset_acc;;
+mult.ee r0 lr2 lr2 lr2;;
+acc.first;;
+bkpt;;
+"""
+        encoded = assemble(asm)
+        load_program(state, [decode_instruction_word(w) for w in encoded])
+        run_until_complete(state)
+        acc = state.regfile.raw("r_acc")
+        expected = (70000 * 70000) & 0xFFFFFFFF
+        if expected >= 0x80000000:
+            expected -= 0x100000000
+        for i in range(128):
+            v = struct.unpack_from("<i", acc, i * 4)[0]
+            assert v == expected, f"lane {i}"
+
+
+class TestWideVectorMemBypassIsolation:
+    """Encoding 0 (r0) and 2 (mem_bypass) must not share debug staging storage."""
+
+    def test_r0_and_mem_bypass_independent(self) -> None:
+        r0 = struct.pack("<128f", *([1.0] * 128))
+        mb = struct.pack("<128f", *([99.0] * 128))
+        rc = struct.pack("<128f", *([2.0] * 128))
+
+        def run_mult(which: str) -> float:
+            st = IpuState(wide_vector_debug=True, wide_vector_arithmetic=WideVectorArithmetic.FP32)
+            st.regfile.set_cr(15, DType.INT8)
+            st.xmem.write_address(0x1000, r0)
+            st.xmem.write_address(0x1100, mb)
+            st.xmem.write_address(0x2000, rc)
+            asm = f"""\
+set lr0 0x1000;;
+set lr1 0x1100;;
+set lr2 0x2000;;
+set lr3 0;;
+ldr_mult_reg r0 lr0 cr0;;
+ldr_mult_reg mem_bypass lr1 cr0;;
+ldr_cyclic_mult_reg lr2 cr0 lr3;;
+reset_acc;;
+mult.ee {which} lr3 lr3 lr3;;
+acc.first;;
+bkpt;;
+"""
+            encoded = assemble(asm)
+            load_program(st, [decode_instruction_word(w) for w in encoded])
+            run_until_complete(st)
+            return struct.unpack_from("<f", st.regfile.raw("r_acc"), 0)[0]
+
+        assert run_mult("r0") == pytest.approx(2.0)
+        assert run_mult("mem_bypass") == pytest.approx(198.0)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements [issue #33](https://github.com/rechefe/ipu-emulator/issues/33): optional emulator mode where mult-stage vectors (`r0`/`r1`/`mem_bypass` via `ldr_mult_reg`, and `r_cyclic` via `ldr_cyclic_mult_reg`) are interpreted as 128×32-bit lanes (FP32 or INT32) for multiply/accumulate, while XMEM addresses and instruction encodings stay unchanged.

### API

- `IpuState(wide_vector_debug=True, wide_vector_arithmetic=WideVectorArithmetic.FP32 | INT32, wide_vector_quantize_output=False)`
- **FP32**: lane-wise float multiply and float add in `acc` / `acc.stride` / `agg*`.
- **INT32**: lane-wise signed multiply with 32-bit wrap; add uses the same wrap semantics as INT8-mode `ipu_add`.
- **`wide_vector_quantize_output`**: when set, `aaq` writes `aaq_result` from wide lanes for comparison with the real quantized path. Otherwise `aaq` is a no-op in wide mode; use existing `str_acc_reg` to dump 512-byte `r_acc`.
- **Masking**: `mult` mask-and-shift is skipped in wide mode (128-bit mask slots do not align to 128 float/int lanes).

### Fix vs naive staging

Debug staging is keyed by **MultStageReg encoding index** (0=r0, 1=r1, 2=mem_bypass), not `r` array element index, so `r0` and `mem_bypass` cannot overwrite each other.

### Docs

Under **Programming the IPU**, see [Wide-vector debug mode](https://github.com/rechefe/ipu-emulator/blob/cursor/issue-33-debug-wide-vectors-3b5f/docs/wide-vector-debug-mode.md) (`docs/wide-vector-debug-mode.md`) for usage, XMEM layout, alignment, and differences from normal mode.

### Tests

`//src/tools/ipu-emu-py:test_wide_vector_debug` Bazel target (pytest).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11237913-de1c-48ba-862f-ce8f45f83b5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11237913-de1c-48ba-862f-ce8f45f83b5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

