### PR TITLE
Issue #51: valid_elements operand for agg / agg.first

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -90,7 +90,7 @@ ldr_mult_reg r0 lr0 cr0; mult.ee r0 lr1 0 lr3; acc; add lr0 lr0 1; bne lr0 lr1 n
 | XMEM | `ldr`, `str_acc_reg`, `ldr_cyclic_mult_reg`, … | Memory load/store |
 | MULT | `mult.ee`, `mult.ve.cyclic`, `mult.ve.padded`, `mult.ve.cr`, `mult.ve.aaq`, … | 8-bit vector multiply |
 | ACC | `acc`, `acc.stride`, `acc.max`, `acc.max.first`, `reset_acc` | Accumulate into r_acc |
-| AAQ | `agg` (sum/max + post-fn) | Aggregate r_acc → aaq register |
+| AAQ | `agg` / `agg.first` (sum/max + post-fn + `valid_elements` mask), `aaq` | Aggregate r_acc → aaq register |
 | LR (×3) | `set`, `add`, `sub`, `incr_mod_pow2` | Scalar loop register ops |
 | COND | `beq`, `bne`, `blt`, `bnz`, `bz`, `b`, `br`, `bkpt` | Branches |
 | BREAK | `break`, `break.ifeq` | Debug breakpoints |

--- a/docs/content/specs/stage-aaq.md
+++ b/docs/content/specs/stage-aaq.md
@@ -157,6 +157,10 @@ Supported activation functions:
 
 ### 7.1 Aggregate (`agg`)
 
