### PR TITLE
Encode incr_mod_pow2 k in 4 bits (k − 1)

### DIFF
--- a/src/tools/ipu-as-py/src/ipu_as/immediate.py
+++ b/src/tools/ipu-as-py/src/ipu_as/immediate.py
@@ -1,16 +1,17 @@
 import lark
 
 import ipu_as.ipu_token as ipu_token
+from ipu_common.incr_mod_pow2_k import (
+    LR_MOD_POW2_K_FIELD_BITS,
+    LR_MOD_POW2_K_MAX,
+    LR_MOD_POW2_K_MIN,
+)
 from ipu_common.acc_stride_enums import (
     ELEMENTS_IN_ROW_NAMES,
     HORIZONTAL_STRIDE_NAMES,
     VERTICAL_STRIDE_NAMES,
 )
 from ipu_common.acc_agg_enums import AGG_MODE_NAMES, POST_FN_NAMES
-
-# incr_mod_pow2 k operand — matches ISA (Issue #47)
-LR_MOD_POW2_K_MIN = 1
-LR_MOD_POW2_K_MAX = 9
 
 
 class LrImmediateType(ipu_token.NumberToken):
@@ -19,8 +20,12 @@ class LrImmediateType(ipu_token.NumberToken):
         return 16
 
 
-class LrModPow2KImmediate(LrImmediateType):
-    """Immediate k for incr_mod_pow2: must be in [LR_MOD_POW2_K_MIN, LR_MOD_POW2_K_MAX] per ISA."""
+class LrModPow2KImmediate(ipu_token.IpuToken):
+    """Semantic k ∈ [LR_MOD_POW2_K_MIN, LR_MOD_POW2_K_MAX]; encoded as (k−1) in LR_MOD_POW2_K_FIELD_BITS bits."""
+
+    @classmethod
+    def bits(cls) -> int:
+        return LR_MOD_POW2_K_FIELD_BITS
 
     @classmethod
     def default(cls) -> "ipu_token.IpuToken":
@@ -32,11 +37,22 @@ class LrModPow2KImmediate(LrImmediateType):
 
     def __init__(self, token: ipu_token.AnnotatedToken):
         super().__init__(token)
+        try:
+            self.int = int(token.token.value, 0)
+        except ValueError:
+            self._raise_error(f"Value {self.token.value} is not a valid integer")
         if not (LR_MOD_POW2_K_MIN <= self.int <= LR_MOD_POW2_K_MAX):
             self._raise_error(
                 f"Value {self.int} out of range [{LR_MOD_POW2_K_MIN}, {LR_MOD_POW2_K_MAX}] "
                 "for incr_mod_pow2 k operand"
             )
+
+    def encode(self) -> int:
+        return self.int - LR_MOD_POW2_K_MIN
+
+    @classmethod
+    def decode(cls, value: int) -> str:
+        return str(value + LR_MOD_POW2_K_MIN)
 
 
 class BreakImmediateType(ipu_token.NumberToken):

--- a/src/tools/ipu-common/src/ipu_common/incr_mod_pow2_k.py
+++ b/src/tools/ipu-common/src/ipu_common/incr_mod_pow2_k.py
@@ -1,0 +1,12 @@
+"""incr_mod_pow2 k operand — shared by assembler and emulator.
+
+The LR slot encodes k in a narrow field: semantic k ∈ [LR_MOD_POW2_K_MIN, LR_MOD_POW2_K_MAX]
+is stored as (k - 1) in LR_MOD_POW2_K_FIELD_BITS bits (4 bits → nine distinct codes 0..8).
+"""
+
+LR_MOD_POW2_K_MIN = 1
+LR_MOD_POW2_K_MAX = 9
+LR_MOD_POW2_K_FIELD_BITS = 4
+
+# Valid encoded values are 0 .. (LR_MOD_POW2_K_MAX - LR_MOD_POW2_K_MIN)
+LR_MOD_POW2_K_ENCODED_MAX = LR_MOD_POW2_K_MAX - LR_MOD_POW2_K_MIN

--- a/src/tools/ipu-common/src/ipu_common/instruction_spec.py
+++ b/src/tools/ipu-common/src/ipu_common/instruction_spec.py
@@ -27,7 +27,7 @@ OPERAND TYPE NAMES (resolved by ipu_as into actual token classes):
   - "CrIdx": cr0-cr15 (CrRegField)
   - "LcrIdx": lr0-lr15 or cr0-cr15 (LcrRegField)
   - "Immediate": 16-bit signed integer for LR immediates (LrImmediateType)
-  - "LrModPow2KImmediate": k operand for incr_mod_pow2, range [1, 9]
+  - "LrModPow2KImmediate": k operand for incr_mod_pow2 (semantic k ∈ [1, 9]; encoded as k−1 in 4 bits)
   - "BreakImmediate": 16-bit break condition value (BreakImmediateType)
   - "Label": Branch target label (LabelToken)
 
