### PR TITLE
Fix MkDocs build: nested docs paths, stage spec filename, Mermaid fences

### DIFF
--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -1,10 +1,10 @@
 load("@rules_python//python:defs.bzl", "py_binary")
 load("@ipu_as_deps//:requirements.bzl", "requirement")
 
-# Automatically include all markdown files in docs/
+# All checked-in Markdown under docs/, preserving paths (e.g. specs/*.md).
 filegroup(
     name = "doc_sources",
-    srcs = glob(["*.md"]),
+    srcs = glob(["**/*.md"]),
 )
 
 py_binary(
@@ -65,9 +65,15 @@ genrule(
         # Copy mkdocs config
         cp $(location mkdocs.yml) $(@D)/docs_temp/
         
-        # Copy all source markdown files
+        # Copy source markdown files, preserving subdirectories (nav paths may be nested).
         for src in $(locations :doc_sources); do
-            cp $$src $(@D)/docs_temp/docs/
+            case "$$src" in
+                */docs/*) rel="$${src#*/docs/}" ;;
+                docs/*) rel="$${src#docs/}" ;;
+                *) rel="$$(basename "$$src")" ;;
+            esac
+            mkdir -p "$$(dirname "$(@D)/docs_temp/docs/$$rel")"
+            cp "$$src" "$(@D)/docs_temp/docs/$$rel"
         done
         
         # Copy generated instruction docs

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -59,12 +59,16 @@ nav:
       - Instruction Reference: instructions.md
   - Specs:
       - Cache Unit Specification: specs/cache-unit.md
-      - IPU Specification: specs/Stage-aaq.md
+      - IPU Specification: specs/stage-aaq.md
   - Release Log: release-log.md
 markdown_extensions:
   - admonition
   - pymdownx.details
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.highlight:
       anchor_linenums: true
       line_spans: __span


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The docs site build failed or omitted nested pages because only top-level `*.md` files were included and copied flat into `docs_temp/docs/`. On case-sensitive systems the nav pointed at `specs/Stage-aaq.md` while the repo file is `specs/stage-aaq.md`.

## Changes

- **Nav:** Point the IPU spec entry at `specs/stage-aaq.md`.
- **Bazel:** Use `glob(["**/*.md"])` so every checked-in Markdown file (including `specs/*.md`) is an input to `build_docs`. Copy sources into the staging tree while preserving relative paths so nav entries like `specs/cache-unit.md` work.
- **Mermaid:** Extend `pymdownx.superfences` with `custom_fences` for Mermaid so fenced diagrams in spec pages render with Material.

## Verification

- Local `mkdocs build` against a layout mirroring the genrule (`mkdocs.yml` + `docs/` tree) succeeds.
- CI: `bazel build //docs:build_docs` (requires `uv` for the requirements repo rule in this environment).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-91c80f30-4ea8-410f-a2d7-6d95f6f57203"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91c80f30-4ea8-410f-a2d7-6d95f6f57203"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