+**Assembly syntax:** `agg <agg_mode> <post_fn> <valid_elements> <cr_idx> <aaq_rf_idx>`
+
+- `valid_elements`: any `lr0`–`lr15` or `cr0`–`cr15` operand (5-bit `LcrIdx` encoding). The **value** read from that register at cycle start is the number of `r_acc` lanes fed into the adder/max tree (unsigned, clamped to 0–128). Lanes from index `valid_elements` through 127 are masked out.
+
 ```text
 // r_acc lanes are always FP32; only the first valid_elements lanes are used
 values = [activation(r_acc[i]) for i in 0..valid_elements-1]
@@ -216,6 +220,10 @@ flowchart TD
 | 4 | `sqrt` | `sqrt(x)` | 0 if x < 0 |
 
 #### 7.1.1 Aggregate First (`agg.first`)
+
+**Assembly syntax:** `agg.first <agg_mode> <post_fn> <valid_elements> <cr_idx> <aaq_rf_idx>`
+
+Same `valid_elements` masking rules as `agg`.
 
 Identical to `agg` except that `max` mode ignores the RF feedback value:
 

--- a/src/tools/ipu-as-py/src/ipu_as/inst.py
+++ b/src/tools/ipu-as-py/src/ipu_as/inst.py
@@ -433,6 +433,7 @@ class AaqInst(Inst):
         return [
             immediate.AggModeField,
             immediate.PostFnField,
+            reg.LcrRegField,
             reg.CrRegField,
             reg.AaqRegField,
         ]

--- a/src/tools/ipu-common/src/ipu_common/instruction_spec.py
+++ b/src/tools/ipu-common/src/ipu_common/instruction_spec.py
@@ -124,7 +124,7 @@ SLOT_BINARY_LAYOUT: dict[str, list[str]] = {
     "xmem": ["MultStageReg", "LrIdx", "LrIdx", "CrIdx"],
     "mult": ["MultStageReg", "LrIdx", "MultMaskOffsetImmediate", "LrIdx", "LrIdx", "CrIdx", "AaqRegIdx"],
     "acc": ["AaqRegIdx", "ElementsInRow", "HorizontalStride", "VerticalStride", "LrIdx"],
-    "aaq": ["AggMode", "PostFn", "CrIdx", "AaqRegIdx"],
+    "aaq": ["AggMode", "PostFn", "LcrIdx", "CrIdx", "AaqRegIdx"],
     "lr": ["LrIdx", "LrIdx", "LcrIdx", "AddSubSrcB", "Immediate", "LrModPow2KImmediate"],
     "cond": ["LcrIdx", "LcrIdx", "Label"],
     "break": ["LrIdx", "BreakImmediate"],
@@ -658,26 +658,37 @@ INSTRUCTION_SPEC = {
             "operands": [
                 {"name": "agg_mode", "type": "AggMode"},
                 {"name": "post_fn", "type": "PostFn"},
+                {
+                    "name": "valid_elements",
+                    "type": "LcrIdx",
+                    "read": "snapshot",
+                },
                 {"name": "cr_idx", "type": "CrIdx"},
                 {"name": "aaq_rf_idx", "type": "AaqRegIdx"},
             ],
             "doc": InstructionDoc(
                 title="Accumulator Aggregate",
-                summary="Collapse 128 r_acc words into one value (SUM or MAX), apply post function, store to selected AAQ register.",
-                syntax="agg agg_mode post_fn cr_idx aaq_rf_idx",
+                summary=(
+                    "Collapse r_acc lanes into one value (SUM or MAX), using only the first "
+                    "valid_elements words for the tree; apply post function; store to selected AAQ register."
+                ),
+                syntax="agg agg_mode post_fn valid_elements cr_idx aaq_rf_idx",
                 operands=[
                     "agg_mode: sum or max",
                     "post_fn: value, value_cr, inv, or inv_sqrt",
+                    "valid_elements: lane count from an LR or CR register (value read at cycle start; "
+                    "unsigned, clamped to 0–128; indices [valid_elements..127] are masked out)",
                     "cr_idx: CR register for value_cr post function (cr0-cr15)",
                     "aaq_rf_idx: AAQ register to store result (aaq0-aaq3)",
                 ],
                 operation=(
-                    "If sum: v = sum(r_acc[0..127]). "
-                    "If max: v = max(r_acc[0..127], aaq[aaq_rf_idx]). "
+                    "Let n = min(valid_elements, 128). "
+                    "If sum: v = sum(r_acc[0..n-1]). "
+                    "If max: v = max(r_acc[0..n-1], aaq[aaq_rf_idx]). "
                     "Apply post_fn(v): value→v, value_cr→v*cr[cr_idx], inv→1/v, inv_sqrt→1/sqrt(v). "
                     "aaq[aaq_rf_idx] = result."
                 ),
-                example="agg sum value cr0 aaq0;;",
+                example="agg sum value lr0 cr0 aaq0;;",
             ),
             "execute_fn": "execute_agg",
         },
@@ -685,26 +696,34 @@ INSTRUCTION_SPEC = {
             "operands": [
                 {"name": "agg_mode", "type": "AggMode"},
                 {"name": "post_fn", "type": "PostFn"},
+                {
+                    "name": "valid_elements",
+                    "type": "LcrIdx",
+                    "read": "snapshot",
+                },
                 {"name": "cr_idx", "type": "CrIdx"},
                 {"name": "aaq_rf_idx", "type": "AaqRegIdx"},
             ],
             "doc": InstructionDoc(
                 title="Accumulator Aggregate First",
                 summary="Like agg, but for MAX mode ignores the previous AAQ register value, avoiding contamination from uninitialized data.",
-                syntax="agg.first agg_mode post_fn cr_idx aaq_rf_idx",
+                syntax="agg.first agg_mode post_fn valid_elements cr_idx aaq_rf_idx",
                 operands=[
                     "agg_mode: sum or max",
                     "post_fn: value, value_cr, inv, or inv_sqrt",
+                    "valid_elements: lane count from an LR or CR register (value read at cycle start; "
+                    "unsigned, clamped to 0–128; indices [valid_elements..127] are masked out)",
                     "cr_idx: CR register for value_cr post function (cr0-cr15)",
                     "aaq_rf_idx: AAQ register to store result (aaq0-aaq3)",
                 ],
                 operation=(
-                    "If sum: v = sum(r_acc[0..127]). "
-                    "If max: v = max(r_acc[0..127]) (previous aaq value is NOT included). "
+                    "Let n = min(valid_elements, 128). "
+                    "If sum: v = sum(r_acc[0..n-1]). "
+                    "If max: v = max(r_acc[0..n-1]) (previous aaq value is NOT included). "
                     "Apply post_fn(v): value→v, value_cr→v*cr[cr_idx], inv→1/v, inv_sqrt→1/sqrt(v). "
                     "aaq[aaq_rf_idx] = result."
                 ),
-                example="agg.first max value cr0 aaq0;;",
+                example="agg.first max value lr0 cr0 aaq0;;",
             ),
             "execute_fn": "execute_agg_first",
         },

--- a/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
@@ -945,36 +945,72 @@ class Ipu:
         """Execute aaq_nop: No operation for AAQ slot."""
         pass
 
+    def _agg_active_lane_count(self, valid_elements: int) -> int:
+        """Number of r_acc words included in agg / agg.first (clamped)."""
+        n_words = R_ACC_SIZE // 4
+        v = int(valid_elements) & 0xFFFFFFFF
+        return min(v, n_words)
+
+    def _agg_reduce_raw(
+        self,
+        *,
+        agg_mode: int,
+        fmt: str,
+        acc_buf: bytearray,
+        valid_elements: int,
+        aaq_rf_idx: int,
+        include_aaq_in_max: bool,
+    ) -> float | int:
+        """Reduce r_acc[0:active) with SUM or MAX; optional AAQ feedback in MAX mode."""
+        active = self._agg_active_lane_count(valid_elements)
+        if get_agg_mode(agg_mode) == AGG_MODE_SUM:
+            total: float | int = 0 if fmt == "<i" else 0.0
+            for i in range(active):
+                total += struct.unpack_from(fmt, acc_buf, i * 4)[0]
+            return total
+        if include_aaq_in_max:
+            aaq_raw = self.state.regfile.get_aaq(aaq_rf_idx) & 0xFFFFFFFF
+            best = struct.unpack(fmt, struct.pack("<I", aaq_raw))[0]
+            for i in range(active):
+                v = struct.unpack_from(fmt, acc_buf, i * 4)[0]
+                if v > best:
+                    best = v
+            return best
+        if active == 0:
+            return -2147483648 if fmt == "<i" else float("-inf")
+        best = struct.unpack_from(fmt, acc_buf, 0)[0]
+        for i in range(1, active):
+            v = struct.unpack_from(fmt, acc_buf, i * 4)[0]
+            if v > best:
+                best = v
+        return best
+
     def execute_agg(
         self,
         *,
         agg_mode: int,
         post_fn: int,
+        valid_elements: int,
         cr_idx: int,
         aaq_rf_idx: int,
     ) -> None:
-        """Execute acc.agg: Collapse 128 r_acc words to one value (SUM or MAX), apply post function, store to AAQ.
+        """Execute acc.agg: Collapse r_acc words to one value (SUM or MAX), apply post function, store to AAQ.
 
         For MAX, the current value of the target AAQ register is included in the max (no update if already max).
+        Only the first ``valid_elements`` lanes (clamped to 128) participate in the tree.
         """
         dtype = self.state.get_cr_dtype()
         fmt = self._acc_agg_lane_fmt()
         acc_buf = self.state.regfile.raw("r_acc")
-        n_words = R_ACC_SIZE // 4  # 128
 
-        # Collect all 128 words as scalar values
-        values = []
-        for i in range(n_words):
-            val = struct.unpack_from(fmt, acc_buf, i * 4)[0]
-            values.append(val)
-
-        if get_agg_mode(agg_mode) == AGG_MODE_SUM:
-            raw_result = sum(values)
-        else:
-            # MAX: include current AAQ value in the comparison
-            aaq_raw = self.state.regfile.get_aaq(aaq_rf_idx) & 0xFFFFFFFF
-            current_aaq = struct.unpack(fmt, struct.pack("<I", aaq_raw))[0]
-            raw_result = max(values + [current_aaq])
+        raw_result = self._agg_reduce_raw(
+            agg_mode=agg_mode,
+            fmt=fmt,
+            acc_buf=acc_buf,
+            valid_elements=valid_elements,
+            aaq_rf_idx=aaq_rf_idx,
+            include_aaq_in_max=True,
+        )
 
         # Apply post function
         fn = get_post_fn(post_fn)
@@ -1029,6 +1065,7 @@ class Ipu:
         *,
         agg_mode: int,
         post_fn: int,
+        valid_elements: int,
         cr_idx: int,
         aaq_rf_idx: int,
     ) -> None:
@@ -1036,18 +1073,15 @@ class Ipu:
         dtype = self.state.get_cr_dtype()
         fmt = self._acc_agg_lane_fmt()
         acc_buf = self.state.regfile.raw("r_acc")
-        n_words = R_ACC_SIZE // 4  # 128
 
-        values = []
-        for i in range(n_words):
-            val = struct.unpack_from(fmt, acc_buf, i * 4)[0]
-            values.append(val)
-
-        if get_agg_mode(agg_mode) == AGG_MODE_SUM:
-            raw_result = sum(values)
-        else:
-            # MAX: do NOT include previous AAQ value — this is the .first behaviour
-            raw_result = max(values)
+        raw_result = self._agg_reduce_raw(
+            agg_mode=agg_mode,
+            fmt=fmt,
+            acc_buf=acc_buf,
+            valid_elements=valid_elements,
+            aaq_rf_idx=aaq_rf_idx,
+            include_aaq_in_max=False,
+        )
 
         fn = get_post_fn(post_fn)
         if fn == POST_FN_VALUE:

--- a/src/tools/ipu-emu-py/test/test_execute.py
+++ b/src/tools/ipu-emu-py/test/test_execute.py
@@ -905,11 +905,12 @@ bkpt;;
 
         state = _make_state(
             """\
-agg sum value cr0 aaq0;;
+agg sum value lr1 cr0 aaq0;;
 bkpt;;
 """
         )
         state.regfile.set_cr(15, DType.INT8)
+        state.regfile.set_lr(1, 128)
         # r_acc: set each word to 1, so sum = 128
         for i in range(128):
             state.regfile.set_r_acc_word(i, struct.unpack("<I", struct.pack("<i", 1))[0])
@@ -925,11 +926,12 @@ bkpt;;
 
         state = _make_state(
             """\
-agg max value cr0 aaq1;;
+agg max value lr1 cr0 aaq1;;
 bkpt;;
 """
         )
         state.regfile.set_cr(15, DType.INT8)
+        state.regfile.set_lr(1, 128)
         for i in range(128):
             state.regfile.set_r_acc_word(i, struct.unpack("<I", struct.pack("<i", 10 + (i % 5)))[0])
         state.regfile.set_aaq(1, struct.unpack("<I", struct.pack("<i", 20))[0])  # 20 > 14
@@ -944,11 +946,12 @@ bkpt;;
 
         state = _make_state(
             """\
-agg max value cr0 aaq0;;
+agg max value lr1 cr0 aaq0;;
 bkpt;;
 """
         )
         state.regfile.set_cr(15, DType.INT8)
+        state.regfile.set_lr(1, 128)
         for i in range(128):
             state.regfile.set_r_acc_word(i, struct.unpack("<I", struct.pack("<i", 5))[0])
         state.regfile.set_r_acc_word(10, struct.unpack("<I", struct.pack("<i", 100))[0])
@@ -963,11 +966,12 @@ bkpt;;
 
         state = _make_state(
             """\
-agg sum value_cr cr1 aaq2;;
+agg sum value_cr lr1 cr1 aaq2;;
 bkpt;;
 """
         )
         state.regfile.set_cr(15, DType.INT8)
+        state.regfile.set_lr(1, 128)
         for i in range(128):
             state.regfile.set_r_acc_word(i, struct.unpack("<I", struct.pack("<i", 1))[0])
         state.regfile.set_cr(1, struct.unpack("<I", struct.pack("<i", 3))[0])
@@ -983,11 +987,12 @@ bkpt;;
 
         state = _make_state(
             """\
-agg.first max value cr0 aaq0;;
+agg.first max value lr1 cr0 aaq0;;
 bkpt;;
 """
         )
         state.regfile.set_cr(15, DType.INT8)
+        state.regfile.set_lr(1, 128)
         for i in range(128):
             state.regfile.set_r_acc_word(i, struct.unpack("<I", struct.pack("<i", 10 + (i % 5)))[0])
         # Set aaq0 to a large "garbage" value that would win against r_acc if included
@@ -1003,11 +1008,12 @@ bkpt;;
 
         state = _make_state(
             """\
-agg.first max value cr0 aaq1;;
+agg.first max value lr1 cr0 aaq1;;
 bkpt;;
 """
         )
         state.regfile.set_cr(15, DType.INT8)
+        state.regfile.set_lr(1, 128)
         for i in range(128):
             state.regfile.set_r_acc_word(i, struct.unpack("<I", struct.pack("<i", 5))[0])
         state.regfile.set_r_acc_word(63, struct.unpack("<I", struct.pack("<i", 77))[0])
@@ -1022,11 +1028,12 @@ bkpt;;
 
         state = _make_state(
             """\
-agg.first sum value cr0 aaq2;;
+agg.first sum value lr1 cr0 aaq2;;
 bkpt;;
 """
         )
         state.regfile.set_cr(15, DType.INT8)
+        state.regfile.set_lr(1, 128)
         for i in range(128):
             state.regfile.set_r_acc_word(i, struct.unpack("<I", struct.pack("<i", 2))[0])
         state.regfile.set_aaq(2, struct.unpack("<I", struct.pack("<i", 9999))[0])
@@ -1034,6 +1041,82 @@ bkpt;;
         run_until_complete(state)
         # Sum of 128 twos = 256; previous aaq value irrelevant
         assert state.regfile.get_aaq(2) == struct.unpack("<I", struct.pack("<i", 256))[0]
+
+    def test_agg_sum_masks_inactive_lanes(self):
+        """agg sum: only first valid_elements r_acc words contribute (tail masked out)."""
+        import struct
+
+        state = _make_state(
+            """\
+agg sum value lr1 cr0 aaq0;;
+bkpt;;
+"""
+        )
+        state.regfile.set_cr(15, DType.INT8)
+        state.regfile.set_lr(1, 3)
+        for i in range(128):
+            v = 10 if i < 3 else 1000
+            state.regfile.set_r_acc_word(i, struct.unpack("<I", struct.pack("<i", v))[0])
+        state.regfile.set_aaq(0, 0)
+        run_until_complete(state)
+        assert state.regfile.get_aaq(0) == struct.unpack("<I", struct.pack("<i", 30))[0]
+
+    def test_agg_sum_valid_elements_from_cr(self):
+        """agg sum: valid_elements may be read from a CR register (LcrIdx encoding)."""
+        import struct
+
+        state = _make_state(
+            """\
+agg sum value cr2 cr0 aaq0;;
+bkpt;;
+"""
+        )
+        state.regfile.set_cr(15, DType.INT8)
+        state.regfile.set_cr(2, 100)
+        for i in range(128):
+            v = 1 if i < 100 else 500
+            state.regfile.set_r_acc_word(i, struct.unpack("<I", struct.pack("<i", v))[0])
+        state.regfile.set_aaq(0, 0)
+        run_until_complete(state)
+        assert state.regfile.get_aaq(0) == struct.unpack("<I", struct.pack("<i", 100))[0]
+
+    def test_agg_max_masks_tail_large_values(self):
+        """agg max: masked-out lanes cannot beat AAQ; feedback still applies over active set."""
+        import struct
+
+        state = _make_state(
+            """\
+agg max value lr1 cr0 aaq0;;
+bkpt;;
+"""
+        )
+        state.regfile.set_cr(15, DType.INT8)
+        state.regfile.set_lr(1, 100)
+        for i in range(128):
+            v = 5 if i < 100 else 9999
+            state.regfile.set_r_acc_word(i, struct.unpack("<I", struct.pack("<i", v))[0])
+        state.regfile.set_aaq(0, struct.unpack("<I", struct.pack("<i", 50))[0])
+        run_until_complete(state)
+        assert state.regfile.get_aaq(0) == struct.unpack("<I", struct.pack("<i", 50))[0]
+
+    def test_agg_first_max_masks_tail(self):
+        """agg.first max: only active prefix participates; tail spikes ignored."""
+        import struct
+
+        state = _make_state(
+            """\
+agg.first max value lr1 cr0 aaq0;;
+bkpt;;
+"""
+        )
+        state.regfile.set_cr(15, DType.INT8)
+        state.regfile.set_lr(1, 50)
+        for i in range(128):
+            v = 3 if i < 50 else 200
+            state.regfile.set_r_acc_word(i, struct.unpack("<I", struct.pack("<i", v))[0])
+        state.regfile.set_aaq(0, struct.unpack("<I", struct.pack("<i", 0))[0])
+        run_until_complete(state)
+        assert state.regfile.get_aaq(0) == struct.unpack("<I", struct.pack("<i", 3))[0]
 
 
 # ============================================================================

--- a/src/tools/ipu-emu-py/test/test_wide_vector_debug.py
+++ b/src/tools/ipu-emu-py/test/test_wide_vector_debug.py
@@ -319,8 +319,9 @@ class TestWideVectorAggInt32:
         st = IpuState(wide_vector_debug=True, wide_vector_arithmetic=WideVectorArithmetic.INT32)
         st.regfile.set_cr(15, DType.INT8)
         st.regfile.set_r_acc_bytes(acc)
+        st.regfile.set_lr(1, 128)
         asm = """\
-agg sum inv cr0 aaq0;;
+agg sum inv lr1 cr0 aaq0;;
 bkpt;;
 """
         encoded = assemble(asm)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This implements [issue #51](https://github.com/rechefe/ipu-emulator/issues/51): the accumulator aggregate instructions now take a **valid_elements** operand so SUM/MAX only include the first *n* `r_acc` words (hardware-style masking).

### Changes
- **ISA / assembler:** `SLOT_BINARY_LAYOUT["aaq"]` gains `LcrIdx` between `PostFn` and `CrIdx`. Syntax is `agg <agg_mode> <post_fn> <valid_elements> <cr_idx> <aaq_rf_idx>` (and the same for `agg.first`). The operand is any `lr0`–`lr15` or `cr0`–`cr15` token; the **value** is read at cycle start (`read: snapshot`) and interpreted as an unsigned 32-bit count, clamped to 0–128.
- **Emulator:** Shared `_agg_reduce_raw` / `_agg_active_lane_count` reduce only `r_acc[0:n)`. MAX with RF feedback still compares against the target AAQ when using `agg`; `agg.first` MAX uses the same prefix masking without AAQ in the tree (empty prefix uses a type-appropriate minimum sentinel).
- **Tests:** Existing agg tests preset `lr1` to 128 so behavior matches the old full-vector case. New tests cover partial sums, CR-sourced counts, and masked MAX.
- **Docs:** `docs/content/specs/stage-aaq.md` documents assembly syntax; `SKILL.md` AAQ row updated.

### Verification
`bazel` was not available in this environment; tests were run with `pytest` and `PYTHONPATH` set to `ipu-emu-py`, `ipu-as-py`, and `ipu-common` source roots (`test_execute`, `test_wide_vector_debug`, `test_assemble` all passed).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bbe7c64d-6554-4b2e-bca9-391d5f40b54b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bbe7c64d-6554-4b2e-bca9-391d5f40b54b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

