### PR TITLE
Allow three LR sub-instructions per VLIW word (issue #45)

### DIFF
--- a/src/tools/ipu-as-py/src/ipu_as/compound_inst.py
+++ b/src/tools/ipu-as-py/src/ipu_as/compound_inst.py
@@ -71,7 +71,7 @@ class CompoundInst:
             "lr": inst.LrInst,
             "cond": inst.CondInst,
         }
-        # Order defines bit layout: break, xmem, mult, acc, aaq, lr(×N), cond
+        # Order defines bit layout: break, xmem, mult, acc, aaq, lr(×N), cond (N = SLOT_COUNT["lr"])
         _slot_order = ["break", "xmem", "mult", "acc", "aaq", "lr", "cond"]
         result = []
         for slot in _slot_order:

--- a/src/tools/ipu-common/src/ipu_common/instruction_spec.py
+++ b/src/tools/ipu-common/src/ipu_common/instruction_spec.py
@@ -145,14 +145,14 @@ SLOT_BINARY_LAYOUT: dict[str, list[str]] = {
 }
 
 # How many times each slot appears in the VLIW instruction word.
-# Most slots appear once; LR appears twice (two independent sub-instructions).
+# Most slots appear once; LR appears three times (three independent sub-instructions).
 SLOT_COUNT: dict[str, int] = {
     "break": 1,
     "xmem": 1,
     "mult": 1,
     "acc": 1,
     "aaq": 1,
-    "lr": 2,
+    "lr": 3,
     "cond": 1,
 }
 

--- a/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
@@ -104,7 +104,7 @@ _SLOT_FIELD_PREFIX = {
     "aaq": "aaq_inst",
     "cond": "cond_inst",
     "break": "break_inst",
-    # LR is special: "lr_inst_0" and "lr_inst_1"
+    # LR is special: "lr_inst_0", "lr_inst_1", ... (count from SLOT_COUNT["lr"])
 }
 
 
@@ -138,7 +138,7 @@ def _build_all_instruction_field_maps() -> dict[tuple, dict[str, str]]:
 
     Returns a dict keyed by:
       (slot_type, inst_name)       — for non-LR slots
-      ("lr", inst_name, slot_idx)  — for LR sub-slots (0 and 1)
+      ("lr", inst_name, slot_idx)  — for LR sub-slots (0 .. SLOT_COUNT["lr"]-1)
     """
     result: dict[tuple, dict[str, str]] = {}
 
@@ -459,10 +459,10 @@ class Ipu:
         self.state.regfile.set_lr(dest, (src_a - src_b) & 0xFFFFFFFF)
 
     def _dispatch_lr_slots(self, inst: dict[str, int]) -> None:
-        """Dispatch both LR sub-slots with conflict detection.
+        """Dispatch all LR sub-slots with conflict detection.
 
-        LR is special: the VLIW word contains TWO LR sub-instructions
-        (lr_inst_0 and lr_inst_1). Each is dispatched independently
+        LR is special: the VLIW word contains multiple LR sub-instructions
+        (lr_inst_0, lr_inst_1, …). Each is dispatched independently
         with named operands. Read operands are auto-resolved to values.
         """
         pending: list[tuple[str, str, dict[str, int]]] = []
@@ -1232,7 +1232,7 @@ class Ipu:
             return BreakResult.BREAK
 
         # Execute all other slots using the snapshot
-        self._dispatch_lr_slots(inst)  # LR has dual sub-slots
+        self._dispatch_lr_slots(inst)  # LR has multiple sub-slots
         self.dispatch_instruction("xmem", inst)
         self.dispatch_instruction("mult", inst)
         self.dispatch_instruction("acc", inst)

--- a/src/tools/ipu-emu-py/test/test_execute.py
+++ b/src/tools/ipu-emu-py/test/test_execute.py
@@ -128,6 +128,46 @@ bkpt;;
 
 
 # ============================================================================
+# Three LR sub-slots per VLIW (SLOT_COUNT["lr"] == 3)
+# ============================================================================
+
+
+class TestThreeLrSlots:
+    def test_three_lr_instructions_parallel(self):
+        """Three independent LR ops may execute in the same cycle."""
+        state = _run(
+            """\
+set lr0 1; set lr1 2; set lr2 3;;
+bkpt;;
+"""
+        )
+        assert state.regfile.get_lr(0) == 1
+        assert state.regfile.get_lr(1) == 2
+        assert state.regfile.get_lr(2) == 3
+
+    def test_fourth_lr_instruction_rejected(self):
+        from ipu_as.compound_inst import CompoundInst
+        from ipu_as.lark_tree import parse
+
+        ast = parse("set lr0 1; set lr1 2; set lr2 3; set lr3 4;;")
+        with pytest.raises(ValueError, match="Too many instructions of type LrInst"):
+            CompoundInst(ast[0])
+
+    def test_decode_three_lr_sub_slots(self):
+        """Assemble → decode exposes lr_inst_0, lr_inst_1, lr_inst_2."""
+        encoded = assemble("set lr4 10; set lr5 20; set lr6 30;;\nbkpt;;")
+        assert len(encoded) == 2
+        d = decode_instruction_word(encoded[0])
+        assert d["lr_inst_0_token_0_lr_inst_opcode"] == 1  # set
+        assert d["lr_inst_0_token_1_lr_reg_field"] == 4
+        assert d["lr_inst_0_token_4_lr_immediate_type"] == 10
+        assert d["lr_inst_1_token_1_lr_reg_field"] == 5
+        assert d["lr_inst_1_token_4_lr_immediate_type"] == 20
+        assert d["lr_inst_2_token_1_lr_reg_field"] == 6
+        assert d["lr_inst_2_token_4_lr_immediate_type"] == 30
+
+
+# ============================================================================
 # Memory Operations
 # ============================================================================
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Issue #45 (GitHub was not reachable from this environment; implementation matches the described change: increase parallel LR slots from 2 to 3).

- Set `SLOT_COUNT["lr"]` to **3** in `instruction_spec.py` so the assembler compound layout and emulator LR dispatch stay in sync.
- Updated LR dispatch comments in `ipu.py` to describe multiple sub-slots generically.
- Clarified the compound-inst slot-order comment (N = `SLOT_COUNT["lr"]`).

## Tests

Added `TestThreeLrSlots` in `test_execute.py`:

- Three `set` instructions in one compound run and produce the expected LR values.
- A fourth LR instruction in one compound raises `ValueError` from the assembler.
- Assemble/decode round-trip checks `lr_inst_0`, `lr_inst_1`, and `lr_inst_2` field names and immediates.

## Verification

`bazel` was not available in this agent environment. Tests were run with:

`PYTHONPATH=... python3 -m pytest src/tools/ipu-emu-py/test/test_execute.py` (75 passed, including the three new tests).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a2991d2-78bf-4932-9c1d-a828196d20c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a2991d2-78bf-4932-9c1d-a828196d20c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

