### PR TITLE
Add incr_mod_pow2 LR instruction (Issue #47)

### DIFF
--- a/src/tools/ipu-as-py/src/ipu_as/immediate.py
+++ b/src/tools/ipu-as-py/src/ipu_as/immediate.py
@@ -1,3 +1,5 @@
+import lark
+
 import ipu_as.ipu_token as ipu_token
 from ipu_common.acc_stride_enums import (
     ELEMENTS_IN_ROW_NAMES,
@@ -11,6 +13,21 @@ class LrImmediateType(ipu_token.NumberToken):
     @classmethod
     def bits(cls) -> int:
         return 16
+
+
+class LrModPow2KImmediate(LrImmediateType):
+    """Immediate k for incr_mod_pow2: must be in [1, 9] per ISA."""
+
+    @classmethod
+    def default(cls) -> "ipu_token.IpuToken":
+        return cls(ipu_token.AnnotatedToken(lark.Token("NUMBER", "1"), 0))
+
+    def __init__(self, token: ipu_token.AnnotatedToken):
+        super().__init__(token)
+        if not (1 <= self.int <= 9):
+            self._raise_error(
+                f"Value {self.int} out of range [1, 9] for incr_mod_pow2 k operand"
+            )
 
 
 class BreakImmediateType(ipu_token.NumberToken):

--- a/src/tools/ipu-as-py/src/ipu_as/immediate.py
+++ b/src/tools/ipu-as-py/src/ipu_as/immediate.py
@@ -8,6 +8,10 @@ from ipu_common.acc_stride_enums import (
 )
 from ipu_common.acc_agg_enums import AGG_MODE_NAMES, POST_FN_NAMES
 
+# incr_mod_pow2 k operand — matches ISA (Issue #47)
+LR_MOD_POW2_K_MIN = 1
+LR_MOD_POW2_K_MAX = 9
+
 
 class LrImmediateType(ipu_token.NumberToken):
     @classmethod
@@ -16,17 +20,22 @@ class LrImmediateType(ipu_token.NumberToken):
 
 
 class LrModPow2KImmediate(LrImmediateType):
-    """Immediate k for incr_mod_pow2: must be in [1, 9] per ISA."""
+    """Immediate k for incr_mod_pow2: must be in [LR_MOD_POW2_K_MIN, LR_MOD_POW2_K_MAX] per ISA."""
 
     @classmethod
     def default(cls) -> "ipu_token.IpuToken":
-        return cls(ipu_token.AnnotatedToken(lark.Token("NUMBER", "1"), 0))
+        return cls(
+            ipu_token.AnnotatedToken(
+                lark.Token("NUMBER", str(LR_MOD_POW2_K_MIN)), 0
+            )
+        )
 
     def __init__(self, token: ipu_token.AnnotatedToken):
         super().__init__(token)
-        if not (1 <= self.int <= 9):
+        if not (LR_MOD_POW2_K_MIN <= self.int <= LR_MOD_POW2_K_MAX):
             self._raise_error(
-                f"Value {self.int} out of range [1, 9] for incr_mod_pow2 k operand"
+                f"Value {self.int} out of range [{LR_MOD_POW2_K_MIN}, {LR_MOD_POW2_K_MAX}] "
+                "for incr_mod_pow2 k operand"
             )
 
 

--- a/src/tools/ipu-as-py/src/ipu_as/inst.py
+++ b/src/tools/ipu-as-py/src/ipu_as/inst.py
@@ -27,6 +27,7 @@ OPERAND_TYPE_MAP: dict[str, type[ipu_token.IpuToken]] = {
     "AggMode": immediate.AggModeField,
     "PostFn": immediate.PostFnField,
     "Immediate": immediate.LrImmediateType,
+    "LrModPow2KImmediate": immediate.LrModPow2KImmediate,
     "BreakImmediate": immediate.BreakImmediateType,
     "Label": ipu_token.LabelToken,
 }
@@ -426,7 +427,13 @@ class AaqInst(Inst):
 class LrInst(Inst):
     @classmethod
     def operand_types(cls) -> list[type[ipu_token.IpuToken]]:
-        return [reg.LrRegField, reg.LcrRegField, reg.LcrRegField, immediate.LrImmediateType]
+        return [
+            reg.LrRegField,
+            reg.LcrRegField,
+            reg.LcrRegField,
+            immediate.LrImmediateType,
+            immediate.LrModPow2KImmediate,
+        ]
 
     @classmethod
     def opcode_type(cls) -> type[ipu_token.IpuToken]:

--- a/src/tools/ipu-common/src/ipu_common/instruction_spec.py
+++ b/src/tools/ipu-common/src/ipu_common/instruction_spec.py
@@ -26,7 +26,8 @@ OPERAND TYPE NAMES (resolved by ipu_as into actual token classes):
   - "LrIdx": lr0-lr15 (LrRegField)  
   - "CrIdx": cr0-cr15 (CrRegField)
   - "LcrIdx": lr0-lr15 or cr0-cr15 (LcrRegField)
-  - "Immediate": 32-bit signed integer (LrImmediateType)
+  - "Immediate": 16-bit signed integer for LR immediates (LrImmediateType)
+  - "LrModPow2KImmediate": k operand for incr_mod_pow2, range [1, 9]
   - "BreakImmediate": 16-bit break condition value (BreakImmediateType)
   - "Label": Branch target label (LabelToken)
 
@@ -139,7 +140,7 @@ SLOT_BINARY_LAYOUT: dict[str, list[str]] = {
     "mult": ["MultStageReg", "LrIdx", "LrIdx", "LrIdx", "LrIdx", "CrIdx", "AaqRegIdx"],
     "acc": ["AaqRegIdx", "ElementsInRow", "HorizontalStride", "VerticalStride", "LrIdx"],
     "aaq": ["AggMode", "PostFn", "CrIdx", "AaqRegIdx"],
-    "lr": ["LrIdx", "LcrIdx", "LcrIdx", "Immediate"],
+    "lr": ["LrIdx", "LcrIdx", "LcrIdx", "Immediate", "LrModPow2KImmediate"],
     "cond": ["LcrIdx", "LcrIdx", "Label"],
     "break": ["LrIdx", "BreakImmediate"],
 }
@@ -276,7 +277,7 @@ INSTRUCTION_SPEC = {
     
     # =========================================================================
     # LR Slot (Loop Register Instructions)
-    # Opcode = position: incr=0, set=1, add=2, sub=3
+    # Opcode = position: incr=0, set=1, add=2, sub=3, incr_mod_pow2=4
     # =========================================================================
     "lr": {
         "incr": {
@@ -354,6 +355,29 @@ INSTRUCTION_SPEC = {
                 example="sub lr0 lr1 lr2;;",
             ),
             "execute_fn": "execute_lr_sub",
+        },
+        "incr_mod_pow2": {
+            "operands": [
+                {"name": "dst", "type": "LrIdx"},
+                {"name": "step", "type": "LcrIdx", "read": "snapshot"},
+                {"name": "k", "type": "LrModPow2KImmediate"},
+            ],
+            "doc": InstructionDoc(
+                title="Increment Loop Register Modulo Power of Two",
+                summary=(
+                    "Add a loop or configuration register into the destination loop "
+                    "register, then mask to k low bits (mod 2^k)."
+                ),
+                syntax="incr_mod_pow2 dst step k",
+                operands=[
+                    "dst: Destination loop register (lr0-lr15); read and written",
+                    "step: Signed 32-bit increment from lr0-lr15 or cr0-cr15",
+                    "k: Immediate in [1, 9]; mask = (1 << k) - 1",
+                ],
+                operation="dst <- (dst + step) & ((1 << k) - 1)",
+                example="incr_mod_pow2 lr2 lr3 4;;",
+            ),
+            "execute_fn": "execute_lr_incr_mod_pow2",
         },
     },
     
@@ -946,7 +970,7 @@ def extract_opcodes() -> Dict[str, List[str]]:
     Example:
         {
             "xmem": ["str_acc_reg", "ldr_mult_reg", ...],
-            "lr": ["incr", "set", "add", "sub"],
+            "lr": ["incr", "set", "add", "sub", "incr_mod_pow2"],
             ...
         }
     """
@@ -1119,7 +1143,7 @@ def validate_instruction_spec() -> None:
         "MultStageReg", "LrIdx", "CrIdx", "LcrIdx", "AaqRegIdx",
         "ElementsInRow", "HorizontalStride", "VerticalStride",
         "AggMode", "PostFn",
-        "Immediate", "BreakImmediate", "Label"
+        "Immediate", "LrModPow2KImmediate", "BreakImmediate", "Label"
     }
     valid_read_sources = {"snapshot", "live"}
     

--- a/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
@@ -92,6 +92,7 @@ _TYPE_FIELD_SUFFIX = {
     "AggMode": "agg_mode_field",
     "PostFn": "post_fn_field",
     "Immediate": "lr_immediate_type",
+    "LrModPow2KImmediate": "lr_mod_pow2_k_immediate",
     "BreakImmediate": "break_immediate_type",
     "Label": "label_token",
 }
@@ -457,6 +458,19 @@ class Ipu:
     def execute_lr_sub(self, *, dest: int, src_a: int, src_b: int) -> None:
         """Execute sub: Subtract two LCR registers."""
         self.state.regfile.set_lr(dest, (src_a - src_b) & 0xFFFFFFFF)
+
+    def execute_lr_incr_mod_pow2(self, *, dst: int, step: int, k: int) -> None:
+        """incr_mod_pow2: dst <- (dst + step) mod 2^k.
+
+        Old dst is taken from the cycle-start snapshot (read-before-write). Step is
+        resolved from LcrIdx (snapshot), interpreted as uint32 like ``add``/``sub``.
+        k is validated at assemble time [1, 9].
+        """
+        assert self.snapshot is not None
+        cur = self.snapshot.get_lr(dst)
+        step_u = step & 0xFFFFFFFF
+        mask = (1 << k) - 1
+        self.state.regfile.set_lr(dst, ((cur + step_u) & 0xFFFFFFFF) & mask)
 
     def _dispatch_lr_slots(self, inst: dict[str, int]) -> None:
         """Dispatch all LR sub-slots with conflict detection.

--- a/src/tools/ipu-emu-py/test/test_execute.py
+++ b/src/tools/ipu-emu-py/test/test_execute.py
@@ -22,7 +22,9 @@ from ipu_emu.emulator import (
 from ipu_emu.ipu_state import IpuState, INST_MEM_SIZE
 from ipu_emu.ipu_math import DType
 
-from ipu_as.lark_tree import assemble
+from ipu_as.lark_tree import assemble, parse
+
+from ipu_as.compound_inst import CompoundInst
 
 
 # ---------------------------------------------------------------------------
@@ -128,6 +130,79 @@ bkpt;;
 
 
 # ============================================================================
+# incr_mod_pow2 (Issue #47): dst <- (dst + step) mod 2^k
+# ============================================================================
+
+
+class TestIncrModPow2:
+    def test_basic_wrap_small_k(self):
+        """k=4 → mod 16; 15 + 1 wraps to 0."""
+        state = _run(
+            """\
+set lr0 15;;
+set lr1 1;;
+incr_mod_pow2 lr0 lr1 4;;
+bkpt;;
+"""
+        )
+        assert state.regfile.get_lr(0) == 0
+
+    def test_k9_mask_511(self):
+        """k=9 → mask 511; largest legal k from spec."""
+        state = _run(
+            """\
+set lr0 500;;
+set lr1 20;;
+incr_mod_pow2 lr0 lr1 9;;
+bkpt;;
+"""
+        )
+        assert state.regfile.get_lr(0) == (500 + 20) & 511
+
+    def test_read_before_write_same_register(self):
+        """dst and step both lr0: uses snapshot value of lr0 for the sum."""
+        state = _run(
+            """\
+set lr0 5;;
+incr_mod_pow2 lr0 lr0 3;;
+bkpt;;
+"""
+        )
+        assert state.regfile.get_lr(0) == (5 + 5) & 7
+
+    def test_step_from_cr(self):
+        state = _make_state(
+            """\
+set lr0 2;;
+incr_mod_pow2 lr0 cr4 4;;
+bkpt;;
+"""
+        )
+        state.regfile.set_cr(4, 10)
+        run_until_complete(state)
+        assert state.regfile.get_lr(0) == (2 + 10) & 15
+
+    def test_large_unsigned_step_reduces_mod_mask(self):
+        """Uint32 add before mask: step loaded from CR as full uint32."""
+        state = _make_state(
+            """\
+set lr0 3;;
+incr_mod_pow2 lr0 cr5 3;;
+bkpt;;
+"""
+        )
+        state.regfile.set_cr(5, 0xFFFFFFFE)
+        run_until_complete(state)
+        assert state.regfile.get_lr(0) == (3 + 0xFFFFFFFE) & 7
+
+    def test_assembler_rejects_k_out_of_range(self):
+        with pytest.raises(ValueError, match=r"incr_mod_pow2 k operand"):
+            CompoundInst(parse("incr_mod_pow2 lr0 lr1 0;;")[0])
+        with pytest.raises(ValueError, match=r"incr_mod_pow2 k operand"):
+            CompoundInst(parse("incr_mod_pow2 lr0 lr1 10;;")[0])
+
+
+# ============================================================================
 # Three LR sub-slots per VLIW (SLOT_COUNT["lr"] == 3)
 # ============================================================================
 
@@ -161,10 +236,13 @@ bkpt;;
         assert d["lr_inst_0_token_0_lr_inst_opcode"] == 1  # set
         assert d["lr_inst_0_token_1_lr_reg_field"] == 4
         assert d["lr_inst_0_token_4_lr_immediate_type"] == 10
+        assert d["lr_inst_0_token_5_lr_mod_pow2_k_immediate"] == 1  # NOP default
         assert d["lr_inst_1_token_1_lr_reg_field"] == 5
         assert d["lr_inst_1_token_4_lr_immediate_type"] == 20
+        assert d["lr_inst_1_token_5_lr_mod_pow2_k_immediate"] == 1
         assert d["lr_inst_2_token_1_lr_reg_field"] == 6
         assert d["lr_inst_2_token_4_lr_immediate_type"] == 30
+        assert d["lr_inst_2_token_5_lr_mod_pow2_k_immediate"] == 1
 
 
 # ============================================================================
@@ -1038,6 +1116,7 @@ class TestDecodeRoundtrip:
         assert d["lr_inst_0_token_0_lr_inst_opcode"] == 1  # set
         assert d["lr_inst_0_token_1_lr_reg_field"] == 13
         assert d["lr_inst_0_token_4_lr_immediate_type"] == 0x1000
+        assert d["lr_inst_0_token_5_lr_mod_pow2_k_immediate"] == 1
 
 
 # ============================================================================


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **Issue #47**: new LR slot instruction `incr_mod_pow2 dst step k` with

`dst ← (dst + step) & ((1 << k) - 1)`

per spec (operands: **dst** `LrIdx`, **step** `LcrIdx`, **k** immediate ∈ [1, 9]).

## Implementation notes

- **`instruction_spec.py`**: Added `incr_mod_pow2` after `sub` (opcode index 4). Extended LR binary layout with **`LrModPow2KImmediate`** so `k` is validated at assemble time.
- **`ipu_as`**: New `LrModPow2KImmediate` token (16-bit like other LR immediates; default uses **`LR_MOD_POW2_K_MIN`** for NOP padding). Bounds **`LR_MOD_POW2_K_MIN`** / **`LR_MOD_POW2_K_MAX`** are module-level parameters in `immediate.py`.
- **`ipu.py`**: `execute_lr_incr_mod_pow2` reads previous **dst** from the cycle-start **snapshot** (read-before-write); **step** uses resolved `LcrIdx` values like `add`/`sub` (uint32 add, then mask).

## Tests

`TestIncrModPow2` in `test_execute.py` covers wrap (k=4), k=9, dst==step same-register snapshot, step from **cr**, large uint32 step via **cr**, k out of range at assemble time, and updates decode roundtrip assertions for the new default **k** token.

Closes #47
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-544ab936-7102-438c-8bff-2d7a27f44b67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-544ab936-7102-438c-8bff-2d7a27f44b67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