@@ -372,7 +372,7 @@ INSTRUCTION_SPEC = {
                 operands=[
                     "dst: Destination loop register (lr0-lr15); read and written",
                     "step: Signed 32-bit increment from lr0-lr15 or cr0-cr15",
-                    "k: Immediate in [1, 9]; mask = (1 << k) - 1",
+                    "k: Immediate in [1, 9]; encoded in 4 bits as (k − 1); mask = (1 << k) - 1",
                 ],
                 operation="dst <- (dst + step) & ((1 << k) - 1)",
                 example="incr_mod_pow2 lr2 lr3 4;;",

--- a/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
@@ -46,6 +46,7 @@ from ipu_common.acc_agg_enums import (
     get_agg_mode,
     get_post_fn,
 )
+from ipu_common.incr_mod_pow2_k import LR_MOD_POW2_K_ENCODED_MAX, LR_MOD_POW2_K_MIN
 from ipu_common.registers import get_register_sizes, get_mult_stage_map
 
 # ---------------------------------------------------------------------------
@@ -464,12 +465,17 @@ class Ipu:
 
         Old dst is taken from the cycle-start snapshot (read-before-write). Step is
         resolved from LcrIdx (snapshot), interpreted as uint32 like ``add``/``sub``.
-        k is validated at assemble time [1, 9].
+        ``k`` is the raw encoded field (k_semantic − 1); semantic exponent is k + 1.
         """
         assert self.snapshot is not None
+        if k > LR_MOD_POW2_K_ENCODED_MAX:
+            raise EmulatorError(
+                f"incr_mod_pow2: invalid k encoding {k} (max {LR_MOD_POW2_K_ENCODED_MAX})"
+            )
+        k_exp = k + LR_MOD_POW2_K_MIN
         cur = self.snapshot.get_lr(dst)
         step_u = step & 0xFFFFFFFF
-        mask = (1 << k) - 1
+        mask = (1 << k_exp) - 1
         self.state.regfile.set_lr(dst, ((cur + step_u) & 0xFFFFFFFF) & mask)
 
     def _dispatch_lr_slots(self, inst: dict[str, int]) -> None:

--- a/src/tools/ipu-emu-py/test/test_execute.py
+++ b/src/tools/ipu-emu-py/test/test_execute.py
@@ -195,6 +195,12 @@ bkpt;;
         run_until_complete(state)
         assert state.regfile.get_lr(0) == (3 + 0xFFFFFFFE) & 7
 
+    def test_k_encoded_four_bits(self):
+        """k operand uses 4 bits: semantic k=9 encodes as 8 in the instruction word."""
+        encoded = assemble("incr_mod_pow2 lr0 lr1 9;; bkpt;;")
+        d = decode_instruction_word(encoded[0])
+        assert d["lr_inst_0_token_5_lr_mod_pow2_k_immediate"] == 8
+
     def test_assembler_rejects_k_out_of_range(self):
         with pytest.raises(ValueError, match=r"incr_mod_pow2 k operand"):
             CompoundInst(parse("incr_mod_pow2 lr0 lr1 0;;")[0])
@@ -236,13 +242,13 @@ bkpt;;
         assert d["lr_inst_0_token_0_lr_inst_opcode"] == 1  # set
         assert d["lr_inst_0_token_1_lr_reg_field"] == 4
         assert d["lr_inst_0_token_4_lr_immediate_type"] == 10
-        assert d["lr_inst_0_token_5_lr_mod_pow2_k_immediate"] == 1  # NOP default
+        assert d["lr_inst_0_token_5_lr_mod_pow2_k_immediate"] == 0  # NOP default (k=1 → encoded 0)
         assert d["lr_inst_1_token_1_lr_reg_field"] == 5
         assert d["lr_inst_1_token_4_lr_immediate_type"] == 20
-        assert d["lr_inst_1_token_5_lr_mod_pow2_k_immediate"] == 1
+        assert d["lr_inst_1_token_5_lr_mod_pow2_k_immediate"] == 0
         assert d["lr_inst_2_token_1_lr_reg_field"] == 6
         assert d["lr_inst_2_token_4_lr_immediate_type"] == 30
-        assert d["lr_inst_2_token_5_lr_mod_pow2_k_immediate"] == 1
+        assert d["lr_inst_2_token_5_lr_mod_pow2_k_immediate"] == 0
 
 
 # ============================================================================
@@ -1116,7 +1122,7 @@ class TestDecodeRoundtrip:
         assert d["lr_inst_0_token_0_lr_inst_opcode"] == 1  # set
         assert d["lr_inst_0_token_1_lr_reg_field"] == 13
         assert d["lr_inst_0_token_4_lr_immediate_type"] == 0x1000
-        assert d["lr_inst_0_token_5_lr_mod_pow2_k_immediate"] == 1
+        assert d["lr_inst_0_token_5_lr_mod_pow2_k_immediate"] == 0
 
 
 # ============================================================================


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to merged PR #49: **`incr_mod_pow2`** semantic **k ∈ [1, 9]** is now encoded in **4 bits** as **`k − 1`** (codes **0…8**), instead of a **16-bit** immediate for that operand.

Nine distinct **k** values require **at least 4 bits** (3 bits only encode eight codes).

## Changes

- **`ipu_common/incr_mod_pow2_k.py`**: Shared **`LR_MOD_POW2_K_FIELD_BITS = 4`**, bounds, **`LR_MOD_POW2_K_ENCODED_MAX`**.
- **`immediate.py`**: **`LrModPow2KImmediate`** implements **`bits() → 4`** with **`encode`/`decode`** mapping **`k ↔ k−1`**.
- **`ipu.py`**: Handler interprets the decoded field as encoded **k**, exponent **`encoded + 1`**.
- **`test_execute.py`**: Decode asserts (**NOP → encoded 0**), **`k=9 → encoded 8**, assembler range checks unchanged.

Reduces LR sub-instruction width by **12 bits** per unused **k** field vs the prior layout.

## Testing

`pytest` on `src/tools/ipu-emu-py/test/` (195 passed).

Refs #47
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-544ab936-7102-438c-8bff-2d7a27f44b67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-544ab936-7102-438c-8bff-2d7a27f44b67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

