### PR TITLE
Standardize upper-case instruction mnemonics and lower-case operand names

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ Use `bazel`, not `pip install` or `python` directly.
 - **Never duplicate instruction metadata.** `instruction_spec.py` is the single source of truth for both the assembler and emulator.
 - **Operand names in `execute_*` handlers must exactly match** the `"name"` fields in `instruction_spec.py`.
 - **`cr15` is reserved** — never use it for application data.
+- **Docs and written examples:** instruction mnemonics are **upper case**; operand and register field tokens are **lower case** (the assembler still accepts any case for mnemonics).
 
 ## Adding an Instruction (quick checklist)
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -52,6 +52,11 @@ Do not hardcode opcodes anywhere. Do not duplicate instruction metadata.
 
 Same principle applies to **`registers.py`** for register definitions.
 
+### Naming in prose, docs, and examples
+
+- **Instruction mnemonics** are written in **upper case** everywhere in this repository (Markdown, comments, `InstructionDoc.syntax` / examples, and the keys in `INSTRUCTION_SPEC`). The assembler still accepts upper or lower case in source files.
+- **Operand and field names** (`dest`, `src_a`, register tokens like `lr0` / `r0`) are written in **lower case**.
+
 ---
 
 ## ISA Concepts
@@ -61,7 +66,7 @@ Same principle applies to **`registers.py`** for register definitions.
 Every cycle executes one **compound instruction** — multiple independent slots in parallel:
 
 ```asm
-ldr_mult_reg r0 lr0 cr0; mult.ee r0 lr1 0 lr3; acc; add lr0 lr0 1; bne lr0 lr1 next;;
+LDR_MULT_REG r0 lr0 cr0; MULT.EE r0 lr1 0 lr3; ACC; ADD lr0 lr0 1; BNE lr0 lr1 next;;
 ```
 
 - Slots: `break`, `xmem`, `mult`, `acc`, `aaq`, `lr` (×3), `cond`
@@ -87,13 +92,13 @@ ldr_mult_reg r0 lr0 cr0; mult.ee r0 lr1 0 lr3; acc; add lr0 lr0 1; bne lr0 lr1 n
 
 | Slot | Instructions | Purpose |
 |------|-------------|---------|
-| XMEM | `ldr`, `str_acc_reg`, `ldr_cyclic_mult_reg`, … | Memory load/store |
-| MULT | `mult.ee`, `mult.ve.cyclic`, `mult.ve.padded`, `mult.ve.cr`, `mult.ve.aaq`, … | 8-bit vector multiply |
-| ACC | `acc`, `acc.stride`, `acc.max`, `acc.max.first`, `reset_acc` | Accumulate into r_acc |
-| AAQ | `agg` / `agg.first` (sum/max + post-fn + `valid_elements` mask), `aaq` | Aggregate r_acc → aaq register |
-| LR (×3) | `set`, `add`, `sub`, `incr_mod_pow2` | Scalar loop register ops |
-| COND | `beq`, `bne`, `blt`, `bnz`, `bz`, `b`, `br`, `bkpt` | Branches |
-| BREAK | `break`, `break.ifeq` | Debug breakpoints |
+| XMEM | `LDR_MULT_REG`, `STR_ACC_REG`, `LDR_CYCLIC_MULT_REG`, … | Memory load/store |
+| MULT | `MULT.EE`, `MULT.VE.CYCLIC`, `MULT.VE.PADDED`, `MULT.VE.CR`, `MULT.VE.AAQ`, … | 8-bit vector multiply |
+| ACC | `ACC`, `ACC.STRIDE`, `ACC.MAX`, `ACC.MAX.FIRST`, `RESET_ACC` | Accumulate into r_acc |
+| AAQ | `AGG` / `AGG.FIRST` (sum/max + post-fn + `valid_elements` mask), `AAQ` | Aggregate r_acc → aaq register |
+| LR (×3) | `SET`, `ADD`, `SUB`, `INCR_MOD_POW2` | Scalar loop register ops |
+| COND | `BEQ`, `BNE`, `BLT`, `BNZ`, `BZ`, `B`, `BR`, `BKPT` | Branches |
+| BREAK | `BREAK`, `BREAK.IFEQ` | Debug breakpoints |
 
 ### Operand Types (defined in instruction_spec)
 
@@ -105,7 +110,7 @@ ldr_mult_reg r0 lr0 cr0; mult.ee r0 lr1 0 lr3; acc; add lr0 lr0 1; bne lr0 lr1 n
 
 1. **Define it in `instruction_spec.py`:**
    ```python
-   "my_inst": {
+   "MY_INST": {
        "operands": [
            {"name": "dest", "type": "AaqRegIdx"},
            {"name": "src",  "type": "MultStageReg", "read": "snapshot"},
@@ -143,7 +148,7 @@ def _run(asm_code: str) -> IpuState:
     return state
 
 def test_my_instruction():
-    state = _run("my_inst aaq0 r0;;")
+    state = _run("MY_INST aaq0 r0;;")
     assert state.regfile.get_aaq(0) == expected
 ```
 
@@ -193,7 +198,7 @@ Each app lives under `ipu-apps/src/ipu_apps/<name>/` and has:
 
 ## Debugging
 
-Add `break;;` to assembly, then run with the debug callback:
+Add `BREAK;;` to assembly, then run with the debug callback:
 
 ```python
 from ipu_emu.debug_cli import debug_prompt

--- a/docs/content/adding-instruction.md
+++ b/docs/content/adding-instruction.md
@@ -8,9 +8,11 @@ The IPU uses a **single source of truth** for all instruction definitions: `INST
 
 Adding an instruction is a 3-step process:
 
-1. **Add to instruction_spec** — define the instruction with operands and documentation
+1. **Add to instruction_spec** — define the instruction with operands and documentation (instruction **mnemonic keys** are **upper case**; each operand’s `"name"` is **lower case**)
 2. **Implement execution handler** — write the Python method in the emulator's `Ipu` class  
 3. **Add tests** — verify the instruction works correctly
+
+The assembler accepts mnemonics in any case; written examples and the spec use upper case by convention.
 
 No manual opcode management needed — opcodes are automatically derived from instruction position.
 
@@ -20,14 +22,14 @@ When you add a **new operand type** string to `INSTRUCTION_SPEC`, also add it to
 
 Open `src/tools/ipu-common/src/ipu_common/instruction_spec.py` and find the `INSTRUCTION_SPEC` dictionary. Locate the slot type where your instruction belongs (e.g., `"mult"`, `"acc"`, `"xmem"`, `"lr"`, `"cond"`, `"break"`).
 
-Add your instruction to the slot's dictionary:
+Add your instruction to the slot's dictionary (**instruction keys are upper-case mnemonics**, e.g. `MULT.EE`, `STR_ACC_REG`; operand `"name"` fields stay **lower case**):
 
 ```python
 INSTRUCTION_SPEC = {
     "mult": {
         # ... existing mult instructions ...
-        
-        "my_new_instruction": {
+
+        "MY_NEW_INSTRUCTION": {
             "operands": [
                 {"name": "dest", "type": "MultStageReg"},
                 {"name": "src_a", "type": "MultStageReg", "read": "snapshot"},
@@ -36,17 +38,17 @@ INSTRUCTION_SPEC = {
             "doc": InstructionDoc(
                 title="My New Operation",
                 summary="Performs a custom operation on two source registers.",
-                syntax="my_new_instruction Rd Ra Rb",
+                syntax="MY_NEW_INSTRUCTION dest src_a src_b",
                 operands=[
-                    "Rd: Destination mult stage register (r0 or r1)",
-                    "Ra: First source mult stage register",
-                    "Rb: Second source mult stage register",
+                    "dest: Destination mult-stage register (r0 or r1)",
+                    "src_a: First source mult-stage register",
+                    "src_b: Second source mult-stage register",
                 ],
                 operation=(
                     "for i in [0, R_REG_SIZE):\n"
-                    "    Rd[i] = custom_operation(Ra[i], Rb[i])"
+                    "    dest[i] = custom_operation(src_a[i], src_b[i])"
                 ),
-                example="my_new_instruction r0 r1 r0;;",
+                example="MY_NEW_INSTRUCTION r0 r1 r0;;",
             ),
             "execute_fn": "execute_my_new_instruction",
         },
@@ -104,8 +106,8 @@ class Ipu:
     
     def execute_my_new_instruction(self, *, dest: int, src_a: bytearray,
                                     src_b: bytearray) -> None:
-        """Execute my_new_instruction: performs custom operation.
-        
+        """Execute MY_NEW_INSTRUCTION: performs custom operation.
+
         Args:
             dest: Destination register index (raw MultStageRegField value)
             src_a: Source A register bytes (auto-resolved from snapshot)
@@ -184,7 +186,7 @@ from ipu_emu.ipu_state import IpuState
 from ipu_emu.ipu import Ipu
 
 def test_my_new_instruction():
-    """Test my_new_instruction performs custom operation correctly."""
+    """Test MY_NEW_INSTRUCTION performs custom operation correctly."""
     state = IpuState()
     ipu = Ipu(state)
     
@@ -224,7 +226,7 @@ After adding your instruction, verify it works in both assembler and emulator:
 
 ```bash
 # Verify assembler accepts the instruction
-echo "my_new_instruction r0 r1 r0;;" | bazel run //src/tools/ipu-as-py:ipu-as -- assemble --format hex -
+echo "MY_NEW_INSTRUCTION r0 r1 r0;;" | bazel run //src/tools/ipu-as-py:ipu-as -- assemble --format hex -
 
 # Run all tests
 bazel test //...

--- a/docs/content/building-applications.md
+++ b/docs/content/building-applications.md
@@ -283,41 +283,42 @@ This section walks through a complete real-world implementation: a fully-connect
 
 ### Assembly Program
 
-The IPU assembly implements the core computation: activations for the current sample live in **`R0`** (loaded once per sample). Each inner-loop iteration loads a 128-byte **weight row** into the cyclic register (**`RC`**) and issues **`MULT.VE.CYCLIC`**, which multiplies that row by the scalar **`R0[LR5]`** (loop counter advanced via **`add`**), then accumulates. The harness initializes **`cr3`**, **`cr4`**, and **`cr5`** with stride constants **128**, **1**, and **256** so the program can add large steps without the removed **`incr`** mnemonic.
+The IPU assembly implements the core computation: activations for the current sample live in **`r0`** (loaded once per sample). Each inner-loop iteration loads a 128-byte **weight row** into the cyclic register (**`r_cyclic`**) and issues **`MULT.VE.CYCLIC`**, which multiplies that row by the scalar **`r0[lr5]`** (loop counter advanced via **`ADD`**), then accumulates. The harness initializes **`cr3`**, **`cr4`**, and **`cr5`** with stride constants **128**, **1**, and **256** so the program can add large steps without the removed **`incr`** mnemonic.
 
 ```asm
-set                 lr0 0 ;;
-set                 lr1 1280 ;;
-set                 lr2 0 ;;
+    SET                 lr0 0 ;;
+    SET                 lr1 1280 ;;
+    SET                 lr2 0 ;;
 
 input_loop:
-    reset_acc;;
+    RESET_ACC;;
 
-    ldr_mult_reg        r0 lr0 cr0;;
+    LDR_MULT_REG        r0 lr0 cr0;;
 
-    set                 lr4 -128;;
-    set                 lr5 -1;;
-    set                 lr6 127;;
-    set                 lr15 0;;
+    SET                 lr4 -128;;
+    SET                 lr5 -1;;
+    SET                 lr6 127;;
+    SET                 lr15 0;;
+
 
 element_loop:
-    ldr_cyclic_mult_reg lr4 cr1 lr15;
-    add                 lr4 lr4 cr3;
-    add                 lr5 lr5 cr4;
-    mult.ve.cyclic      lr15 0 lr15 lr5;
-    acc;
-    blt                 lr5 lr6 element_loop;;
+    LDR_CYCLIC_MULT_REG lr4 cr1 lr15;
+    ADD                 lr4 lr4 cr3;
+    ADD                 lr5 lr5 cr4;
+    MULT.VE.CYCLIC      lr15 0 lr15 lr5;
+    ACC;
+    BLT                 lr5 lr6 element_loop;;
 
-    str_acc_reg         lr7 cr2;;
-    add                 lr7 lr7 cr5;
-    add                 lr0 lr0 cr3;;
+    STR_ACC_REG         lr7 cr2;;
+    ADD                 lr7 lr7 cr5;
+    ADD                 lr0 lr0 cr3;;
 
-    break;;
+    BREAK;;
 
-    blt                 lr0 lr1 input_loop;;
+    BLT                 lr0 lr1 input_loop;;
 
 end:
-    bkpt;;
+    BKPT;;
 ```
 
 ### Python Application Class

--- a/docs/content/debugging.md
+++ b/docs/content/debugging.md
@@ -6,13 +6,13 @@ The IPU emulator includes a powerful interactive debugger that allows you to pau
 
 ### 1. Add Break Instructions to Your Assembly
 
-Add `break` instructions where you want execution to pause:
+Add `BREAK` instructions where you want execution to pause:
 
 ```asm
 main_loop:
-    break ;;              # Unconditional break
-    reset_acc;;
-    ldr_cyclic_mult_reg lr0 cr0 lr15;;
+    BREAK ;;              # Unconditional break
+    RESET_ACC;;
+    LDR_CYCLIC_MULT_REG lr0 cr0 lr15;;
 ```
 
 ### 2. Enable Debug Mode
@@ -230,7 +230,7 @@ IPU Debug - Break at PC=3
   ...
 
 === Current Instruction ===
-  break lr0 0; reset_acc; mult_nop; acc_nop; b lr0 lr0 @4;;
+  BREAK.IFEQ lr0 0; RESET_ACC; MULT_NOP; ACC_NOP; B lr0 lr0 @4;;
 
 debug >>> get lr1
 lr1 = 1280 (0x500)

--- a/docs/content/specs/stage-aaq.md
+++ b/docs/content/specs/stage-aaq.md
@@ -261,16 +261,16 @@ Notes:
 - The Quantization block appends 12 bits of metadata to the 1024-bit data
   payload to form the full 1036-bit `aaq_result`: bits [11:4] = 8-bit scale
   factor, bits [3:0] = 4-bit representation type (INT8, e6m1, e5m2, …).
-- `aaq_result` must be flushed to XMEM with `xmem.store_aaq_result offset base`
-  before the next `aaq` overwrites it.
-- In wide-vector debug mode `aaq` is a no-op unless
+- `aaq_result` must be flushed to XMEM with `XMEM.STORE_AAQ_RESULT offset base`
+  before the next `AAQ` overwrites it.
+- In wide-vector debug mode `AAQ` is a no-op unless
   `wide_vector_quantize_output` is explicitly set (debug feature only).
 
-**ISA Interactions** — instructions in other slots that consume `aaq_result` written by `aaq`:
+**ISA Interactions** — instructions in other slots that consume `aaq_result` written by `AAQ`:
 
 | Instruction | Slot | Operation |
 |-------------|------|-----------|
-| `xmem.store_aaq_result offset base` | XMEM | Writes the 128-byte `aaq_result` register to XMEM at address `offset + base`. Must be issued before the next `aaq` to avoid overwrite. |
+| `XMEM.STORE_AAQ_RESULT offset base` | XMEM | Writes the 128-byte `aaq_result` register to XMEM at address `offset + base`. Must be issued before the next `AAQ` to avoid overwrite. |
 
 ## 8. ISA 
 

--- a/docs/content/wide-vector-debug-mode.md
+++ b/docs/content/wide-vector-debug-mode.md
@@ -19,7 +19,7 @@ Construct [`IpuState`](https://github.com/rechefe/ipu-emulator/blob/master/src/t
 |-----------|---------|---------|
 | `wide_vector_debug` | `False` | Turn wide-vector mode on. |
 | `wide_vector_arithmetic` | `WideVectorArithmetic.FP32` | `FP32` or `INT32` lane arithmetic. |
-| `wide_vector_quantize_output` | `False` | If `True`, the `aaq` instruction writes `aaq_result` from wide lanes for comparison with the real quantized path. If `False`, `aaq` does nothing in wide mode (results stay in `r_acc`). |
+| `wide_vector_quantize_output` | `False` | If `True`, the `AAQ` instruction writes `aaq_result` from wide lanes for comparison with the real quantized path. If `False`, `AAQ` does nothing in wide mode (results stay in `r_acc`). |
 
 ```python
 from ipu_emu.ipu_state import IpuState, WideVectorArithmetic
@@ -48,8 +48,8 @@ The high-level helper [`run_test`](https://github.com/rechefe/ipu-emulator/blob/
 
 While **addresses are still byte addresses**, wide mode changes how much data some loads consume per instruction:
 
-- **`ldr_mult_reg`** reads **512 bytes** from XMEM (128×FP32 or 128×INT32, depending on `wide_vector_arithmetic`) into internal staging for **`r0` or `r1` only**. The architectural 128-byte `r` register bytes in the regfile are not the source for mult operands in this mode.
-- **`ldr_cyclic_mult_reg`** reads **512 bytes** into `r_cyclic` at the given **`index`**, which must be **aligned to 512** (same rule as 128-byte alignment in normal mode, scaled to the wide chunk).
+- **`LDR_MULT_REG`** reads **512 bytes** from XMEM (128×FP32 or 128×INT32, depending on `wide_vector_arithmetic`) into internal staging for **`r0` or `r1` only**. The architectural 128-byte `r` register bytes in the regfile are not the source for mult operands in this mode.
+- **`LDR_CYCLIC_MULT_REG`** reads **512 bytes** into `r_cyclic` at the given **`index`**, which must be **aligned to 512** (same rule as 128-byte alignment in normal mode, scaled to the wide chunk).
 
 Prepare XMEM accordingly (e.g. raw `float32` or `int32` little-endian blobs).
 
@@ -62,14 +62,14 @@ Wide mode unpacks `r_cyclic` as 128 consecutive 32-bit lanes starting at a **byt
 ## Semantics that differ from normal mode
 
 - **Multiply masks** (`mask_offset` immediate slot 0–7 / `mask_shift` LR): mask-and-shift on `mult_res` is **disabled** in wide mode, because the 128-bit mask layout does not map to 128 FP32/INT32 lanes.
-- **`aaq`**: unless `wide_vector_quantize_output=True`, **`aaq` is a no-op** in wide mode; full lane results remain in **`r_acc`**. Use the existing debug-only **`str_acc_reg`** instruction (or read `r_acc` in Python) to dump 512 bytes of accumulator data.
-- **LR and CR** are **not** widened; scalars such as `mult.ve.cr` still use the **low byte** of a CR as a signed value in the wide path.
+- **`AAQ`**: unless `wide_vector_quantize_output=True`, **`AAQ` is a no-op** in wide mode; full lane results remain in **`r_acc`**. Use the existing debug-only **`STR_ACC_REG`** instruction (or read `r_acc` in Python) to dump 512 bytes of accumulator data.
+- **LR and CR** are **not** widened; scalars such as **`MULT.VE.CR`** still use the **low byte** of a CR as a signed value in the wide path.
 
 ## INT32 vs FP32
 
 - **`WideVectorArithmetic.FP32`**: lane multiply and accumulate-add use IEEE float; good for spotting FP8/INT8 quantization effects.
-- **`WideVectorArithmetic.INT32`**: lane multiply uses 32-bit signed wrap; add matches INT8-mode wrap semantics per lane. `agg` post-functions that need integer results use integer-friendly paths when the lane format is INT32.
+- **`WideVectorArithmetic.INT32`**: lane multiply uses 32-bit signed wrap; add matches INT8-mode wrap semantics per lane. **`AGG`** post-functions that need integer results use integer-friendly paths when the lane format is INT32.
 
 ## Related documentation
 
-- [Debugging IPU Programs](debugging.md) — interactive `break` / `debug_prompt` workflow (orthogonal to wide-vector mode; you can combine them by passing a state created with `wide_vector_debug=True` into `run_with_debug`).
+- [Debugging IPU Programs](debugging.md) — interactive **`BREAK`** / `debug_prompt` workflow (orthogonal to wide-vector mode; you can combine them by passing a state created with `wide_vector_debug=True` into `run_with_debug`).

--- a/src/tools/ipu-apps/src/ipu_apps/fully_connected/fully_connected.asm
+++ b/src/tools/ipu-apps/src/ipu_apps/fully_connected/fully_connected.asm
@@ -1,33 +1,33 @@
-    set                 lr0 0 ;;
-    set                 lr1 1280 ;;
-    set                 lr2 0 ;;
+    SET                 lr0 0 ;;
+    SET                 lr1 1280 ;;
+    SET                 lr2 0 ;;
 
 input_loop:
-    reset_acc;;
+    RESET_ACC;;
 
-    ldr_mult_reg        r0 lr0 cr0;;
+    LDR_MULT_REG        r0 lr0 cr0;;
 
-    set                 lr4 -128;;
-    set                 lr5 -1;;
-    set                 lr6 127;;
-    set                 lr15 0;;
+    SET                 lr4 -128;;
+    SET                 lr5 -1;;
+    SET                 lr6 127;;
+    SET                 lr15 0;;
 
 
 element_loop:
-    ldr_cyclic_mult_reg lr4 cr1 lr15;
-    add                 lr4 lr4 cr3;
-    add                 lr5 lr5 cr4;
-    mult.ve.cyclic      lr15 0 lr15 lr5;
-    acc;
-    blt                 lr5 lr6 element_loop;;
+    LDR_CYCLIC_MULT_REG lr4 cr1 lr15;
+    ADD                 lr4 lr4 cr3;
+    ADD                 lr5 lr5 cr4;
+    MULT.VE.CYCLIC      lr15 0 lr15 lr5;
+    ACC;
+    BLT                 lr5 lr6 element_loop;;
 
-    str_acc_reg         lr7 cr2;;
-    add                 lr7 lr7 cr5;
-    add                 lr0 lr0 cr3;;
+    STR_ACC_REG         lr7 cr2;;
+    ADD                 lr7 lr7 cr5;
+    ADD                 lr0 lr0 cr3;;
 
-    break;;
+    BREAK;;
 
-    blt                 lr0 lr1 input_loop;;
+    BLT                 lr0 lr1 input_loop;;
 
 end:
-    bkpt;;
+    BKPT;;

--- a/src/tools/ipu-as-py/src/ipu_as/gen_docs.py
+++ b/src/tools/ipu-as-py/src/ipu_as/gen_docs.py
@@ -14,7 +14,7 @@ OPERAND_TYPE_DETAILS: dict[str, str] = {
     "MultStageReg": (
         "Multiply-stage field in the VLIW encoding. Assembly accepts **`r0`** and **`r1`** only; "
         "the field is **two bits** wide (encoding `2` is reserved). Used as the destination of "
-        "`ldr_mult_reg` and as the `ra` operand of `mult.ee`."
+        "`LDR_MULT_REG` and as the **`ra`** operand of `MULT.EE`."
     ),
     "LrIdx": (
         "Loop register index: resolves to **`lr0`** … **`lr15`**. Often used for addresses, strides, "
@@ -30,7 +30,7 @@ OPERAND_TYPE_DETAILS: dict[str, str] = {
         "`**cr0`–`cr15`** in the usual combined ordering used by the assembler."
     ),
     "AddSubSrcB": (
-        "Second source for **`add`** / **`sub`** in the LR slot: **`lr0`–`lr15`**, **`cr0`–`cr15`**, "
+        "Second source for **`ADD`** / **`SUB`** in the LR slot: **`lr0`–`lr15`**, **`cr0`–`cr15`**, "
         "or an **unsigned 5-bit immediate** (`0`–`31`). Encoded in **6 bits**: **`0`–`31`** use the "
         "same ordering as **`LcrIdx`**; **`32`–`63`** encode immediates as **`32 + imm`**."
     ),
@@ -40,15 +40,15 @@ OPERAND_TYPE_DETAILS: dict[str, str] = {
         "`ipu_common`)."
     ),
     "HorizontalStride": (
-        "ACC-slot immediate: **horizontal stride** bit pattern for `acc.stride` (see "
+        "ACC-slot immediate: **horizontal stride** bit pattern for `ACC.STRIDE` (see "
         "`acc_stride_enums`)."
     ),
     "VerticalStride": (
-        "ACC-slot immediate: **vertical stride** bit pattern for `acc.stride` (see "
+        "ACC-slot immediate: **vertical stride** bit pattern for `ACC.STRIDE` (see "
         "`acc_stride_enums`)."
     ),
     "AggMode": (
-        "AAQ-slot immediate: aggregation mode for the `aaq` instruction (sum / max family); see "
+        "AAQ-slot immediate: aggregation mode for the `AGG` / `AGG.FIRST` instructions (sum / max family); see "
         "`acc_agg_enums`."
     ),
     "PostFn": (
@@ -57,10 +57,10 @@ OPERAND_TYPE_DETAILS: dict[str, str] = {
     ),
     "Immediate": (
         "Signed **16-bit** immediate carried in the LR slot (sign-extended by the emulator for "
-        "`set`)."
+        "`SET`)."
     ),
     "LrModPow2KImmediate": (
-        "Four-bit immediate for **`incr_mod_pow2`**: encodes exponent **k** with semantic "
+        "Four-bit immediate for **`INCR_MOD_POW2`**: encodes exponent **k** with semantic "
         "**k ∈ [1, 9]** as **(k − 1)** in the word."
     ),
     "MultMaskOffsetImmediate": (
@@ -68,7 +68,7 @@ OPERAND_TYPE_DETAILS: dict[str, str] = {
         "**`0`**–**`7`**, each a **128-bit** region of **`r_mask`** (eight mask slots total). "
         "**`mask_shift`** remains an **`LrIdx`**."
     ),
-    "BreakImmediate": "16-bit value for **`break`** / breakpoint slot conditions.",
+    "BreakImmediate": "16-bit value for **`BREAK`** / breakpoint slot conditions.",
     "Label": (
         "Branch target: a symbolic **`label`** or a relative offset accepted by the cond slot "
         "(e.g. `loop`, `+3`)."
@@ -137,15 +137,15 @@ Assembly is line-oriented. One **compound instruction** may contain several **sl
 ```asm
 # Comments start with # or //
 label:                          # Labels end with a colon
-    ldr_mult_reg r0 lr0 cr0;     # XMEM: load into mult stage R0
-    mult.ee r0 lr1 0 lr3;      # MULT: element-wise multiply
-    acc;                         # ACC: accumulate
-    add lr0 lr0 1;               # LR: bump address (increment via add)
-    bne lr0 lr1 next;            # COND: branch
+    LDR_MULT_REG r0 lr0 cr0;     # XMEM: load into mult stage r0
+    MULT.EE r0 lr1 0 lr3;        # MULT: element-wise multiply
+    ACC;                         # ACC: accumulate
+    ADD lr0 lr0 1;               # LR: bump address (increment via ADD)
+    BNE lr0 lr1 next;            # COND: branch
     ;;
 ```
 
-Use **lower-case** mnemonics and register names in source (e.g. `mult.ee`, `lr0`, `r0`). Generated documentation often uses **upper-case** for readability (e.g. `MULT.EE`, `LR0`, `R0`).
+By convention, **instruction mnemonics are written in upper case** in documentation and examples (e.g. `MULT.EE`, `LDR_MULT_REG`). **Operand tokens** use **lower case** (`lr0`, `r0`, `cr0`). The assembler accepts **any case** for mnemonics and register tokens.
 
 ## Compound instructions
 
@@ -166,7 +166,7 @@ xmem_inst; mult_inst; acc_inst; aaq_inst; lr_inst_a; lr_inst_b; lr_inst_c; cond_
 **Example (parallel slots):**
 
 ```asm
-ldr_mult_reg r0 lr0 cr0; mult.ee r0 lr1 0 lr3; acc; add lr0 lr0 1; bne lr0 lr1 loop;;
+LDR_MULT_REG r0 lr0 cr0; MULT.EE r0 lr1 0 lr3; ACC; ADD lr0 lr0 1; BNE lr0 lr1 loop;;
 ```
 
 ## Register names
@@ -189,14 +189,14 @@ The **`mem_bypass`** vector may still exist in the **emulator regfile** for debu
 
 ```asm
 start:
-    set lr0 0
+    SET lr0 0;;
 loop:
-    add lr0 lr0 1
-    bne lr0 lr1 loop
-    bkpt
+    ADD lr0 lr0 1;;
+    BNE lr0 lr1 loop;;
+    BKPT;;
 ```
 
-Relative labels such as `b +5` / `b -2` are supported where the grammar accepts a **label** token (see cond-slot instructions in the reference).
+Relative labels such as `B +5` / `B -2` are supported where the grammar accepts a **label** token (see cond-slot instructions in the reference).
 
 ## Jinja2 preprocessing
 
@@ -211,8 +211,8 @@ Relative labels such as `b +5` / `b -2` are supported where the grammar accepts 
 
 ```jinja2
 {% set base = 0x1000 %}
-set lr0 {{ base }};
-ldr_mult_reg r0 lr0 cr0;;
+SET lr0 {{ base }};
+LDR_MULT_REG r0 lr0 cr0;;
 ```
 
 ## Running the assembler

--- a/src/tools/ipu-as-py/src/ipu_as/immediate.py
+++ b/src/tools/ipu-as-py/src/ipu_as/immediate.py
@@ -48,7 +48,7 @@ class LrModPow2KImmediate(ipu_token.IpuToken):
         if not (LR_MOD_POW2_K_MIN <= self.int <= LR_MOD_POW2_K_MAX):
             self._raise_error(
                 f"Value {self.int} out of range [{LR_MOD_POW2_K_MIN}, {LR_MOD_POW2_K_MAX}] "
-                "for incr_mod_pow2 k operand"
+                "for INCR_MOD_POW2 k operand"
             )
 
     def encode(self) -> int:

--- a/src/tools/ipu-as-py/src/ipu_as/inst.py
+++ b/src/tools/ipu-as-py/src/ipu_as/inst.py
@@ -77,7 +77,10 @@ def validate_inst_structure(cls: type) -> type:
 class Inst:
     def __init__(self, inst: dict[str, any]):
         self.opcode = self.opcode_type()(inst["opcode"])
-        struct_entry = self.struct_by_opcode_table()[inst["opcode"].token.value]
+        opcode_idx = self.opcode.encode()
+        struct_table = self.struct_by_opcode_table()
+        struct_names = list(struct_table.keys())
+        struct_entry = struct_table[struct_names[opcode_idx]]
         operand_types = self._operand_types_from_struct(struct_entry)
 
         if len(inst["operands"]) != len(operand_types):
@@ -95,7 +98,7 @@ class Inst:
         full_token_list = [None for _ in range(1 + len(self.operand_types()))]
         full_token_list[0] = self.opcode
         for i, operand in enumerate(self.operands):
-            mapped_index = self._inst_mapping_table[self.opcode.token.value][i]
+            mapped_index = self._inst_mapping_table[self.opcode.encode()][i]
             full_token_list[mapped_index + 1] = operand
         for i in range(len(full_token_list)):
             if full_token_list[i] is None:
@@ -113,12 +116,16 @@ class Inst:
     @classmethod
     def _validate_instr_structure(cls) -> None:
         cls._inst_mapping_table = dict()
-        for opcode, struct_entry in cls.struct_by_opcode_table().items():
-            assert (
-                opcode in cls.opcode_type().enum_array()
-            ), f"Configuration of {cls.__name__} is invalid, opcode key must be of type {cls.opcode_type().__name__}"
+        names = cls.opcode_type().enum_array()
+        for opcode_idx, (opcode_name, struct_entry) in enumerate(
+            cls.struct_by_opcode_table().items()
+        ):
+            assert opcode_name == names[opcode_idx], (
+                f"Configuration of {cls.__name__} is invalid: opcode table order "
+                f"does not match {cls.opcode_type().__name__}.enum_array()"
+            )
 
-            cls._inst_mapping_table[opcode] = cls._find_instruction_inst_mapping(
+            cls._inst_mapping_table[opcode_idx] = cls._find_instruction_inst_mapping(
                 cls._operand_types_from_struct(struct_entry)
             )
 
@@ -171,8 +178,9 @@ class Inst:
 
     @classmethod
     def find_inst_type_by_opcode(cls, opcode: str) -> type["Inst"]:
+        opl = opcode.lower()
         for subclass in cls.__subclasses__():
-            if opcode in subclass.struct_by_opcode_table().keys():
+            if any(opl == name.lower() for name in subclass.struct_by_opcode_table()):
                 return subclass
         raise ValueError(f"Opcode '{opcode}' not found in any Inst subclass.")
 
@@ -255,8 +263,7 @@ class Inst:
         doc: InstructionDoc,
         spec_operands: list[dict],
     ) -> list[str]:
-        display_opcode = opcode.upper()
-        lines = [f"### `{display_opcode}` — {doc.title}", ""]
+        lines = [f"### `{opcode}` — {doc.title}", ""]
         lines.append(f"**Syntax:** `{doc.syntax}`")
         lines.append("")
 
@@ -324,7 +331,7 @@ class XmemInst(Inst):
         return XmemInst(
             {
                 "opcode": ipu_token.AnnotatedToken(
-                    token=lark.Token("TOKEN", "xmem_nop", line=0, column=0),
+                    token=lark.Token("TOKEN", "XMEM_NOP", line=0, column=0),
                     instr_id=addr,
                 ),
                 "operands": [],
@@ -367,7 +374,7 @@ class MultInst(Inst):
         return MultInst(
             {
                 "opcode": ipu_token.AnnotatedToken(
-                    token=lark.Token("TOKEN", "mult_nop", line=0, column=0),
+                    token=lark.Token("TOKEN", "MULT_NOP", line=0, column=0),
                     instr_id=addr,
                 ),
                 "operands": [],
@@ -410,7 +417,7 @@ class AccInst(Inst):
         return AccInst(
             {
                 "opcode": ipu_token.AnnotatedToken(
-                    token=lark.Token("TOKEN", "acc_nop", line=0, column=0),
+                    token=lark.Token("TOKEN", "ACC_NOP", line=0, column=0),
                     instr_id=addr,
                 ),
                 "operands": [],
@@ -451,7 +458,7 @@ class AaqInst(Inst):
         return AaqInst(
             {
                 "opcode": ipu_token.AnnotatedToken(
-                    token=lark.Token("TOKEN", "aaq_nop", line=0, column=0),
+                    token=lark.Token("TOKEN", "AAQ_NOP", line=0, column=0),
                     instr_id=addr,
                 ),
                 "operands": [],
@@ -493,7 +500,7 @@ class LrInst(Inst):
         return LrInst(
             {
                 "opcode": ipu_token.AnnotatedToken(
-                    token=lark.Token("TOKEN", "add", line=0, column=0),
+                    token=lark.Token("TOKEN", "ADD", line=0, column=0),
                     instr_id=addr,
                 ),
                 "operands": [
@@ -541,7 +548,7 @@ class CondInst(Inst):
         return CondInst(
             {
                 "opcode": ipu_token.AnnotatedToken(
-                    token=lark.Token("TOKEN", "b", line=0, column=0), instr_id=addr
+                    token=lark.Token("TOKEN", "B", line=0, column=0), instr_id=addr
                 ),
                 "operands": [
                     ipu_token.AnnotatedToken(
@@ -579,7 +586,7 @@ class BreakInst(Inst):
         return BreakInst(
             {
                 "opcode": ipu_token.AnnotatedToken(
-                    token=lark.Token("TOKEN", "break_nop", line=0, column=0),
+                    token=lark.Token("TOKEN", "BREAK_NOP", line=0, column=0),
                     instr_id=addr,
                 ),
                 "operands": [],

--- a/src/tools/ipu-as-py/src/ipu_as/ipu_token.py
+++ b/src/tools/ipu-as-py/src/ipu_as/ipu_token.py
@@ -68,7 +68,7 @@ class NumberToken(IpuToken):
 class EnumToken(IpuToken):
     def __init__(self, token: AnnotatedToken):
         super().__init__(token)
-        if self.token.value.lower() not in self.enum_array():
+        if self.token.value.lower() not in {n.lower() for n in self.enum_array()}:
             self._raise_error(
                 (
                     f"Value {self.token.value} not in enum options\n"

--- a/src/tools/ipu-common/src/ipu_common/instruction_spec.py
+++ b/src/tools/ipu-common/src/ipu_common/instruction_spec.py
@@ -26,11 +26,11 @@ OPERAND TYPE NAMES (resolved by ipu_as into actual token classes):
   - "LrIdx": lr0-lr15 (LrRegField)  
   - "CrIdx": cr0-cr15 (CrRegField)
   - "LcrIdx": lr0-lr15 or cr0-cr15 (LcrRegField)
-  - "AddSubSrcB": second operand for add/sub — lr, cr, or unsigned IMM5 (AddSubSrcBField; 6-bit encoding)
+  - "AddSubSrcB": second operand for ADD/SUB — lr, cr, or unsigned IMM5 (AddSubSrcBField; 6-bit encoding)
   - "Immediate": 16-bit signed integer for LR immediates (LrImmediateType)
-  - "LrModPow2KImmediate": k operand for incr_mod_pow2 (semantic k ∈ [1, 9]; encoded as k−1 in 4 bits)
+  - "LrModPow2KImmediate": k operand for INCR_MOD_POW2 (semantic k ∈ [1, 9]; encoded as k−1 in 4 bits)
   - "MultMaskOffsetImmediate": mask slot index for mult masking (0–7; eight 128-bit slots in r_mask)
-  - "BreakImmediate": 16-bit break condition value (BreakImmediateType)
+  - "BreakImmediate": 16-bit BREAK condition value (BreakImmediateType)
   - "Label": Branch target label (LabelToken)
 
 SINGLE SOURCE OF TRUTH:
@@ -84,7 +84,7 @@ __all__ = [
     "SLOT_BINARY_LAYOUT",
     "SLOT_COUNT",
     "VALID_OPERAND_TYPES",
-    "extract_opcodes",
+    "canonical_instruction_name",
     "get_instruction",
     "get_instruction_by_opcode",
     "create_assembler_opcodes",
@@ -153,10 +153,10 @@ SLOT_COUNT: dict[str, int] = {
 INSTRUCTION_SPEC = {
     # =========================================================================
     # XMEM Slot (Memory Load/Store Instructions)
-    # Opcode = position in list: str_acc_reg=0, ldr_mult_reg=1, etc.
+    # Opcode = position in list: STR_ACC_REG=0, LDR_MULT_REG=1, etc.
     # =========================================================================
     "xmem": {
-        "str_acc_reg": {
+        "STR_ACC_REG": {
             "operands": [
                 {"name": "offset", "type": "LrIdx", "read": "live"},
                 {"name": "base", "type": "CrIdx", "read": "live"},
@@ -164,17 +164,17 @@ INSTRUCTION_SPEC = {
             "doc": InstructionDoc(
                 title="Store Accumulator",
                 summary="Store accumulator to memory.",
-                syntax="str_acc_reg offset base",
+                syntax="STR_ACC_REG offset base",
                 operands=[
                     "offset: Offset register (lr0-lr15)",
                     "base: Base address register (cr0-cr15)",
                 ],
                 operation="Memory[offset + base] = r_acc",
-                example="str_acc_reg cr0 cr1;;",
+                example="STR_ACC_REG cr0 cr1;;",
             ),
             "execute_fn": "execute_str_acc_reg",
         },
-        "ldr_mult_reg": {
+        "LDR_MULT_REG": {
             "operands": [
                 {"name": "dest", "type": "MultStageReg"},
                 {"name": "offset", "type": "LrIdx", "read": "live"},
@@ -183,18 +183,18 @@ INSTRUCTION_SPEC = {
             "doc": InstructionDoc(
                 title="Load Register",
                 summary="Load data from memory into a multiplication stage register.",
-                syntax="ldr_mult_reg dest offset base",
+                syntax="LDR_MULT_REG dest offset base",
                 operands=[
-                    "`DEST`: `R0` | `R1` — mult-stage register to load (2-bit field; only these encodings are valid).",
-                    "`OFFSET`: `LR0`..`LR15` — offset register.",
-                    "`BASE`: `CR0`..`CR15` — base address register.",
+                    "`dest`: **`r0`** | **`r1`** — mult-stage register to load (2-bit field; only these encodings are valid).",
+                    "`offset`: **`lr0`**…**`lr15`** — offset register.",
+                    "`base`: **`cr0`**…**`cr15`** — base address register.",
                 ],
-                operation="DEST = Memory[OFFSET + BASE]  # 128 bytes (512 in wide-vector debug mode)",
-                example="set lr0 0x1000;;\nldr_mult_reg r0 lr0 cr0;;",
+                operation="dest = Memory[offset + base]  # 128 bytes (512 in wide-vector debug mode)",
+                example="SET lr0 0x1000;;\nLDR_MULT_REG r0 lr0 cr0;;",
             ),
             "execute_fn": "execute_ldr_mult_reg",
         },
-        "ldr_cyclic_mult_reg": {
+        "LDR_CYCLIC_MULT_REG": {
             "operands": [
                 {"name": "offset", "type": "LrIdx", "read": "live"},
                 {"name": "base", "type": "CrIdx", "read": "live"},
@@ -203,7 +203,7 @@ INSTRUCTION_SPEC = {
             "doc": InstructionDoc(
                 title="Load Cyclic Register",
                 summary="Load with cyclic addressing into r_cyclic.",
-                syntax="ldr_cyclic_mult_reg offset base index",
+                syntax="LDR_CYCLIC_MULT_REG offset base index",
                 operands=[
                     "offset: Offset register (lr0-lr15)",
                     "base: Base address register (cr0-cr15)",
@@ -213,7 +213,7 @@ INSTRUCTION_SPEC = {
             ),
             "execute_fn": "execute_ldr_cyclic_mult_reg",
         },
-        "ldr_mult_mask_reg": {
+        "LDR_MULT_MASK_REG": {
             "operands": [
                 {"name": "offset", "type": "LrIdx", "read": "live"},
                 {"name": "base", "type": "CrIdx", "read": "live"},
@@ -221,7 +221,7 @@ INSTRUCTION_SPEC = {
             "doc": InstructionDoc(
                 title="Load Mask Register",
                 summary="Load mask data from memory.",
-                syntax="ldr_mult_mask_reg offset base mask_idx",
+                syntax="LDR_MULT_MASK_REG offset base mask_idx",
                 operands=[
                     "offset: Offset register (lr0-lr15)",
                     "base: Base address register (cr0-cr15)",
@@ -230,17 +230,17 @@ INSTRUCTION_SPEC = {
             ),
             "execute_fn": "execute_ldr_mult_mask_reg",
         },
-        "xmem_nop": {
+        "XMEM_NOP": {
             "operands": [],
             "doc": InstructionDoc(
                 title="No Operation (XMEM)",
                 summary="No operation for xmem slot.",
-                syntax="xmem_nop",
+                syntax="XMEM_NOP",
                 operands=[],
             ),
             "execute_fn": "execute_xmem_nop",
         },
-        "xmem.store_aaq_result": {
+        "XMEM.STORE_AAQ_RESULT": {
             "operands": [
                 {"name": "offset", "type": "LrIdx", "read": "live"},
                 {"name": "base", "type": "CrIdx", "read": "live"},
@@ -248,13 +248,13 @@ INSTRUCTION_SPEC = {
             "doc": InstructionDoc(
                 title="Store AAQ Result",
                 summary="Write the 128-byte AAQ quantization result register to external memory.",
-                syntax="xmem.store_aaq_result offset base",
+                syntax="XMEM.STORE_AAQ_RESULT offset base",
                 operands=[
                     "offset: Offset register (lr0-lr15)",
                     "base: Base address register (cr0-cr15)",
                 ],
                 operation="Memory[offset + base] = aaq_result  # 128 bytes",
-                example="xmem.store_aaq_result lr0 cr0;;",
+                example="XMEM.STORE_AAQ_RESULT lr0 cr0;;",
             ),
             "execute_fn": "execute_xmem_store_aaq_result",
         },
@@ -262,10 +262,10 @@ INSTRUCTION_SPEC = {
     
     # =========================================================================
     # LR Slot (Loop Register Instructions)
-    # Opcode = position: set=0, add=1, sub=2, incr_mod_pow2=3
+    # Opcode = position: SET=0, ADD=1, SUB=2, INCR_MOD_POW2=3
     # =========================================================================
     "lr": {
-        "set": {
+        "SET": {
             "operands": [
                 {"name": "reg", "type": "LrIdx"},
                 {"name": "value", "type": "Immediate"},
@@ -273,17 +273,17 @@ INSTRUCTION_SPEC = {
             "doc": InstructionDoc(
                 title="Set Loop Register",
                 summary="Set a loop register to an immediate value.",
-                syntax="set reg value",
+                syntax="SET reg value",
                 operands=[
                     "reg: Loop register (lr0-lr15)",
                     "value: 32-bit immediate value",
                 ],
                 operation="reg = value",
-                example="set lr0 0x1000;;",
+                example="SET lr0 0x1000;;",
             ),
             "execute_fn": "execute_lr_set",
         },
-        "add": {
+        "ADD": {
             "operands": [
                 {"name": "dest", "type": "LrIdx"},
                 {"name": "src_a", "type": "LrIdx", "read": "snapshot"},
@@ -295,18 +295,18 @@ INSTRUCTION_SPEC = {
                     "Add two sources (second source may be an LR, CR, or 5-bit unsigned immediate) "
                     "and store the result in the destination LR."
                 ),
-                syntax="add dest src_a src_b",
+                syntax="ADD dest src_a src_b",
                 operands=[
                     "dest: Destination local register (lr0-lr15)",
                     "src_a: First source local register (lr0-lr15)",
                     "src_b: Second source — lr0-lr15, cr0-cr15, or unsigned immediate 0–31",
                 ],
                 operation="dest = src_a + src_b",
-                example="add lr0 lr1 lr2;;\nadd lr3 lr1 cr5;;\nadd lr4 lr1 7;;",
+                example="ADD lr0 lr1 lr2;;\nadd lr3 lr1 cr5;;\nadd lr4 lr1 7;;",
             ),
             "execute_fn": "execute_lr_add",
         },
-        "sub": {
+        "SUB": {
             "operands": [
                 {"name": "dest", "type": "LrIdx"},
                 {"name": "src_a", "type": "LrIdx", "read": "snapshot"},
@@ -318,18 +318,18 @@ INSTRUCTION_SPEC = {
                     "Subtract the second source from the first (second source may be an LR, CR, "
                     "or 5-bit unsigned immediate) and store the result in the destination LR."
                 ),
-                syntax="sub dest src_a src_b",
+                syntax="SUB dest src_a src_b",
                 operands=[
                     "dest: Destination local register (lr0-lr15)",
                     "src_a: First source local register (lr0-lr15)",
                     "src_b: Second source — lr0-lr15, cr0-cr15, or unsigned immediate 0–31",
                 ],
                 operation="dest = src_a - src_b",
-                example="sub lr0 lr1 lr2;;\nsub lr3 lr1 cr5;;\nsub lr4 lr1 7;;",
+                example="SUB lr0 lr1 lr2;;\nsub lr3 lr1 cr5;;\nsub lr4 lr1 7;;",
             ),
             "execute_fn": "execute_lr_sub",
         },
-        "incr_mod_pow2": {
+        "INCR_MOD_POW2": {
             "operands": [
                 {"name": "dst", "type": "LrIdx"},
                 {"name": "step", "type": "LcrIdx", "read": "snapshot"},
@@ -341,14 +341,14 @@ INSTRUCTION_SPEC = {
                     "Add a loop or configuration register into the destination loop "
                     "register, then mask to k low bits (mod 2^k)."
                 ),
-                syntax="incr_mod_pow2 dst step k",
+                syntax="INCR_MOD_POW2 dst step k",
                 operands=[
                     "dst: Destination loop register (lr0-lr15); read and written",
                     "step: Signed 32-bit increment from lr0-lr15 or cr0-cr15",
                     "k: Immediate in [1, 9]; encoded in 4 bits as (k − 1); mask = (1 << k) - 1",
                 ],
                 operation="dst <- (dst + step) & ((1 << k) - 1)",
-                example="incr_mod_pow2 lr2 lr3 4;;",
+                example="INCR_MOD_POW2 lr2 lr3 4;;",
             ),
             "execute_fn": "execute_lr_incr_mod_pow2",
         },
@@ -356,11 +356,11 @@ INSTRUCTION_SPEC = {
     
     # =========================================================================
     # MULT Slot (Multiply Instructions)
-    # Opcode = position: mult.ee=0, mult.ve.cyclic=1, mult.ve.padded=2, mult_nop=3,
-    #          mult.ve.cr=4, mult.ve.aaq=5
+    # Opcode = position: MULT.EE=0, MULT.VE.CYCLIC=1, MULT.VE.PADDED=2, MULT_NOP=3,
+    #          MULT.VE.CR=4, MULT.VE.AAQ=5
     # =========================================================================
     "mult": {
-        "mult.ee": {
+        "MULT.EE": {
             "operands": [
                 {"name": "ra", "type": "MultStageReg", "read": "live"},
                 {"name": "cyclic_offset", "type": "LrIdx", "read": "live"},
@@ -370,19 +370,19 @@ INSTRUCTION_SPEC = {
             "doc": InstructionDoc(
                 title="Element-wise Multiply",
                 summary="Multiply elements of two registers element by element.",
-                syntax="MULT.EE RA CYCLIC_OFFSET MASK_OFFSET MASK_SHIFT",
+                syntax="MULT.EE ra cyclic_offset mask_offset mask_shift",
                 operands=[
-                    "`RA`: `R0` | `R1` — multiplicand mult-stage register (same cycle as `LDR_MULT_REG` into `R0`/`R1` is allowed).",
-                    "`CYCLIC_OFFSET`: `LR0`..`LR15` — base byte offset into `RC` (cyclic register).",
-                    "`MASK_OFFSET`: immediate mask slot `0`..`7` — selects one of eight 128-bit masks in `RM`.",
-                    "`MASK_SHIFT`: `LR0`..`LR15` — shift applied to the mask register.",
+                    "`ra`: **`r0`** | **`r1`** — multiplicand mult-stage register (same cycle as `LDR_MULT_REG` into **`r0`**/**`r1`** is allowed).",
+                    "`cyclic_offset`: **`lr0`**…**`lr15`** — base byte offset into **`r_cyclic`**.",
+                    "`mask_offset`: immediate mask slot **`0`**…**`7`** — selects one of eight 128-bit masks in **`r_mask`**.",
+                    "`mask_shift`: **`lr0`**…**`lr15`** — shift applied to the mask register.",
                 ],
-                operation="For each lane i: MULT_RES[i] = IPU_MULT(RA[i], RC[CYCLIC_OFFSET + i]); then apply mask and shift.",
-                example="MULT.EE R0 LR0 0 LR2;;",
+                operation="For each lane i: mult_res[i] = ipu_mult(ra[i], r_cyclic[cyclic_offset + i]); then apply mask and shift.",
+                example="MULT.EE r0 lr0 0 lr2;;",
             ),
             "execute_fn": "execute_mult_ee",
         },
-        "mult.ve.cyclic": {
+        "MULT.VE.CYCLIC": {
             "operands": [
                 {"name": "cyclic_offset", "type": "LrIdx", "read": "live"},
                 {"name": "mask_offset", "type": "MultMaskOffsetImmediate"},
@@ -392,23 +392,23 @@ INSTRUCTION_SPEC = {
             "doc": InstructionDoc(
                 title="Vector-Element Multiply (cyclic RC)",
                 summary=(
-                    "Multiply a fixed element from R0 or R1 against RC[cyclic_offset:cyclic_offset+128]. "
-                    "`FIXED_IDX` 0..127 selects `R0[FIXED_IDX]`, 128..255 selects `R1[FIXED_IDX - 128]`. "
-                    "RC is addressed cyclically modulo 512 bytes (no padding with 1 past the boundary)."
+                    "Multiply a fixed element from r0 or r1 against r_cyclic[cyclic_offset:cyclic_offset+128]. "
+                    "`fixed_idx` 0..127 selects `r0[fixed_idx]`, 128..255 selects `r1[fixed_idx - 128]`. "
+                    "r_cyclic is addressed cyclically modulo 512 bytes (no padding with 1 past the boundary)."
                 ),
-                syntax="MULT.VE.CYCLIC CYCLIC_OFFSET MASK_OFFSET MASK_SHIFT FIXED_IDX",
+                syntax="MULT.VE.CYCLIC cyclic_offset mask_offset mask_shift fixed_idx",
                 operands=[
-                    "`CYCLIC_OFFSET`: `LR0`..`LR15` — base byte offset into `RC` (reduced mod 512).",
-                    "`MASK_OFFSET`: immediate mask slot `0`..`7` — selects one of eight 128-bit masks in `RM`.",
-                    "`MASK_SHIFT`: `LR0`..`LR15` — shift applied to the mask register.",
-                    "`FIXED_IDX`: `LR0`..`LR15` (value read live) — scalar index into `R0`/`R1`.",
+                    "`cyclic_offset`: **`lr0`**…**`lr15`** — base byte offset into **`r_cyclic`** (reduced mod 512).",
+                    "`mask_offset`: immediate mask slot **`0`**…**`7`** — selects one of eight 128-bit masks in **`r_mask`**.",
+                    "`mask_shift`: **`lr0`**…**`lr15`** — shift applied to the mask register.",
+                    "`fixed_idx`: **`lr0`**…**`lr15`** (value read live) — scalar index into **`r0`**/**`r1`**.",
                 ],
-                operation="For i in [0, 128): RB = RC[(CYCLIC_OFFSET + i) mod 512]; SCALAR from R0/R1 via FIXED_IDX; MULT_RES[i] = SCALAR * RB (then mask/shift).",
-                example="MULT.VE.CYCLIC LR0 0 LR2 LR3;;",
+                operation="For i in [0, 128): rb = r_cyclic[(cyclic_offset + i) % 512]; scalar from r0/r1 via fixed_idx; mult_res[i] = scalar * rb (then mask/shift).",
+                example="MULT.VE.CYCLIC lr0 0 lr2 lr3;;",
             ),
             "execute_fn": "execute_mult_ve_cyclic",
         },
-        "mult.ve.padded": {
+        "MULT.VE.PADDED": {
             "operands": [
                 {"name": "cyclic_offset", "type": "LrIdx", "read": "live"},
                 {"name": "mask_offset", "type": "MultMaskOffsetImmediate"},
@@ -418,32 +418,32 @@ INSTRUCTION_SPEC = {
             "doc": InstructionDoc(
                 title="Vector-Element Multiply (padded RC)",
                 summary=(
-                    "Same scalar × RC row as `mult.ve.cyclic`, but indices at or past the 512-byte RC "
+                    "Same scalar × RC row as `MULT.VE.CYCLIC`, but indices at or past the 512-byte RC "
                     "boundary within the 128-element window use a dtype-specific 1 instead of wrapping."
                 ),
-                syntax="MULT.VE.PADDED CYCLIC_OFFSET MASK_OFFSET MASK_SHIFT FIXED_IDX",
+                syntax="MULT.VE.PADDED cyclic_offset mask_offset mask_shift fixed_idx",
                 operands=[
-                    "`CYCLIC_OFFSET`: `LR0`..`LR15` — base byte offset into `RC`; out-of-range lanes use dtype 1.",
-                    "`MASK_OFFSET`: immediate mask slot `0`..`7` — selects one of eight 128-bit masks in `RM`.",
-                    "`MASK_SHIFT`: `LR0`..`LR15` — shift applied to the mask register.",
-                    "`FIXED_IDX`: `LR0`..`LR15` (value read live) — scalar index into `R0`/`R1`.",
+                    "`cyclic_offset`: **`lr0`**…**`lr15`** — base byte offset into `r_cyclic`; out-of-range lanes use dtype 1.",
+                    "`mask_offset`: immediate mask slot **`0`**…**`7`** — selects one of eight 128-bit masks in `r_mask`.",
+                    "`mask_shift`: **`lr0`**…**`lr15`** — shift applied to the mask register.",
+                    "`fixed_idx`: **`lr0`**…**`lr15`** (value read live) — scalar index into **`r0`**/**`r1`**.",
                 ],
-                operation="For i in [0, 128): RB = RC[CYCLIC_OFFSET + i] if in bounds else dtype_one; SCALAR from R0/R1; MULT_RES[i] = SCALAR * RB (then mask/shift).",
-                example="MULT.VE.PADDED LR0 0 LR2 LR3;;",
+                operation="For i in [0, 128): rb = r_cyclic[cyclic_offset + i] if in bounds else dtype_one; scalar from r0/r1; mult_res[i] = scalar * rb (then mask/shift).",
+                example="MULT.VE.PADDED lr0 0 lr2 lr3;;",
             ),
             "execute_fn": "execute_mult_ve_padded",
         },
-        "mult_nop": {
+        "MULT_NOP": {
             "operands": [],
             "doc": InstructionDoc(
                 title="No Operation (MULT)",
                 summary="No operation for multiply slot.",
-                syntax="mult_nop",
+                syntax="MULT_NOP",
                 operands=[],
             ),
             "execute_fn": "execute_mult_nop",
         },
-        "mult.ve.cr": {
+        "MULT.VE.CR": {
             "operands": [
                 {"name": "cyclic_offset", "type": "LrIdx", "read": "live"},
                 {"name": "mask_offset", "type": "MultMaskOffsetImmediate"},
@@ -453,7 +453,7 @@ INSTRUCTION_SPEC = {
             "doc": InstructionDoc(
                 title="Vector-Element Multiply (CR scalar)",
                 summary="Multiply each element of RC[cyclic_offset:cyclic_offset+128] by a scalar from a CR register. Elements beyond RC boundary are treated as 1 (dtype-specific).",
-                syntax="mult.ve.cr cyclic_offset mask_offset mask_shift cr_idx",
+                syntax="MULT.VE.CR cyclic_offset mask_offset mask_shift cr_idx",
                 operands=[
                     "cyclic_offset: Base offset into RC (cyclic register); non-cyclic — out-of-bounds elements are padded with 1",
                     "mask_offset: Immediate mask slot 0–7 (128-bit slice of r_mask)",
@@ -461,11 +461,11 @@ INSTRUCTION_SPEC = {
                     "cr_idx: CR register whose low byte supplies the fixed scalar multiplier (cr0-cr15)",
                 ],
                 operation="For i in [0,128): rb = RC[cyclic_offset+i] if in bounds else dtype_one; mult_res[i] = CR[cr_idx][0] * rb",
-                example="mult.ve.cr lr0 0 lr15 cr3;;",
+                example="MULT.VE.CR lr0 0 lr15 cr3;;",
             ),
             "execute_fn": "execute_mult_ve_cr",
         },
-        "mult.ve.aaq": {
+        "MULT.VE.AAQ": {
             "operands": [
                 {"name": "cyclic_offset", "type": "LrIdx", "read": "live"},
                 {"name": "mask_offset", "type": "MultMaskOffsetImmediate"},
@@ -475,7 +475,7 @@ INSTRUCTION_SPEC = {
             "doc": InstructionDoc(
                 title="Vector-Element Multiply (AAQ scalar)",
                 summary="Multiply each element of RC[cyclic_offset:cyclic_offset+128] by a scalar from an AAQ register. Elements beyond RC boundary are treated as 1 (dtype-specific).",
-                syntax="mult.ve.aaq cyclic_offset mask_offset mask_shift aaq_rf_idx",
+                syntax="MULT.VE.AAQ cyclic_offset mask_offset mask_shift aaq_rf_idx",
                 operands=[
                     "cyclic_offset: Base offset into RC (cyclic register); non-cyclic — out-of-bounds elements are padded with 1",
                     "mask_offset: Immediate mask slot 0–7 (128-bit slice of r_mask)",
@@ -483,7 +483,7 @@ INSTRUCTION_SPEC = {
                     "aaq_rf_idx: AAQ register whose low byte supplies the fixed scalar multiplier (aaq0-aaq3)",
                 ],
                 operation="For i in [0,128): rb = RC[cyclic_offset+i] if in bounds else dtype_one; mult_res[i] = AAQ[aaq_rf_idx][0] * rb",
-                example="mult.ve.aaq lr0 0 lr15 aaq1;;",
+                example="MULT.VE.AAQ lr0 0 lr15 aaq1;;",
             ),
             "execute_fn": "execute_mult_ve_aaq",
         },
@@ -491,61 +491,61 @@ INSTRUCTION_SPEC = {
 
     # =========================================================================
     # ACC Slot (Accumulator Instructions)
-    # Opcode = position: acc=0, acc.first=1, reset_acc=2, acc_nop=3, acc.add_aaq=4, acc.add_aaq.first=5, acc.max=6, acc.max.first=7, acc.stride=8
+    # Opcode = position: ACC=0, ACC.FIRST=1, RESET_ACC=2, ACC_NOP=3, ACC.ADD_AAQ=4, ACC.ADD_AAQ.FIRST=5, ACC.MAX=6, ACC.MAX.FIRST=7, ACC.STRIDE=8
     # =========================================================================
     "acc": {
-        "acc": {
+        "ACC": {
             "operands": [],
             "doc": InstructionDoc(
                 title="Accumulate",
                 summary="Accumulate multiply result.",
-                syntax="acc",
+                syntax="ACC",
                 operands=[],
                 operation="r_acc += multiply_result",
             ),
             "execute_fn": "execute_acc",
         },
-        "acc.first": {
+        "ACC.FIRST": {
             "operands": [],
             "doc": InstructionDoc(
                 title="Accumulate First",
-                summary="Set accumulator to multiply result (do not add to previous r_acc).",
-                syntax="acc.first",
+                summary="Set accumulator to multiply result (do not ADD to previous r_acc).",
+                syntax="ACC.FIRST",
                 operands=[],
                 operation="r_acc = multiply_result",
-                example="acc.first;;",
+                example="ACC.FIRST;;",
             ),
             "execute_fn": "execute_acc_first",
         },
-        "reset_acc": {
+        "RESET_ACC": {
             "operands": [],
             "doc": InstructionDoc(
                 title="Reset Accumulator",
                 summary="Reset accumulator to zero.",
-                syntax="reset_acc",
+                syntax="RESET_ACC",
                 operands=[],
                 operation="r_acc = 0",
             ),
             "execute_fn": "execute_reset_acc",
         },
-        "acc_nop": {
+        "ACC_NOP": {
             "operands": [],
             "doc": InstructionDoc(
                 title="No Operation (ACC)",
                 summary="No operation for accumulator slot.",
-                syntax="acc_nop",
+                syntax="ACC_NOP",
                 operands=[],
             ),
             "execute_fn": "execute_acc_nop",
         },
-        "acc.add_aaq": {
+        "ACC.ADD_AAQ": {
             "operands": [
                 {"name": "aaq_rf_idx", "type": "AaqRegIdx"},
             ],
             "doc": InstructionDoc(
                 title="Accumulate and Add AAQ",
-                summary="Accumulate multiply result, then add the selected AAQ register (32-bit) to each of the 128 accumulator words.",
-                syntax="acc.add_aaq aaq_rf_idx",
+                summary="Accumulate multiply result, then ADD the selected AAQ register (32-bit) to each of the 128 accumulator words.",
+                syntax="ACC.ADD_AAQ aaq_rf_idx",
                 operands=[
                     "aaq_rf_idx: AAQ register index (aaq0-aaq3)",
                 ],
@@ -553,18 +553,18 @@ INSTRUCTION_SPEC = {
                     "r_acc += multiply_result;\n"
                     "for i in [0, 128): r_acc[i] += aaq_regs[aaq_rf_idx]"
                 ),
-                example="acc.add_aaq aaq0;;",
+                example="ACC.ADD_AAQ aaq0;;",
             ),
             "execute_fn": "execute_acc_add_aaq",
         },
-        "acc.add_aaq.first": {
+        "ACC.ADD_AAQ.FIRST": {
             "operands": [
                 {"name": "aaq_rf_idx", "type": "AaqRegIdx"},
             ],
             "doc": InstructionDoc(
                 title="Accumulate and Add AAQ (First)",
-                summary="Set accumulator to multiply result plus selected AAQ register (do not add to previous r_acc).",
-                syntax="acc.add_aaq.first aaq_rf_idx",
+                summary="Set accumulator to multiply result plus selected AAQ register (do not ADD to previous r_acc).",
+                syntax="ACC.ADD_AAQ.FIRST aaq_rf_idx",
                 operands=[
                     "aaq_rf_idx: AAQ register index (aaq0-aaq3)",
                 ],
@@ -572,47 +572,47 @@ INSTRUCTION_SPEC = {
                     "r_acc = multiply_result;\n"
                     "for i in [0, 128): r_acc[i] += aaq_regs[aaq_rf_idx]"
                 ),
-                example="acc.add_aaq.first aaq0;;",
+                example="ACC.ADD_AAQ.FIRST aaq0;;",
             ),
             "execute_fn": "execute_acc_add_aaq_first",
         },
-        "acc.max": {
+        "ACC.MAX": {
             "operands": [
                 {"name": "aaq_rf_idx", "type": "AaqRegIdx"},
             ],
             "doc": InstructionDoc(
                 title="Accumulator Max",
-                summary="For each element, set r_acc[i] = max(r_acc[i], mult_res[i], aaq_reg[aaq_rf_idx]).",
-                syntax="acc.max aaq_rf_idx",
+                summary="For each element, SET r_acc[i] = max(r_acc[i], mult_res[i], aaq_reg[aaq_rf_idx]).",
+                syntax="ACC.MAX aaq_rf_idx",
                 operands=[
                     "aaq_rf_idx: AAQ register index (aaq0-aaq3)",
                 ],
                 operation=(
                     "for i in [0, 128): r_acc[i] = max(r_acc[i], mult_res[i], aaq_regs[aaq_rf_idx])"
                 ),
-                example="acc.max aaq0;;",
+                example="ACC.MAX aaq0;;",
             ),
             "execute_fn": "execute_acc_max",
         },
-        "acc.max.first": {
+        "ACC.MAX.FIRST": {
             "operands": [
                 {"name": "aaq_rf_idx", "type": "AaqRegIdx"},
             ],
             "doc": InstructionDoc(
                 title="Accumulator Max (First)",
-                summary="For each element, set r_acc[i] = max(mult_res[i], aaq_reg[aaq_rf_idx]). Previous r_acc is ignored (treated as 0).",
-                syntax="acc.max.first aaq_rf_idx",
+                summary="For each element, SET r_acc[i] = max(mult_res[i], aaq_reg[aaq_rf_idx]). Previous r_acc is ignored (treated as 0).",
+                syntax="ACC.MAX.FIRST aaq_rf_idx",
                 operands=[
                     "aaq_rf_idx: AAQ register index (aaq0-aaq3)",
                 ],
                 operation=(
                     "for i in [0, 128): r_acc[i] = max(mult_res[i], aaq_regs[aaq_rf_idx])"
                 ),
-                example="acc.max.first aaq0;;",
+                example="ACC.MAX.FIRST aaq0;;",
             ),
             "execute_fn": "execute_acc_max_first",
         },
-        "acc.stride": {
+        "ACC.STRIDE": {
             "operands": [
                 {"name": "elements_in_row", "type": "ElementsInRow"},
                 {"name": "horizontal_stride", "type": "HorizontalStride"},
@@ -622,7 +622,7 @@ INSTRUCTION_SPEC = {
             "doc": InstructionDoc(
                 title="Accumulator Stride",
                 summary="Reorder the multiplication result into r_acc using horizontal/vertical stride decimation. Only updates the RACC indexes written; leaves the rest unchanged.",
-                syntax="acc.stride elements_in_row horizontal_stride vertical_stride offset",
+                syntax="ACC.STRIDE elements_in_row horizontal_stride vertical_stride offset",
                 operands=[
                     "elements_in_row: Elements per row (8, 16, 32, or 64)",
                     "horizontal_stride: Horizontal stride mode (enabled, inverted, expand)",
@@ -633,7 +633,7 @@ INSTRUCTION_SPEC = {
                     "Decimate mult_res as rows×cols; apply horizontal stride (take every 2nd column, optional expand); "
                     "then vertical stride (take every 2nd row). Write result into r_acc[start:start+N] where start = (offset%4)*32, N = 32|64|128."
                 ),
-                example="acc.stride 8 off off lr0;;",
+                example="ACC.STRIDE 8 off off lr0;;",
             ),
             "execute_fn": "execute_acc_stride",
         },
@@ -641,20 +641,20 @@ INSTRUCTION_SPEC = {
 
     # =========================================================================
     # AAQ Slot (Activation and Quantization)
-    # Opcode = position: aaq_nop=0, agg=1, agg.first=2
+    # Opcode = position: AAQ_NOP=0, AGG=1, AGG.FIRST=2
     # =========================================================================
     "aaq": {
-        "aaq_nop": {
+        "AAQ_NOP": {
             "operands": [],
             "doc": InstructionDoc(
                 title="No Operation (AAQ)",
                 summary="No operation for AAQ slot.",
-                syntax="aaq_nop",
+                syntax="AAQ_NOP",
                 operands=[],
             ),
             "execute_fn": "execute_aaq_nop",
         },
-        "agg": {
+        "AGG": {
             "operands": [
                 {"name": "agg_mode", "type": "AggMode"},
                 {"name": "post_fn", "type": "PostFn"},
@@ -672,7 +672,7 @@ INSTRUCTION_SPEC = {
                     "Collapse r_acc lanes into one value (SUM or MAX), using only the first "
                     "valid_elements words for the tree; apply post function; store to selected AAQ register."
                 ),
-                syntax="agg agg_mode post_fn valid_elements cr_idx aaq_rf_idx",
+                syntax="AGG agg_mode post_fn valid_elements cr_idx aaq_rf_idx",
                 operands=[
                     "agg_mode: sum or max",
                     "post_fn: value, value_cr, inv, or inv_sqrt",
@@ -684,15 +684,15 @@ INSTRUCTION_SPEC = {
                 operation=(
                     "Let n = min(valid_elements, 128). "
                     "If sum: v = sum(r_acc[0..n-1]). "
-                    "If max: v = max(r_acc[0..n-1], aaq[aaq_rf_idx]). "
+                    "If max: v = max(r_acc[0..n-1], AAQ[aaq_rf_idx]). "
                     "Apply post_fn(v): value→v, value_cr→v*cr[cr_idx], inv→1/v, inv_sqrt→1/sqrt(v). "
-                    "aaq[aaq_rf_idx] = result."
+                    "AAQ[aaq_rf_idx] = result."
                 ),
-                example="agg sum value lr0 cr0 aaq0;;",
+                example="AGG sum value lr0 cr0 aaq0;;",
             ),
             "execute_fn": "execute_agg",
         },
-        "agg.first": {
+        "AGG.FIRST": {
             "operands": [
                 {"name": "agg_mode", "type": "AggMode"},
                 {"name": "post_fn", "type": "PostFn"},
@@ -706,8 +706,8 @@ INSTRUCTION_SPEC = {
             ],
             "doc": InstructionDoc(
                 title="Accumulator Aggregate First",
-                summary="Like agg, but for MAX mode ignores the previous AAQ register value, avoiding contamination from uninitialized data.",
-                syntax="agg.first agg_mode post_fn valid_elements cr_idx aaq_rf_idx",
+                summary="Like AGG, but for MAX mode ignores the previous AAQ register value, avoiding contamination from uninitialized data.",
+                syntax="AGG.FIRST agg_mode post_fn valid_elements cr_idx aaq_rf_idx",
                 operands=[
                     "agg_mode: sum or max",
                     "post_fn: value, value_cr, inv, or inv_sqrt",
@@ -719,26 +719,26 @@ INSTRUCTION_SPEC = {
                 operation=(
                     "Let n = min(valid_elements, 128). "
                     "If sum: v = sum(r_acc[0..n-1]). "
-                    "If max: v = max(r_acc[0..n-1]) (previous aaq value is NOT included). "
+                    "If max: v = max(r_acc[0..n-1]) (previous AAQ value is NOT included). "
                     "Apply post_fn(v): value→v, value_cr→v*cr[cr_idx], inv→1/v, inv_sqrt→1/sqrt(v). "
-                    "aaq[aaq_rf_idx] = result."
+                    "AAQ[aaq_rf_idx] = result."
                 ),
-                example="agg.first max value lr0 cr0 aaq0;;",
+                example="AGG.FIRST max value lr0 cr0 aaq0;;",
             ),
             "execute_fn": "execute_agg_first",
         },
-        "aaq": {
+        "AAQ": {
             "operands": [],
             "doc": InstructionDoc(
                 title="AAQ Quantize",
                 summary="Quantize the 128-word accumulator from INT32 to INT8, storing clamped results in the aaq_result register. Requires INT8 mode.",
-                syntax="aaq",
+                syntax="AAQ",
                 operands=[],
                 operation=(
                     "Requires INT8 mode (cr15 == DType.INT8). "
                     "For i in [0, 128): aaq_result[i] = clamp(trunc(r_acc[i]), -128, 127)"
                 ),
-                example="aaq;;",
+                example="AAQ;;",
             ),
             "execute_fn": "execute_aaq",
         },
@@ -746,10 +746,10 @@ INSTRUCTION_SPEC = {
 
     # =========================================================================
     # COND Slot (Conditional Branch Instructions)
-    # Opcode = position: beq=0, bne=1, blt=2, bnz=3, bz=4, b=5, br=6, bkpt=7
+    # Opcode = position: BEQ=0, BNE=1, BLT=2, BNZ=3, BZ=4, B=5, BR=6, BKPT=7
     # =========================================================================
     "cond": {
-        "beq": {
+        "BEQ": {
             "operands": [
                 {"name": "reg1", "type": "LcrIdx", "read": "snapshot"},
                 {"name": "reg2", "type": "LcrIdx", "read": "snapshot"},
@@ -758,18 +758,18 @@ INSTRUCTION_SPEC = {
             "doc": InstructionDoc(
                 title="Branch if Equal",
                 summary="Branch if two registers are equal.",
-                syntax="beq reg1 reg2 label",
+                syntax="BEQ reg1 reg2 label",
                 operands=[
                     "reg1: First register to compare (lr0-lr15 or cr0-cr15)",
                     "reg2: Second register to compare (lr0-lr15 or cr0-cr15)",
                     "label: Branch target label",
                 ],
                 operation="if (reg1 == reg2) PC = label",
-                example="beq lr0 lr1 end;;",
+                example="BEQ lr0 lr1 end;;",
             ),
             "execute_fn": "execute_beq",
         },
-        "bne": {
+        "BNE": {
             "operands": [
                 {"name": "reg1", "type": "LcrIdx", "read": "snapshot"},
                 {"name": "reg2", "type": "LcrIdx", "read": "snapshot"},
@@ -778,18 +778,18 @@ INSTRUCTION_SPEC = {
             "doc": InstructionDoc(
                 title="Branch if Not Equal",
                 summary="Branch if two registers are not equal.",
-                syntax="bne reg1 reg2 label",
+                syntax="BNE reg1 reg2 label",
                 operands=[
                     "reg1: First register to compare (lr0-lr15 or cr0-cr15)",
                     "reg2: Second register to compare (lr0-lr15 or cr0-cr15)",
                     "label: Branch target label",
                 ],
                 operation="if (reg1 != reg2) PC = label",
-                example="bne lr0 cr0 loop;;",
+                example="BNE lr0 cr0 loop;;",
             ),
             "execute_fn": "execute_bne",
         },
-        "blt": {
+        "BLT": {
             "operands": [
                 {"name": "reg1", "type": "LcrIdx", "read": "snapshot"},
                 {"name": "reg2", "type": "LcrIdx", "read": "snapshot"},
@@ -798,18 +798,18 @@ INSTRUCTION_SPEC = {
             "doc": InstructionDoc(
                 title="Branch if Less Than",
                 summary="Branch if first register is less than second.",
-                syntax="blt reg1 reg2 label",
+                syntax="BLT reg1 reg2 label",
                 operands=[
                     "reg1: First register to compare (lr0-lr15 or cr0-cr15)",
                     "reg2: Second register to compare (lr0-lr15 or cr0-cr15)",
                     "label: Branch target label",
                 ],
                 operation="if (reg1 < reg2) PC = label",
-                example="blt lr0 cr1 smaller;;",
+                example="BLT lr0 cr1 smaller;;",
             ),
             "execute_fn": "execute_blt",
         },
-        "bnz": {
+        "BNZ": {
             "operands": [
                 {"name": "test_reg", "type": "LcrIdx", "read": "snapshot"},
                 {"name": "base_reg", "type": "LcrIdx", "read": "snapshot"},
@@ -818,18 +818,18 @@ INSTRUCTION_SPEC = {
             "doc": InstructionDoc(
                 title="Branch if Not Zero",
                 summary="Branch if test register not equal to base register.",
-                syntax="bnz test_reg base_reg label",
+                syntax="BNZ test_reg base_reg label",
                 operands=[
                     "test_reg: Register to test (lr0-lr15 or cr0-cr15)",
                     "base_reg: Base comparison register (lr0-lr15 or cr0-cr15)",
                     "label: Branch target label",
                 ],
                 operation="if (test_reg != base_reg) PC = label",
-                example="bnz lr3 lr0 loop;;",
+                example="BNZ lr3 lr0 loop;;",
             ),
             "execute_fn": "execute_bnz",
         },
-        "bz": {
+        "BZ": {
             "operands": [
                 {"name": "test_reg", "type": "LcrIdx", "read": "snapshot"},
                 {"name": "base_reg", "type": "LcrIdx", "read": "snapshot"},
@@ -838,50 +838,50 @@ INSTRUCTION_SPEC = {
             "doc": InstructionDoc(
                 title="Branch if Zero",
                 summary="Branch if test register equals base register.",
-                syntax="bz test_reg base_reg label",
+                syntax="BZ test_reg base_reg label",
                 operands=[
                     "test_reg: Register to test (lr0-lr15 or cr0-cr15)",
                     "base_reg: Base comparison register (lr0-lr15 or cr0-cr15)",
                     "label: Branch target label",
                 ],
                 operation="if (test_reg == base_reg) PC = label",
-                example="bz lr0 lr1 zero;;",
+                example="BZ lr0 lr1 zero;;",
             ),
             "execute_fn": "execute_bz",
         },
-        "b": {
+        "B": {
             "operands": [
                 {"name": "label", "type": "Label"},
             ],
             "doc": InstructionDoc(
                 title="Unconditional Branch",
                 summary="Always branch to label.",
-                syntax="b label",
+                syntax="B label",
                 operands=["label: Branch target label"],
                 operation="PC = label",
-                example="b start;;",
+                example="B start;;",
             ),
             "execute_fn": "execute_b",
         },
-        "br": {
+        "BR": {
             "operands": [
                 {"name": "reg", "type": "LcrIdx", "read": "snapshot"},
             ],
             "doc": InstructionDoc(
                 title="Branch Register",
                 summary="Branch to address in register.",
-                syntax="br reg",
+                syntax="BR reg",
                 operands=["reg: Register containing target address (lr0-lr15 or cr0-cr15)"],
                 operation="PC = reg",
             ),
             "execute_fn": "execute_br",
         },
-        "bkpt": {
+        "BKPT": {
             "operands": [],
             "doc": InstructionDoc(
                 title="Breakpoint",
                 summary="Conditional breakpoint.",
-                syntax="bkpt",
+                syntax="BKPT",
                 operands=[],
                 operation="Halt execution (debugging)",
             ),
@@ -891,21 +891,21 @@ INSTRUCTION_SPEC = {
 
     # =========================================================================
     # BREAK Slot (Break Instructions)
-    # Opcode = position: break=0, break.ifeq=1, break_nop=2
+    # Opcode = position: BREAK=0, BREAK.IFEQ=1, BREAK_NOP=2
     # =========================================================================
     "break": {
-        "break": {
+        "BREAK": {
             "operands": [],
             "doc": InstructionDoc(
                 title="Break",
                 summary="Unconditional break.",
-                syntax="break",
+                syntax="BREAK",
                 operands=[],
                 operation="Halt execution",
             ),
             "execute_fn": "execute_break",
         },
-        "break.ifeq": {
+        "BREAK.IFEQ": {
             "operands": [
                 {"name": "reg", "type": "LrIdx", "read": "snapshot"},
                 {"name": "value", "type": "BreakImmediate"},
@@ -913,22 +913,22 @@ INSTRUCTION_SPEC = {
             "doc": InstructionDoc(
                 title="Break if Equal",
                 summary="Break execution if register equals value.",
-                syntax="break.ifeq reg value",
+                syntax="BREAK.IFEQ reg value",
                 operands=[
                     "reg: Register to test (lr0-lr15)",
                     "value: Immediate value to compare against",
                 ],
                 operation="if (reg == value) BREAK",
-                example="break.ifeq lr0 10;;",
+                example="BREAK.IFEQ lr0 10;;",
             ),
             "execute_fn": "execute_break_ifeq",
         },
-        "break_nop": {
+        "BREAK_NOP": {
             "operands": [],
             "doc": InstructionDoc(
                 title="No Operation (BREAK)",
-                summary="No operation for break slot.",
-                syntax="break_nop",
+                summary="No operation for BREAK slot.",
+                syntax="BREAK_NOP",
                 operands=[],
             ),
             "execute_fn": "execute_break_nop",
@@ -941,12 +941,24 @@ INSTRUCTION_SPEC = {
 # Query Functions (position-based opcode derivation)
 # ===========================================================================
 
+def canonical_instruction_name(slot_type: str, instruction_name: str) -> str:
+    """Return the canonical instruction key for ``instruction_name`` (case-insensitive)."""
+    instructions = INSTRUCTION_SPEC[slot_type]
+    lowered = instruction_name.lower()
+    for name in instructions:
+        if name.lower() == lowered:
+            return name
+    raise KeyError(
+        f"Instruction {instruction_name!r} not found in slot {slot_type!r}"
+    )
+
+
 def get_opcode_for_instruction(slot_type: str, instruction_name: str) -> int:
     """Get opcode index for an instruction (derived from its position).
     
     Args:
         slot_type: Slot type (e.g., "xmem", "lr", "mult")
-        instruction_name: Instruction name (e.g., "str_acc_reg")
+        instruction_name: Instruction name (e.g., "STR_ACC_REG")
     
     Returns:
         Opcode index (0-based position in slot's instruction list)
@@ -954,9 +966,10 @@ def get_opcode_for_instruction(slot_type: str, instruction_name: str) -> int:
     Raises:
         KeyError if slot or instruction not found
     """
+    canon = canonical_instruction_name(slot_type, instruction_name)
     instructions = INSTRUCTION_SPEC[slot_type]
     for idx, name in enumerate(instructions.keys()):
-        if name == instruction_name:
+        if name == canon:
             return idx
     raise KeyError(f"Instruction '{instruction_name}' not found in slot '{slot_type}'")
 
@@ -969,8 +982,8 @@ def extract_opcodes() -> Dict[str, List[str]]:
     
     Example:
         {
-            "xmem": ["str_acc_reg", "ldr_mult_reg", ...],
-            "lr": ["set", "add", "sub", "incr_mod_pow2"],
+            "xmem": ["STR_ACC_REG", "LDR_MULT_REG", ...],
+            "lr": ["SET", "ADD", "SUB", "INCR_MOD_POW2"],
             ...
         }
     """
@@ -985,7 +998,7 @@ def get_instruction(slot_type: str, instruction_name: str) -> dict:
     
     Args:
         slot_type: Slot type (e.g., "xmem", "lr", "mult")
-        instruction_name: Instruction name (e.g., "str_acc_reg")
+        instruction_name: Instruction name (e.g., "STR_ACC_REG")
     
     Returns:
         The instruction definition dict with "operands", "doc", "execute_fn"
@@ -993,7 +1006,7 @@ def get_instruction(slot_type: str, instruction_name: str) -> dict:
     Raises:
         KeyError if instruction not found
     """
-    return INSTRUCTION_SPEC[slot_type][instruction_name]
+    return INSTRUCTION_SPEC[slot_type][canonical_instruction_name(slot_type, instruction_name)]
 
 
 def get_instruction_by_opcode(slot_type: str, opcode_index: int) -> Tuple[str, dict]:
@@ -1050,8 +1063,9 @@ def create_assembler_opcodes() -> Dict[str, Type]:
         """Base class for all opcode types."""
         @classmethod
         def find_opcode_class(cls, opcode_token) -> Type["Opcode"]:
+            tv = opcode_token.value.lower()
             for subclass in cls.__subclasses__():
-                if opcode_token.value in subclass.enum_array():
+                if any(tv == name.lower() for name in subclass.enum_array()):
                     return subclass
             raise ValueError(
                 f"Opcode '{opcode_token.value}' not found in any Opcode subclass"
@@ -1114,7 +1128,7 @@ def create_emulator_constants() -> Dict[str, int]:
         
         # Add opcode constants for each instruction
         for opcode_idx, instruction_name in enumerate(instructions.keys()):
-            # Convert name to constant style: "str_acc_reg" → "STR_ACC_REG"
+            # Convert name to constant style: "STR_ACC_REG" → "STR_ACC_REG"
             const_name = instruction_name.upper().replace(".", "_").replace("-", "_")
             constants[f"{prefix}_{const_name}"] = opcode_idx
         

--- a/src/tools/ipu-emu-py/src/ipu_emu/debug_cli.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/debug_cli.py
@@ -6,6 +6,10 @@ register descriptor automatically creates the corresponding debug commands.
 
 Built on Python's ``cmd.Cmd`` for readline support, history, and ``?`` help.
 
+Debugger **verbs** (``set``, ``get``, ``continue``, …) are matched **case-insensitively**
+on the first word, same spirit as assembly mnemonics — they still do **not** go through
+the Lark assembler (that path is only for ``*.asm`` / ``assemble()``).
+
 Usage from Python::
 
     from ipu_emu.debug_cli import debug_prompt, DebugAction
@@ -309,6 +313,23 @@ class DebugCLI(cmd.Cmd):
         self.use_rawinput = False
         self._result: DebugAction = DebugAction.QUIT
         self._generate_register_commands()
+
+    def precmd(self, line: str) -> str:
+        """If the first token names a ``do_*`` handler, normalize it to lowercase.
+
+        So ``SET lr0 1`` dispatches to ``do_set`` like ``set lr0 1``, without using
+        the assembly parser.
+        """
+        stripped = line.strip()
+        if not stripped:
+            return line
+        parts = stripped.split(maxsplit=1)
+        verb = parts[0]
+        tail = parts[1] if len(parts) > 1 else ""
+        canon = verb.lower()
+        if hasattr(self, f"do_{canon}"):
+            return f"{canon} {tail}".rstrip() if tail else canon
+        return line
 
     def _generate_register_commands(self) -> None:
         """Auto-generate ``do_<name>`` methods for each register group."""

--- a/src/tools/ipu-emu-py/src/ipu_emu/execute.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/execute.py
@@ -14,8 +14,8 @@ An instruction is stored as a ``dict[str, int]`` whose keys match the
 C struct field names produced by ``CompoundInst.get_fields()``, e.g.::
 
     {
-        "break_inst_token_0_break_inst_opcode": 2,   # break_nop
-        "xmem_inst_token_0_xmem_inst_opcode": 4,     # xmem_nop
+        "break_inst_token_0_break_inst_opcode": 2,   # BREAK_NOP
+        "xmem_inst_token_0_xmem_inst_opcode": 4,     # XMEM_NOP
         ...
     }
 

--- a/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
@@ -509,8 +509,8 @@ class Ipu:
             field_map = _INSTRUCTION_FIELD_MAP[("lr", inst_name, slot_idx)]
             kwargs = {name: inst[field_key] for name, field_key in field_map.items()}
 
-            # Unfilled LR slots encode ``add lrX lrX 0`` (IMM5 0 → encoding 32): identity, no write.
-            if inst_name == "add":
+            # Unfilled LR slots encode ``ADD lrX lrX 0`` (IMM5 0 → encoding 32): identity, no write.
+            if inst_name == "ADD":
                 sb = kwargs.get("src_b")
                 if (
                     kwargs.get("dest") == kwargs.get("src_a")

--- a/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
@@ -389,13 +389,13 @@ class Ipu:
     # -----------------------------------------------------------------------
 
     def execute_xmem_nop(self) -> None:
-        """Execute xmem_nop: No operation."""
+        """Execute XMEM_NOP: No operation."""
         pass
 
     def execute_str_acc_reg(self, *, offset: int, base: int) -> None:
-        """Execute str_acc_reg: Store accumulator to memory (debug only)."""
+        """Execute STR_ACC_REG: Store accumulator to memory (debug only)."""
         warnings.warn(
-            "[DEBUG ONLY] str_acc_reg is not a hardware instruction and is available "
+            "[DEBUG ONLY] STR_ACC_REG is not a hardware instruction and is available "
             "for emulator debugging purposes only",
             stacklevel=2,
         )
@@ -404,10 +404,10 @@ class Ipu:
         self.state.xmem.write_address(addr, acc_data)
 
     def execute_ldr_mult_reg(self, *, dest: int, offset: int, base: int) -> None:
-        """Execute ldr_mult_reg: Load data from memory into a mult stage register."""
+        """Execute LDR_MULT_REG: Load data from memory into a mult stage register."""
         if dest not in (0, 1):
             raise EmulatorError(
-                f"ldr_mult_reg: dest must be 0 (r0) or 1 (r1); got {dest}"
+                f"LDR_MULT_REG: dest must be 0 (r0) or 1 (r1); got {dest}"
             )
         addr = offset + base
         if self._wide_vector_active():
@@ -427,7 +427,7 @@ class Ipu:
         self.state.regfile.set_register_bytes(reg_name, elem_idx, data)
 
     def execute_ldr_cyclic_mult_reg(self, *, offset: int, base: int, index: int) -> None:
-        """Execute ldr_cyclic_mult_reg: Load with cyclic addressing into r_cyclic."""
+        """Execute LDR_CYCLIC_MULT_REG: Load with cyclic addressing into r_cyclic."""
         addr = offset + base
         assert index % R_REG_SIZE == 0, (
             f"LR index for cyclic load must be aligned to {R_REG_SIZE}: got {index}"
@@ -445,7 +445,7 @@ class Ipu:
         self.state.regfile.set_r_cyclic_at(index, data)
 
     def execute_ldr_mult_mask_reg(self, *, offset: int, base: int) -> None:
-        """Execute ldr_mult_mask_reg: Load mask data from memory."""
+        """Execute LDR_MULT_MASK_REG: Load mask data from memory."""
         addr = offset + base
         data = self.state.xmem.read_address(addr, R_REG_SIZE)
         self.state.regfile.set_r_mask(data)
@@ -462,19 +462,19 @@ class Ipu:
         return value
 
     def execute_lr_set(self, *, reg: int, value: int) -> None:
-        """Execute set: Set a loop register to an immediate value."""
+        """Execute SET: Set a loop register to an immediate value."""
         self.state.regfile.set_lr(reg, self._sign_extend_16(value) & 0xFFFFFFFF)
 
     def execute_lr_add(self, *, dest: int, src_a: int, src_b: int) -> None:
-        """Execute add: uint32 ``dest = src_a + src_b`` (``src_b`` may be an immediate)."""
+        """Execute ADD: uint32 ``dest = src_a + src_b`` (``src_b`` may be an immediate)."""
         self.state.regfile.set_lr(dest, (src_a + src_b) & 0xFFFFFFFF)
 
     def execute_lr_sub(self, *, dest: int, src_a: int, src_b: int) -> None:
-        """Execute sub: uint32 ``dest = src_a - src_b`` (``src_b`` may be an immediate)."""
+        """Execute SUB: uint32 ``dest = src_a - src_b`` (``src_b`` may be an immediate)."""
         self.state.regfile.set_lr(dest, (src_a - src_b) & 0xFFFFFFFF)
 
     def execute_lr_incr_mod_pow2(self, *, dst: int, step: int, k: int) -> None:
-        """incr_mod_pow2: dst <- (dst + step) mod 2^k.
+        """INCR_MOD_POW2: dst <- (dst + step) mod 2^k.
 
         Old dst is taken from the cycle-start snapshot (read-before-write). Step is
         resolved from LcrIdx (snapshot), interpreted as uint32 like ``add``/``sub``.
@@ -483,7 +483,7 @@ class Ipu:
         assert self.snapshot is not None
         if k > LR_MOD_POW2_K_ENCODED_MAX:
             raise EmulatorError(
-                f"incr_mod_pow2: invalid k encoding {k} (max {LR_MOD_POW2_K_ENCODED_MAX})"
+                f"INCR_MOD_POW2: invalid k encoding {k} (max {LR_MOD_POW2_K_ENCODED_MAX})"
             )
         k_exp = k + LR_MOD_POW2_K_MIN
         cur = self.snapshot.get_lr(dst)
@@ -544,12 +544,12 @@ class Ipu:
     # -----------------------------------------------------------------------
 
     def execute_mult_nop(self) -> None:
-        """Execute mult_nop: No operation."""
+        """Execute MULT_NOP: No operation."""
         pass
 
     def execute_mult_ee(self, *, ra: bytearray | int, cyclic_offset: int,
                         mask_offset: int, mask_shift: int) -> None:
-        """Execute mult_ee: Element-wise multiplication."""
+        """Execute MULT.EE: Element-wise multiplication."""
         mult_res = self.state.regfile.raw("mult_res")
 
         if self._wide_vector_active():
@@ -650,7 +650,7 @@ class Ipu:
 
     def execute_mult_ve_cyclic(self, *, cyclic_offset: int,
                                mask_offset: int, mask_shift: int, fixed_idx: int) -> None:
-        """Execute mult.ve.cyclic: fixed R0/R1 element × RC row with cyclic addressing."""
+        """Execute MULT.VE.CYCLIC: fixed r0/r1 element × r_cyclic row with cyclic addressing."""
         self._execute_mult_ve_variant(
             pad_128_ones=False,
             cyclic_offset=cyclic_offset,
@@ -661,7 +661,7 @@ class Ipu:
 
     def execute_mult_ve_padded(self, *, cyclic_offset: int,
                                mask_offset: int, mask_shift: int, fixed_idx: int) -> None:
-        """Execute mult.ve.padded: fixed R0/R1 element × RC row with boundary padding."""
+        """Execute MULT.VE.PADDED: fixed r0/r1 element × r_cyclic row with boundary padding."""
         self._execute_mult_ve_variant(
             pad_128_ones=True,
             cyclic_offset=cyclic_offset,
@@ -672,7 +672,7 @@ class Ipu:
 
     def execute_mult_ve_cr(self, *, cyclic_offset: int, mask_offset: int,
                            mask_shift: int, cr_idx: int) -> None:
-        """Execute mult.ve.cr: CR scalar x RC elements with boundary padding.
+        """Execute MULT.VE.CR: CR scalar × r_cyclic elements with boundary padding.
 
         Multiplies the low byte of CR[cr_idx] against each byte of
         RC[cyclic_offset : cyclic_offset+128]. Like mult.ve.padded, this is
@@ -719,7 +719,7 @@ class Ipu:
 
     def execute_mult_ve_aaq(self, *, cyclic_offset: int, mask_offset: int,
                             mask_shift: int, aaq_rf_idx: int) -> None:
-        """Execute mult.ve.aaq: AAQ scalar x RC elements with boundary padding.
+        """Execute MULT.VE.AAQ: AAQ scalar × r_cyclic elements with boundary padding.
 
         Multiplies the low byte of AAQ[aaq_rf_idx] against each byte of
         RC[cyclic_offset : cyclic_offset+128]. Non-cyclic: elements where
@@ -768,15 +768,15 @@ class Ipu:
     # -----------------------------------------------------------------------
 
     def execute_acc_nop(self) -> None:
-        """Execute acc_nop: No operation."""
+        """Execute ACC_NOP: No operation."""
         pass
 
     def execute_reset_acc(self) -> None:
-        """Execute reset_acc: Reset accumulator to zero."""
+        """Execute RESET_ACC: Reset accumulator to zero."""
         self.state.regfile.set_r_acc_bytes(bytearray(R_ACC_SIZE))
 
     def execute_acc(self) -> None:
-        """Execute acc: Accumulate mult_res into accumulator."""
+        """Execute ACC: Accumulate mult_res into accumulator."""
         dtype = self.state.get_cr_dtype()
         acc_buf = self.state.regfile.raw("r_acc")
         mult_res = self.state.regfile.raw("mult_res")
@@ -793,7 +793,7 @@ class Ipu:
             struct.pack_into(fmt, acc_buf, i * 4, result)
 
     def execute_acc_first(self) -> None:
-        """Execute acc.first: Set r_acc to multiply result (no previous sum)."""
+        """Execute ACC.FIRST: Set r_acc to multiply result (no previous sum)."""
         dtype = self.state.get_cr_dtype()
         acc_buf = self.state.regfile.raw("r_acc")
         mult_res = self.state.regfile.raw("mult_res")
@@ -804,7 +804,7 @@ class Ipu:
             struct.pack_into(fmt, acc_buf, i * 4, mult_val)
 
     def execute_acc_add_aaq(self, *, aaq_rf_idx: int) -> None:
-        """Execute acc.add_aaq: Accumulate mult_res, then add aaq[aaq_rf_idx] to each of the 128 accumulator words."""
+        """Execute ACC.ADD_AAQ: Accumulate mult_res, then add aaq[aaq_rf_idx] to each of the 128 accumulator words."""
         dtype = self.state.get_cr_dtype()
         acc_buf = self.state.regfile.raw("r_acc")
         mult_res = self.state.regfile.raw("mult_res")
@@ -825,7 +825,7 @@ class Ipu:
             struct.pack_into(fmt, acc_buf, i * 4, result)
 
     def execute_acc_add_aaq_first(self, *, aaq_rf_idx: int) -> None:
-        """Execute acc.add_aaq.first: Set r_acc to mult_res + aaq[aaq_rf_idx] (no previous sum)."""
+        """Execute ACC.ADD_AAQ.FIRST: Set r_acc to mult_res + aaq[aaq_rf_idx] (no previous sum)."""
         dtype = self.state.get_cr_dtype()
         acc_buf = self.state.regfile.raw("r_acc")
         mult_res = self.state.regfile.raw("mult_res")
@@ -844,7 +844,7 @@ class Ipu:
             struct.pack_into(fmt, acc_buf, i * 4, result)
 
     def execute_acc_max(self, *, aaq_rf_idx: int) -> None:
-        """Execute acc.max: r_acc[i] = max(r_acc[i], mult_res[i], aaq_reg[aaq_rf_idx]).
+        """Execute ACC.MAX: r_acc[i] = max(r_acc[i], mult_res[i], aaq_reg[aaq_rf_idx]).
 
         All register values are interpreted as signed (int32 for INT8 dtype, float32 for FP8).
         """
@@ -863,7 +863,7 @@ class Ipu:
             struct.pack_into(fmt, acc_buf, i * 4, result)
 
     def execute_acc_max_first(self, *, aaq_rf_idx: int) -> None:
-        """Execute acc.max.first: r_acc[i] = max(mult_res[i], aaq_reg[aaq_rf_idx]). Previous r_acc ignored.
+        """Execute ACC.MAX.FIRST: r_acc[i] = max(mult_res[i], aaq_reg[aaq_rf_idx]). Previous r_acc ignored.
 
         All register values are interpreted as signed (int32 for INT8 dtype, float32 for FP8).
         """
@@ -887,7 +887,7 @@ class Ipu:
         vertical_stride: int,
         offset: int,
     ) -> None:
-        """Execute acc.stride: Decimate mult_res by horizontal/vertical stride and write into r_acc.
+        """Execute ACC.STRIDE: Decimate mult_res by horizontal/vertical stride and write into r_acc.
 
         Operand semantics from ipu_common.acc_stride_enums (single source of truth).
         offset: LR value; (offset % 4) * 32 is the start index in r_acc (0, 32, 64, or 96).
@@ -942,7 +942,7 @@ class Ipu:
             struct.pack_into(fmt, acc_buf, (base + i) * 4, val)
 
     def execute_aaq_nop(self) -> None:
-        """Execute aaq_nop: No operation for AAQ slot."""
+        """Execute AAQ_NOP: No operation for AAQ slot."""
         pass
 
     def _agg_active_lane_count(self, valid_elements: int) -> int:
@@ -994,7 +994,7 @@ class Ipu:
         cr_idx: int,
         aaq_rf_idx: int,
     ) -> None:
-        """Execute acc.agg: Collapse r_acc words to one value (SUM or MAX), apply post function, store to AAQ.
+        """Execute AGG: Collapse r_acc words to one value (SUM or MAX), apply post function, store to AAQ.
 
         For MAX, the current value of the target AAQ register is included in the max (no update if already max).
         Only the first ``valid_elements`` lanes (clamped to 128) participate in the tree.
@@ -1069,7 +1069,7 @@ class Ipu:
         cr_idx: int,
         aaq_rf_idx: int,
     ) -> None:
-        """Execute agg.first: like agg but for MAX mode ignores previous AAQ value."""
+        """Execute AGG.FIRST: like AGG but for MAX mode ignores previous AAQ value."""
         dtype = self.state.get_cr_dtype()
         fmt = self._acc_agg_lane_fmt()
         acc_buf = self.state.regfile.raw("r_acc")
@@ -1129,14 +1129,14 @@ class Ipu:
         self.state.regfile.set_aaq(aaq_rf_idx, self._wide_pack_aaq_bits(fmt, result_val))
 
     def execute_aaq(self) -> None:
-        """Execute aaq: Quantize r_acc (128 × INT32) → aaq_result (128 × INT8).
+        """Execute AAQ: Quantize r_acc (128 × INT32) → aaq_result (128 × INT8).
 
         Requires INT8 mode. Each 32-bit word is truncated (top 8 bits taken via
         arithmetic right-shift by 24) then clamped to [-128, 127] and stored as
         a signed byte in the aaq_result register.
 
         In wide-vector debug mode, ``aaq`` is normally a no-op (results stay in
-        ``r_acc`` as 32-bit lanes; use ``str_acc_reg`` to dump them). Set
+        ``r_acc`` as 32-bit lanes; use ``STR_ACC_REG`` to dump them). Set
         ``state.wide_vector_quantize_output`` to re-run INT8-style quantization
         from wide lanes for comparison with the real path.
         """
@@ -1173,7 +1173,7 @@ class Ipu:
         self.state.regfile.set_aaq_result(result)
 
     def execute_xmem_store_aaq_result(self, *, offset: int, base: int) -> None:
-        """Execute xmem.store_aaq_result: Write 128-byte aaq_result to xmem."""
+        """Execute XMEM.STORE_AAQ_RESULT: Write 128-byte aaq_result to xmem."""
         addr = offset + base
         data = self.state.regfile.get_aaq_result()
         self.state.xmem.write_address(addr, data)
@@ -1183,11 +1183,11 @@ class Ipu:
     # -----------------------------------------------------------------------
 
     def execute_beq(self, *, reg1: int, reg2: int, label: int) -> None:
-        """Execute beq: Branch if equal."""
+        """Execute BEQ: Branch if equal."""
         self.state.program_counter = label if reg1 == reg2 else self.state.program_counter + 1
 
     def execute_bne(self, *, reg1: int, reg2: int, label: int) -> None:
-        """Execute bne: Branch if not equal."""
+        """Execute BNE: Branch if not equal."""
         self.state.program_counter = label if reg1 != reg2 else self.state.program_counter + 1
 
     @staticmethod
@@ -1198,29 +1198,29 @@ class Ipu:
         return value
 
     def execute_blt(self, *, reg1: int, reg2: int, label: int) -> None:
-        """Execute blt: Branch if less than (signed comparison)."""
+        """Execute BLT: Branch if less than (signed comparison)."""
         s1 = self._to_signed_32(reg1)
         s2 = self._to_signed_32(reg2)
         self.state.program_counter = label if s1 < s2 else self.state.program_counter + 1
 
     def execute_bnz(self, *, test_reg: int, base_reg: int, label: int) -> None:
-        """Execute bnz: Branch if not zero."""
+        """Execute BNZ: Branch if not zero."""
         self.state.program_counter = label if test_reg != 0 else self.state.program_counter + 1
 
     def execute_bz(self, *, test_reg: int, base_reg: int, label: int) -> None:
-        """Execute bz: Branch if zero."""
+        """Execute BZ: Branch if zero."""
         self.state.program_counter = label if test_reg == 0 else self.state.program_counter + 1
 
     def execute_b(self, *, label: int) -> None:
-        """Execute b: Unconditional branch."""
+        """Execute B: Unconditional branch."""
         self.state.program_counter = label
 
     def execute_br(self, *, reg: int) -> None:
-        """Execute br: Branch to register value."""
+        """Execute BR: Branch to register value."""
         self.state.program_counter = reg
 
     def execute_bkpt(self) -> None:
-        """Execute bkpt: Breakpoint (halt execution)."""
+        """Execute BKPT: Breakpoint (halt execution)."""
         self.state.program_counter = INST_MEM_SIZE  # halt
 
     # -----------------------------------------------------------------------
@@ -1228,15 +1228,15 @@ class Ipu:
     # -----------------------------------------------------------------------
 
     def execute_break_nop(self) -> BreakResult:
-        """Execute break_nop: No operation."""
+        """Execute BREAK_NOP: No operation."""
         return BreakResult.CONTINUE
 
     def execute_break(self) -> BreakResult:
-        """Execute break: Unconditional break."""
+        """Execute BREAK: Unconditional break."""
         return BreakResult.BREAK
 
     def execute_break_ifeq(self, *, reg: int, value: int) -> BreakResult:
-        """Execute break_ifeq: Break if LR register equals immediate."""
+        """Execute BREAK.IFEQ: Break if LR register equals immediate."""
         if reg == value:
             return BreakResult.BREAK
         return BreakResult.CONTINUE

--- a/src/tools/ipu-emu-py/test/test_debug_cli.py
+++ b/src/tools/ipu-emu-py/test/test_debug_cli.py
@@ -188,7 +188,7 @@ class TestCLICommands:
 
     def test_set_lr(self):
         state = IpuState()
-        action, output = _run_cli(state, "SET lr7 0xFF\ncontinue\n")
+        action, output = _run_cli(state, "set lr7 0xFF\ncontinue\n")
         assert state.regfile.get_lr(7) == 0xFF
         assert "Set lr7" in output
 

--- a/src/tools/ipu-emu-py/test/test_debug_cli.py
+++ b/src/tools/ipu-emu-py/test/test_debug_cli.py
@@ -159,7 +159,7 @@ class TestCLICommands:
     def test_get_lr(self):
         state = IpuState()
         state.regfile.set_lr(5, 0xDEAD)
-        action, output = _run_cli(state, "get lr5\ncontinue\n")
+        action, output = _run_cli(state, "GET lr5\ncontinue\n")
         assert "0x0000dead" in output
 
     def test_get_cr(self):
@@ -188,7 +188,7 @@ class TestCLICommands:
 
     def test_set_lr(self):
         state = IpuState()
-        action, output = _run_cli(state, "set lr7 0xFF\ncontinue\n")
+        action, output = _run_cli(state, "SET lr7 0xFF\ncontinue\n")
         assert state.regfile.get_lr(7) == 0xFF
         assert "Set lr7" in output
 

--- a/src/tools/ipu-emu-py/test/test_debug_cli.py
+++ b/src/tools/ipu-emu-py/test/test_debug_cli.py
@@ -188,7 +188,7 @@ class TestCLICommands:
 
     def test_set_lr(self):
         state = IpuState()
-        action, output = _run_cli(state, "set lr7 0xFF\ncontinue\n")
+        action, output = _run_cli(state, "SET lr7 0xFF\ncontinue\n")
         assert state.regfile.get_lr(7) == 0xFF
         assert "Set lr7" in output
 
@@ -232,7 +232,7 @@ class TestDebugLevels:
         assert "42" in output
 
     def test_level1_shows_disasm(self):
-        state = _make_state_with_program("set lr0 100;;\nbkpt;;")
+        state = _make_state_with_program("SET lr0 100;;\nBKPT;;")
         action, output = _run_cli(state, "continue\n", level=1)
         assert "Current Instruction" in output
 
@@ -250,7 +250,7 @@ class TestDebugLevels:
 
 class TestDisassembly:
     def test_disasm_set_lr(self):
-        state = _make_state_with_program("set lr0 100;;\nbkpt;;")
+        state = _make_state_with_program("SET lr0 100;;\nBKPT;;")
         text = disassemble_current(state)
         assert "set" in text.lower()
         assert "lr0" in text.lower()

--- a/src/tools/ipu-emu-py/test/test_emulator_e2e.py
+++ b/src/tools/ipu-emu-py/test/test_emulator_e2e.py
@@ -168,8 +168,8 @@ class TestRunTest:
         """A program that immediately breaks should run in 1 cycle."""
         from ipu_as.lark_tree import assemble_to_bin_file
 
-        asm = "bkpt;;\n"
-        inst_path = tmp_path / "bkpt.bin"
+        asm = "BKPT;;\n"
+        inst_path = tmp_path / "BKPT.bin"
         assemble_to_bin_file(asm, str(inst_path))
 
         setup_called = [False]
@@ -189,15 +189,15 @@ class TestRunTest:
 
         assert setup_called[0]
         assert teardown_called[0]
-        # bkpt in run_until_complete skips the break, advances PC
+        # BKPT in run_until_complete skips the break, advances PC
         assert cycles >= 1
 
     def test_run_test_with_debug_callback(self, tmp_path: Path) -> None:
         """run_test with debug_callback should invoke it on break."""
         from ipu_as.lark_tree import assemble_to_bin_file
 
-        # Use a BREAK instruction (break slot) followed by bkpt (cond halt)
-        asm = "break;;\nbkpt;;\n"
+        # Use a BREAK instruction (break slot) followed by BKPT (cond halt)
+        asm = "BREAK;;\nBKPT;;\n"
         inst_path = tmp_path / "break.bin"
         assemble_to_bin_file(asm, str(inst_path))
 
@@ -226,12 +226,12 @@ class TestEndToEnd:
         """Assemble a trivial program, run it, verify register state."""
         from ipu_as.lark_tree import assemble_to_bin_file
 
-        # Simple program: set lr0 = 42, then breakpoint
-        asm = "set lr0 42;;\nbkpt;;\n"
+        # Simple program: SET lr0 = 42, then breakpoint
+        asm = "SET lr0 42;;\nBKPT;;\n"
         inst_path = tmp_path / "simple.bin"
         assemble_to_bin_file(asm, str(inst_path))
 
         state, cycles = run_test(inst_path=inst_path)
 
         assert state.regfile.get_lr(0) == 42
-        assert cycles >= 2  # set + bkpt
+        assert cycles >= 2  # set + BKPT

--- a/src/tools/ipu-emu-py/test/test_execute.py
+++ b/src/tools/ipu-emu-py/test/test_execute.py
@@ -55,16 +55,16 @@ def _run(asm_code: str, **kw) -> IpuState:
 
 class TestRegisterOperations:
     def test_set_lr(self):
-        state = _run("set lr13 0x1000;;\nbkpt;;")
+        state = _run("SET lr13 0x1000;;\nBKPT;;")
         assert state.regfile.get_lr(13) == 0x1000
 
     def test_add_imm_accumulates_lr(self):
         state = _run(
             """\
-set lr11 10;;
-add lr11 lr11 5;;
-add lr11 lr11 3;;
-bkpt;;
+SET lr11 10;;
+ADD lr11 lr11 5;;
+ADD lr11 lr11 3;;
+BKPT;;
 """
         )
         assert state.regfile.get_lr(11) == 18  # 10 + 5 + 3
@@ -81,10 +81,10 @@ bkpt;;
     def test_add_lr_lr(self):
         state = _run(
             """\
-set lr1 100;;
-set lr2 50;;
-add lr3 lr1 lr2;;
-bkpt;;
+SET lr1 100;;
+SET lr2 50;;
+ADD lr3 lr1 lr2;;
+BKPT;;
 """
         )
         assert state.regfile.get_lr(1) == 100
@@ -94,9 +94,9 @@ bkpt;;
     def test_add_lr_cr(self):
         state = _make_state(
             """\
-set lr1 200;;
-add lr4 lr1 cr5;;
-bkpt;;
+SET lr1 200;;
+ADD lr4 lr1 cr5;;
+BKPT;;
 """
         )
         state.regfile.set_cr(5, 75)
@@ -108,9 +108,9 @@ bkpt;;
     def test_add_lr_lr_imm5(self):
         state = _run(
             """\
-set lr1 200;;
-add lr4 lr1 11;;
-bkpt;;
+SET lr1 200;;
+ADD lr4 lr1 11;;
+BKPT;;
 """
         )
         assert state.regfile.get_lr(4) == 211
@@ -118,10 +118,10 @@ bkpt;;
     def test_sub_lr_lr(self):
         state = _run(
             """\
-set lr1 100;;
-set lr2 30;;
-sub lr3 lr1 lr2;;
-bkpt;;
+SET lr1 100;;
+SET lr2 30;;
+SUB lr3 lr1 lr2;;
+BKPT;;
 """
         )
         assert state.regfile.get_lr(3) == 70
@@ -129,9 +129,9 @@ bkpt;;
     def test_sub_lr_lr_cr(self):
         state = _make_state(
             """\
-set lr2 45;;
-sub lr5 lr2 cr3;;
-bkpt;;
+SET lr2 45;;
+SUB lr5 lr2 cr3;;
+BKPT;;
 """
         )
         state.regfile.set_cr(3, 200)
@@ -141,16 +141,16 @@ bkpt;;
     def test_sub_lr_lr_imm5(self):
         state = _run(
             """\
-set lr2 100;;
-sub lr3 lr2 30;;
-bkpt;;
+SET lr2 100;;
+SUB lr3 lr2 30;;
+BKPT;;
 """
         )
         assert state.regfile.get_lr(3) == 70
 
 
 # ============================================================================
-# incr_mod_pow2 (Issue #47): dst <- (dst + step) mod 2^k
+# INCR_MOD_POW2 (Issue #47): dst <- (dst + step) mod 2^k
 # ============================================================================
 
 
@@ -159,10 +159,10 @@ class TestIncrModPow2:
         """k=4 → mod 16; 15 + 1 wraps to 0."""
         state = _run(
             """\
-set lr0 15;;
-set lr1 1;;
-incr_mod_pow2 lr0 lr1 4;;
-bkpt;;
+SET lr0 15;;
+SET lr1 1;;
+INCR_MOD_POW2 lr0 lr1 4;;
+BKPT;;
 """
         )
         assert state.regfile.get_lr(0) == 0
@@ -171,10 +171,10 @@ bkpt;;
         """k=9 → mask 511; largest legal k from spec."""
         state = _run(
             """\
-set lr0 500;;
-set lr1 20;;
-incr_mod_pow2 lr0 lr1 9;;
-bkpt;;
+SET lr0 500;;
+SET lr1 20;;
+INCR_MOD_POW2 lr0 lr1 9;;
+BKPT;;
 """
         )
         assert state.regfile.get_lr(0) == (500 + 20) & 511
@@ -183,9 +183,9 @@ bkpt;;
         """dst and step both lr0: uses snapshot value of lr0 for the sum."""
         state = _run(
             """\
-set lr0 5;;
-incr_mod_pow2 lr0 lr0 3;;
-bkpt;;
+SET lr0 5;;
+INCR_MOD_POW2 lr0 lr0 3;;
+BKPT;;
 """
         )
         assert state.regfile.get_lr(0) == (5 + 5) & 7
@@ -193,9 +193,9 @@ bkpt;;
     def test_step_from_cr(self):
         state = _make_state(
             """\
-set lr0 2;;
-incr_mod_pow2 lr0 cr4 4;;
-bkpt;;
+SET lr0 2;;
+INCR_MOD_POW2 lr0 cr4 4;;
+BKPT;;
 """
         )
         state.regfile.set_cr(4, 10)
@@ -206,9 +206,9 @@ bkpt;;
         """Uint32 add before mask: step loaded from CR as full uint32."""
         state = _make_state(
             """\
-set lr0 3;;
-incr_mod_pow2 lr0 cr5 3;;
-bkpt;;
+SET lr0 3;;
+INCR_MOD_POW2 lr0 cr5 3;;
+BKPT;;
 """
         )
         state.regfile.set_cr(5, 0xFFFFFFFE)
@@ -217,15 +217,15 @@ bkpt;;
 
     def test_k_encoded_four_bits(self):
         """k operand uses 4 bits: semantic k=9 encodes as 8 in the instruction word."""
-        encoded = assemble("incr_mod_pow2 lr0 lr1 9;; bkpt;;")
+        encoded = assemble("INCR_MOD_POW2 lr0 lr1 9;; BKPT;;")
         d = decode_instruction_word(encoded[0])
         assert d["lr_inst_0_token_6_lr_mod_pow2_k_immediate"] == 8
 
     def test_assembler_rejects_k_out_of_range(self):
-        with pytest.raises(ValueError, match=r"incr_mod_pow2 k operand"):
-            CompoundInst(parse("incr_mod_pow2 lr0 lr1 0;;")[0])
-        with pytest.raises(ValueError, match=r"incr_mod_pow2 k operand"):
-            CompoundInst(parse("incr_mod_pow2 lr0 lr1 10;;")[0])
+        with pytest.raises(ValueError, match=r"INCR_MOD_POW2 k operand"):
+            CompoundInst(parse("INCR_MOD_POW2 lr0 lr1 0;;")[0])
+        with pytest.raises(ValueError, match=r"INCR_MOD_POW2 k operand"):
+            CompoundInst(parse("INCR_MOD_POW2 lr0 lr1 10;;")[0])
 
 
 # ============================================================================
@@ -238,8 +238,8 @@ class TestThreeLrSlots:
         """Three independent LR ops may execute in the same cycle."""
         state = _run(
             """\
-set lr0 1; set lr1 2; set lr2 3;;
-bkpt;;
+SET lr0 1; SET lr1 2; SET lr2 3;;
+BKPT;;
 """
         )
         assert state.regfile.get_lr(0) == 1
@@ -250,13 +250,13 @@ bkpt;;
         from ipu_as.compound_inst import CompoundInst
         from ipu_as.lark_tree import parse
 
-        ast = parse("set lr0 1; set lr1 2; set lr2 3; set lr3 4;;")
+        ast = parse("SET lr0 1; SET lr1 2; SET lr2 3; SET lr3 4;;")
         with pytest.raises(ValueError, match="Too many instructions of type LrInst"):
             CompoundInst(ast[0])
 
     def test_decode_three_lr_sub_slots(self):
         """Assemble → decode exposes lr_inst_0, lr_inst_1, lr_inst_2."""
-        encoded = assemble("set lr4 10; set lr5 20; set lr6 30;;\nbkpt;;")
+        encoded = assemble("SET lr4 10; SET lr5 20; SET lr6 30;;\nBKPT;;")
         assert len(encoded) == 2
         d = decode_instruction_word(encoded[0])
         assert d["lr_inst_0_token_0_lr_inst_opcode"] == 0  # set
@@ -272,7 +272,7 @@ bkpt;;
 
     def test_decode_add_imm_operand_field(self):
         """``add`` third operand uses AddSubSrcBField; IMM5 encodes as 32 + value."""
-        encoded = assemble("add lr2 lr1 7;; bkpt;;")
+        encoded = assemble("ADD lr2 lr1 7;; BKPT;;")
         d = decode_instruction_word(encoded[0])
         assert d["lr_inst_0_token_0_lr_inst_opcode"] == 1  # add
         assert d["lr_inst_0_token_1_lr_reg_field"] == 2  # dest
@@ -290,9 +290,9 @@ class TestMemoryOperations:
         test_data = bytes(range(128))
         state = _make_state(
             """\
-set lr13 0x1000;;
-ldr_mult_reg r1 lr13 cr0;;
-bkpt;;
+SET lr13 0x1000;;
+LDR_MULT_REG r1 lr13 cr0;;
+BKPT;;
 """
         )
         state.xmem.write_address(0x1000, test_data)
@@ -303,23 +303,23 @@ bkpt;;
         assert r1_data == bytearray(test_data)
 
     def test_store_to_memory(self):
-        """INT8: r1=all-2, cyclic=all-3, mult.ee → acc should be 6 per word."""
+        """INT8: r1=all-2, cyclic=all-3, MULT.EE → acc should be 6 per word."""
         r1_data = bytes([2] * 128)
         cyclic_data = bytes([3] * 512)
 
         state = _make_state(
             """\
-set lr13 0x1000;;
-ldr_mult_reg r1 lr13 cr0;;
-set lr14 0x2000;;
-set lr15 0;;
-ldr_cyclic_mult_reg lr14 cr0 lr15;;
-reset_acc;;
-mult.ee r1 lr0 0 lr0;
-acc;;
-set lr0 0x3000;;
-str_acc_reg lr0 cr0;;
-bkpt;;
+SET lr13 0x1000;;
+LDR_MULT_REG r1 lr13 cr0;;
+SET lr14 0x2000;;
+SET lr15 0;;
+LDR_CYCLIC_MULT_REG lr14 cr0 lr15;;
+RESET_ACC;;
+MULT.EE r1 lr0 0 lr0;
+ACC;;
+SET lr0 0x3000;;
+STR_ACC_REG lr0 cr0;;
+BKPT;;
 """
         )
         state.xmem.write_address(0x1000, r1_data)
@@ -335,10 +335,10 @@ bkpt;;
         cyclic_data = bytes([(i * 2) & 0xFF for i in range(128)])
         state = _make_state(
             """\
-set lr0 0x5000;;
-set lr1 0;;
-ldr_cyclic_mult_reg lr0 cr0 lr1;;
-bkpt;;
+SET lr0 0x5000;;
+SET lr1 0;;
+LDR_CYCLIC_MULT_REG lr0 cr0 lr1;;
+BKPT;;
 """
         )
         state.xmem.write_address(0x5000, cyclic_data)
@@ -352,9 +352,9 @@ bkpt;;
         mask_data = bytes([(i + 1) & 0xFF for i in range(128)])
         state = _make_state(
             """\
-set lr0 0x6000;;
-ldr_mult_mask_reg lr0 cr0;;
-bkpt;;
+SET lr0 0x6000;;
+LDR_MULT_MASK_REG lr0 cr0;;
+BKPT;;
 """
         )
         state.xmem.write_address(0x6000, mask_data)
@@ -375,21 +375,21 @@ bkpt;;
 
         state = _make_state(
             """\
-set lr0 0x1000;;
-ldr_mult_reg r0 lr0 cr0;;
-set lr1 0x2000;;
-set lr2 0;;
-ldr_cyclic_mult_reg lr1 cr0 lr2;;
-set lr3 0x3000;;
-ldr_mult_mask_reg lr3 cr0;;
-reset_acc;;
-set lr5 0;;
-set lr6 0;;
-mult.ee r0 lr6 0 lr5;
-acc;;
-set lr9 0x4000;;
-str_acc_reg lr9 cr0;;
-bkpt;;
+SET lr0 0x1000;;
+LDR_MULT_REG r0 lr0 cr0;;
+SET lr1 0x2000;;
+SET lr2 0;;
+LDR_CYCLIC_MULT_REG lr1 cr0 lr2;;
+SET lr3 0x3000;;
+LDR_MULT_MASK_REG lr3 cr0;;
+RESET_ACC;;
+SET lr5 0;;
+SET lr6 0;;
+MULT.EE r0 lr6 0 lr5;
+ACC;;
+SET lr9 0x4000;;
+STR_ACC_REG lr9 cr0;;
+BKPT;;
 """
         )
         state.xmem.write_address(0x1000, r0_data)
@@ -415,21 +415,21 @@ bkpt;;
 
         state = _make_state(
             """\
-set lr0 0x1000;;
-ldr_mult_reg r0 lr0 cr0;;
-set lr1 0x2000;;
-set lr2 0;;
-ldr_cyclic_mult_reg lr1 cr0 lr2;;
-set lr3 0x3000;;
-ldr_mult_mask_reg lr3 cr0;;
-reset_acc;;
-set lr5 16;;
-set lr6 0;;
-mult.ee r0 lr6 1 lr5;
-acc;;
-set lr9 0x4000;;
-str_acc_reg lr9 cr0;;
-bkpt;;
+SET lr0 0x1000;;
+LDR_MULT_REG r0 lr0 cr0;;
+SET lr1 0x2000;;
+SET lr2 0;;
+LDR_CYCLIC_MULT_REG lr1 cr0 lr2;;
+SET lr3 0x3000;;
+LDR_MULT_MASK_REG lr3 cr0;;
+RESET_ACC;;
+SET lr5 16;;
+SET lr6 0;;
+MULT.EE r0 lr6 1 lr5;
+ACC;;
+SET lr9 0x4000;;
+STR_ACC_REG lr9 cr0;;
+BKPT;;
 """
         )
         state.xmem.write_address(0x1000, r0_data)
@@ -456,12 +456,12 @@ class TestControlFlow:
     def test_unconditional_branch(self):
         state = _run(
             """\
-set lr0 1;;
+SET lr0 1;;
 b skip_section;;
-set lr0 2;;
+SET lr0 2;;
 skip_section:
-set lr1 3;;
-bkpt;;
+SET lr1 3;;
+BKPT;;
 """
         )
         assert state.regfile.get_lr(0) == 1
@@ -470,14 +470,14 @@ bkpt;;
     def test_bne(self):
         state = _run(
             """\
-set lr0 10;;
-set lr1 20;;
-bne lr0 lr1 not_equal_branch;;
-set lr2 0;;
-bkpt;;
+SET lr0 10;;
+SET lr1 20;;
+BNE lr0 lr1 not_equal_branch;;
+SET lr2 0;;
+BKPT;;
 not_equal_branch:
-set lr2 1;;
-bkpt;;
+SET lr2 1;;
+BKPT;;
 """
         )
         assert state.regfile.get_lr(2) == 1
@@ -485,14 +485,14 @@ bkpt;;
     def test_beq(self):
         state = _run(
             """\
-set lr0 42;;
-set lr1 42;;
-beq lr0 lr1 equal_branch;;
-set lr2 0;;
-bkpt;;
+SET lr0 42;;
+SET lr1 42;;
+BEQ lr0 lr1 equal_branch;;
+SET lr2 0;;
+BKPT;;
 equal_branch:
-set lr2 1;;
-bkpt;;
+SET lr2 1;;
+BKPT;;
 """
         )
         assert state.regfile.get_lr(2) == 1
@@ -500,14 +500,14 @@ bkpt;;
     def test_blt(self):
         state = _run(
             """\
-set lr0 5;;
-set lr1 6;;
-blt lr0 lr1 less_branch;;
-set lr2 0;;
-bkpt;;
+SET lr0 5;;
+SET lr1 6;;
+BLT lr0 lr1 less_branch;;
+SET lr2 0;;
+BKPT;;
 less_branch:
-set lr2 1;;
-bkpt;;
+SET lr2 1;;
+BKPT;;
 """
         )
         assert state.regfile.get_lr(2) == 1
@@ -515,13 +515,13 @@ bkpt;;
     def test_bnz(self):
         state = _run(
             """\
-set lr0 1;;
-bnz lr0 lr0 nonzero_branch;;
-set lr2 0;;
-bkpt;;
+SET lr0 1;;
+BNZ lr0 lr0 nonzero_branch;;
+SET lr2 0;;
+BKPT;;
 nonzero_branch:
-set lr2 1;;
-bkpt;;
+SET lr2 1;;
+BKPT;;
 """
         )
         assert state.regfile.get_lr(2) == 1
@@ -529,13 +529,13 @@ bkpt;;
     def test_bz(self):
         state = _run(
             """\
-set lr0 0;;
-bz lr0 lr0 zero_branch;;
-set lr2 0;;
-bkpt;;
+SET lr0 0;;
+BZ lr0 lr0 zero_branch;;
+SET lr2 0;;
+BKPT;;
 zero_branch:
-set lr2 1;;
-bkpt;;
+SET lr2 1;;
+BKPT;;
 """
         )
         assert state.regfile.get_lr(2) == 1
@@ -544,13 +544,13 @@ bkpt;;
         """bne branches when LR does not equal a CR constant."""
         state = _make_state(
             """\
-set lr0 10;;
-bne lr0 cr1 bne_cr_branch;;
-set lr2 0;;
-bkpt;;
+SET lr0 10;;
+BNE lr0 cr1 bne_cr_branch;;
+SET lr2 0;;
+BKPT;;
 bne_cr_branch:
-set lr2 1;;
-bkpt;;
+SET lr2 1;;
+BKPT;;
 """
         )
         state.regfile.set_cr(1, 20)
@@ -561,13 +561,13 @@ bkpt;;
         """beq branches when LR equals a CR constant."""
         state = _make_state(
             """\
-set lr0 42;;
-beq lr0 cr3 beq_cr_branch;;
-set lr2 0;;
-bkpt;;
+SET lr0 42;;
+BEQ lr0 cr3 beq_cr_branch;;
+SET lr2 0;;
+BKPT;;
 beq_cr_branch:
-set lr2 1;;
-bkpt;;
+SET lr2 1;;
+BKPT;;
 """
         )
         state.regfile.set_cr(3, 42)
@@ -578,13 +578,13 @@ bkpt;;
         """blt branches when LR is less than a CR constant."""
         state = _make_state(
             """\
-set lr0 5;;
-blt lr0 cr2 blt_cr_branch;;
-set lr2 0;;
-bkpt;;
+SET lr0 5;;
+BLT lr0 cr2 blt_cr_branch;;
+SET lr2 0;;
+BKPT;;
 blt_cr_branch:
-set lr2 1;;
-bkpt;;
+SET lr2 1;;
+BKPT;;
 """
         )
         state.regfile.set_cr(2, 10)
@@ -595,13 +595,13 @@ bkpt;;
         """bnz branches when test_reg is not zero (CR as base_reg)."""
         state = _make_state(
             """\
-set lr0 5;;
-bnz lr0 cr0 bnz_cr_branch;;
-set lr2 0;;
-bkpt;;
+SET lr0 5;;
+BNZ lr0 cr0 bnz_cr_branch;;
+SET lr2 0;;
+BKPT;;
 bnz_cr_branch:
-set lr2 1;;
-bkpt;;
+SET lr2 1;;
+BKPT;;
 """
         )
         state.regfile.set_cr(0, 0)
@@ -612,13 +612,13 @@ bkpt;;
         """bz branches when test_reg is zero (CR as base_reg)."""
         state = _make_state(
             """\
-set lr0 0;;
-bz lr0 cr0 bz_cr_branch;;
-set lr2 0;;
-bkpt;;
+SET lr0 0;;
+BZ lr0 cr0 bz_cr_branch;;
+SET lr2 0;;
+BKPT;;
 bz_cr_branch:
-set lr2 1;;
-bkpt;;
+SET lr2 1;;
+BKPT;;
 """
         )
         state.regfile.set_cr(0, 0)
@@ -629,11 +629,11 @@ bkpt;;
         """Loop using bne against a CR constant instead of an LR."""
         state = _make_state(
             """\
-set lr0 0;;
+SET lr0 0;;
 cr_loop_start:
-add lr0 lr0 1;;
-bne lr0 cr5 cr_loop_start;;
-bkpt;;
+ADD lr0 lr0 1;;
+BNE lr0 cr5 cr_loop_start;;
+BKPT;;
 """
         )
         state.regfile.set_cr(5, 10)
@@ -643,39 +643,39 @@ bkpt;;
     def test_simple_loop(self):
         state = _run(
             """\
-set lr0 0;;
-set lr1 10;;
-set lr2 0;;
+SET lr0 0;;
+SET lr1 10;;
+SET lr2 0;;
 loop_start:
-add lr0 lr0 1;;
-bne lr0 lr1 loop_start;;
-bkpt;;
+ADD lr0 lr0 1;;
+BNE lr0 lr1 loop_start;;
+BKPT;;
 """,
             max_cycles=1000,
         )
         assert state.regfile.get_lr(0) == 10
 
-    def test_bkpt_halts(self):
+    def test_BKPT_halts(self):
         state = _run(
             """\
-set lr0 99;;
-bkpt;;
-set lr0 0;;
+SET lr0 99;;
+BKPT;;
+SET lr0 0;;
 """
         )
-        # bkpt sets PC = INST_MEM_SIZE, so `set lr0 0` is never reached
+        # BKPT sets PC = INST_MEM_SIZE, so `SET lr0 0` is never reached
         assert state.regfile.get_lr(0) == 99
 
     def test_br_cr(self):
         """br accepts a CR register as the branch target address."""
         state = _make_state(
             """\
-br cr0;;
-set lr0 0;;
-bkpt;;
+BR cr0;;
+SET lr0 0;;
+BKPT;;
 br_cr_target:
-set lr0 1;;
-bkpt;;
+SET lr0 1;;
+BKPT;;
 """
         )
         from ipu_as.label import ipu_labels
@@ -694,7 +694,7 @@ bkpt;;
 
 class TestAccumulator:
     def test_reset(self):
-        state = _make_state("reset_acc;;\nbkpt;;")
+        state = _make_state("RESET_ACC;;\nBKPT;;")
         # Pre-fill acc words with non-zero
         for i in range(128):
             state.regfile.set_r_acc_word(i, 12345)
@@ -703,12 +703,12 @@ class TestAccumulator:
             assert state.regfile.get_r_acc_word(i) == 0
 
     def test_acc_add_aaq(self):
-        """acc.add_aaq adds the selected AAQ register (32-bit) to each of the 128 accumulator words."""
+        """ACC.ADD_AAQ adds the selected AAQ register (32-bit) to each of the 128 accumulator words."""
         state = _make_state(
             """\
-reset_acc;;
-acc.add_aaq aaq1;;
-bkpt;;
+RESET_ACC;;
+ACC.ADD_AAQ aaq1;;
+BKPT;;
 """
         )
         # INT8 dtype (cr15 = 0)
@@ -728,15 +728,15 @@ bkpt;;
             assert w == 102, f"word {i}: expected 102, got {w}"
 
     def test_acc_first(self):
-        """acc.first sets r_acc to mult_res without adding previous r_acc."""
+        """ACC.FIRST sets r_acc to mult_res without adding previous r_acc."""
         state = _make_state(
             """\
-acc.first;;
-bkpt;;
+ACC.FIRST;;
+BKPT;;
 """
         )
         state.regfile.set_cr(15, DType.INT8)
-        # Pre-fill acc with garbage; acc.first should ignore it
+        # Pre-fill acc with garbage; ACC.FIRST should ignore it
         for i in range(128):
             state.regfile.set_r_acc_word(i, 9999)
         mult_buf = state.regfile.raw("mult_res")
@@ -747,11 +747,11 @@ bkpt;;
             assert state.regfile.get_r_acc_word(i) == 7, f"word {i}: expected 7, got {state.regfile.get_r_acc_word(i)}"
 
     def test_acc_add_aaq_first(self):
-        """acc.add_aaq.first sets r_acc to mult_res + aaq (no previous sum)."""
+        """ACC.ADD_AAQ.FIRST sets r_acc to mult_res + aaq (no previous sum)."""
         state = _make_state(
             """\
-acc.add_aaq.first aaq2;;
-bkpt;;
+ACC.ADD_AAQ.FIRST aaq2;;
+BKPT;;
 """
         )
         state.regfile.set_cr(15, DType.INT8)
@@ -767,11 +767,11 @@ bkpt;;
             assert w == 13, f"word {i}: expected 13 (3+10), got {w}"
 
     def test_acc_max(self):
-        """acc.max sets r_acc[i] = max(r_acc[i], mult_res[i], aaq_reg)."""
+        """ACC.MAX sets r_acc[i] = max(r_acc[i], mult_res[i], aaq_reg)."""
         state = _make_state(
             """\
-acc.max aaq1;;
-bkpt;;
+ACC.MAX aaq1;;
+BKPT;;
 """
         )
         state.regfile.set_cr(15, DType.INT8)
@@ -788,11 +788,11 @@ bkpt;;
             assert w == 3, f"word {i}: expected max(1,2,3)=3, got {w}"
 
     def test_acc_max_signed(self):
-        """acc.max treats register values as signed int32; negative values compare correctly."""
+        """ACC.MAX treats register values as signed int32; negative values compare correctly."""
         state = _make_state(
             """\
-acc.max aaq0;;
-bkpt;;
+ACC.MAX aaq0;;
+BKPT;;
 """
         )
         state.regfile.set_cr(15, DType.INT8)
@@ -810,11 +810,11 @@ bkpt;;
             assert val == 5, f"word {i}: expected max(-10, 2, 5)=5 (signed), got {val}"
 
     def test_acc_max_first(self):
-        """acc.max.first sets r_acc[i] = max(mult_res[i], aaq_reg); previous r_acc ignored."""
+        """ACC.MAX.FIRST sets r_acc[i] = max(mult_res[i], aaq_reg); previous r_acc ignored."""
         state = _make_state(
             """\
-acc.max.first aaq0;;
-bkpt;;
+ACC.MAX.FIRST aaq0;;
+BKPT;;
 """
         )
         state.regfile.set_cr(15, DType.INT8)
@@ -830,12 +830,12 @@ bkpt;;
             assert w == 10, f"word {i}: expected max(5,10)=10, got {w}"
 
     def test_acc_stride_no_stride(self):
-        """acc.stride with both strides off copies all 128 mult_res words to r_acc from start 0."""
+        """ACC.STRIDE with both strides off copies all 128 mult_res words to r_acc from start 0."""
         state = _make_state(
             """\
-set lr0 0;;
-acc.stride 8 off off lr0;;
-bkpt;;
+SET lr0 0;;
+ACC.STRIDE 8 off off lr0;;
+BKPT;;
 """
         )
         state.regfile.set_cr(15, DType.INT8)
@@ -848,12 +848,12 @@ bkpt;;
             assert w == i, f"word {i}: expected {i}, got {w}"
 
     def test_acc_stride_horizontal_no_expand(self):
-        """acc.stride with horizontal on, no expand: take every 2nd column → 64 elements at r_acc[0:64]."""
+        """ACC.STRIDE with horizontal on, no expand: take every 2nd column → 64 elements at r_acc[0:64]."""
         state = _make_state(
             """\
-set lr0 0;;
-acc.stride 8 on off lr0;;
-bkpt;;
+SET lr0 0;;
+ACC.STRIDE 8 on off lr0;;
+BKPT;;
 """
         )
         state.regfile.set_cr(15, DType.INT8)
@@ -870,12 +870,12 @@ bkpt;;
             assert w == expected, f"out[{out_i}]: expected {expected}, got {w}"
 
     def test_acc_stride_offset(self):
-        """acc.stride with offset: (lr0 % 4)*32 is start index; 64 elements written at r_acc[32:96]."""
+        """ACC.STRIDE with offset: (lr0 % 4)*32 is start index; 64 elements written at r_acc[32:96]."""
         state = _make_state(
             """\
-set lr0 1;;
-acc.stride 8 on off lr0;;
-bkpt;;
+SET lr0 1;;
+ACC.STRIDE 8 on off lr0;;
+BKPT;;
 """
         )
         # lr0=1 → offset % 4 = 1 → start index 32. Horizontal on, no expand → 64 elements.
@@ -906,7 +906,7 @@ bkpt;;
         state = _make_state(
             """\
 agg sum value lr1 cr0 aaq0;;
-bkpt;;
+BKPT;;
 """
         )
         state.regfile.set_cr(15, DType.INT8)
@@ -927,7 +927,7 @@ bkpt;;
         state = _make_state(
             """\
 agg max value lr1 cr0 aaq1;;
-bkpt;;
+BKPT;;
 """
         )
         state.regfile.set_cr(15, DType.INT8)
@@ -947,7 +947,7 @@ bkpt;;
         state = _make_state(
             """\
 agg max value lr1 cr0 aaq0;;
-bkpt;;
+BKPT;;
 """
         )
         state.regfile.set_cr(15, DType.INT8)
@@ -967,7 +967,7 @@ bkpt;;
         state = _make_state(
             """\
 agg sum value_cr lr1 cr1 aaq2;;
-bkpt;;
+BKPT;;
 """
         )
         state.regfile.set_cr(15, DType.INT8)
@@ -988,7 +988,7 @@ bkpt;;
         state = _make_state(
             """\
 agg.first max value lr1 cr0 aaq0;;
-bkpt;;
+BKPT;;
 """
         )
         state.regfile.set_cr(15, DType.INT8)
@@ -1009,7 +1009,7 @@ bkpt;;
         state = _make_state(
             """\
 agg.first max value lr1 cr0 aaq1;;
-bkpt;;
+BKPT;;
 """
         )
         state.regfile.set_cr(15, DType.INT8)
@@ -1029,7 +1029,7 @@ bkpt;;
         state = _make_state(
             """\
 agg.first sum value lr1 cr0 aaq2;;
-bkpt;;
+BKPT;;
 """
         )
         state.regfile.set_cr(15, DType.INT8)
@@ -1049,7 +1049,7 @@ bkpt;;
         state = _make_state(
             """\
 agg sum value lr1 cr0 aaq0;;
-bkpt;;
+BKPT;;
 """
         )
         state.regfile.set_cr(15, DType.INT8)
@@ -1068,7 +1068,7 @@ bkpt;;
         state = _make_state(
             """\
 agg sum value cr2 cr0 aaq0;;
-bkpt;;
+BKPT;;
 """
         )
         state.regfile.set_cr(15, DType.INT8)
@@ -1087,7 +1087,7 @@ bkpt;;
         state = _make_state(
             """\
 agg max value lr1 cr0 aaq0;;
-bkpt;;
+BKPT;;
 """
         )
         state.regfile.set_cr(15, DType.INT8)
@@ -1106,7 +1106,7 @@ bkpt;;
         state = _make_state(
             """\
 agg.first max value lr1 cr0 aaq0;;
-bkpt;;
+BKPT;;
 """
         )
         state.regfile.set_cr(15, DType.INT8)
@@ -1128,9 +1128,9 @@ class TestProgramCounter:
 
         state = _make_state(
             """\
-set lr0 100;;
-set lr1 200;;
-bkpt;;
+SET lr0 100;;
+SET lr1 200;;
+BKPT;;
 """
         )
         assert state.program_counter == 0
@@ -1151,10 +1151,10 @@ class TestBreakpoints:
 
         state = _make_state(
             """\
-set lr0 1;;
-break;;
-set lr0 2;;
-bkpt;;
+SET lr0 1;;
+BREAK;;
+SET lr0 2;;
+BKPT;;
 """
         )
         r = execute_next_instruction(state)
@@ -1169,12 +1169,12 @@ bkpt;;
 
         state = _make_state(
             """\
-set lr5 42;;
-break.ifeq lr5 42;;
-bkpt;;
+SET lr5 42;;
+BREAK.IFEQ lr5 42;;
+BKPT;;
 """
         )
-        execute_next_instruction(state)  # set lr5 42
+        execute_next_instruction(state)  # SET lr5 42
         assert state.regfile.get_lr(5) == 42
 
         r = execute_next_instruction(state)
@@ -1185,9 +1185,9 @@ bkpt;;
 
         state = _make_state(
             """\
-set lr5 10;;
-break.ifeq lr5 42;;
-bkpt;;
+SET lr5 10;;
+BREAK.IFEQ lr5 42;;
+BKPT;;
 """
         )
         execute_next_instruction(state)
@@ -1202,9 +1202,9 @@ bkpt;;
 
         state = _make_state(
             """\
-break;;
-set lr0 1;;
-bkpt;;
+BREAK;;
+SET lr0 1;;
+BKPT;;
 """
         )
         run_with_debug(state, callback)
@@ -1225,7 +1225,7 @@ class TestDecodeRoundtrip:
 
     def test_roundtrip(self):
         """Assemble → decode → verify known fields."""
-        encoded = assemble("set lr13 0x1000;;\nbkpt;;")
+        encoded = assemble("SET lr13 0x1000;;\nBKPT;;")
         assert len(encoded) == 2
         d = decode_instruction_word(encoded[0])
         # LR opcode should be 'set' = index 0
@@ -1253,17 +1253,17 @@ class TestFp8:
 
         state = _make_state(
             """\
-set lr0 0x1000;;
-ldr_mult_reg r0 lr0 cr0;;
-set lr1 0x2000;;
-set lr2 0;;
-ldr_cyclic_mult_reg lr1 cr0 lr2;;
-reset_acc;;
-set lr5 0;;
-set lr6 0;;
-mult.ee r0 lr6 0 lr5;
-acc;;
-bkpt;;
+SET lr0 0x1000;;
+LDR_MULT_REG r0 lr0 cr0;;
+SET lr1 0x2000;;
+SET lr2 0;;
+LDR_CYCLIC_MULT_REG lr1 cr0 lr2;;
+RESET_ACC;;
+SET lr5 0;;
+SET lr6 0;;
+MULT.EE r0 lr6 0 lr5;
+ACC;;
+BKPT;;
 """
         )
         # Set dtype to E4 (fp8_e4)
@@ -1280,33 +1280,33 @@ bkpt;;
 
 
 # ============================================================================
-# mult.ve.cr and mult.ve.aaq
+# MULT.VE.CR and MULT.VE.AAQ
 # ============================================================================
 
 
 class TestMultVeCrAaq:
-    """Tests for mult.ve.cr and mult.ve.aaq instructions."""
+    """Tests for MULT.VE.CR and MULT.VE.AAQ instructions."""
 
     # ------------------------------------------------------------------
-    # mult.ve.cr
+    # MULT.VE.CR
     # ------------------------------------------------------------------
 
     def test_mult_ve_cr_int8(self):
-        """mult.ve.cr INT8: scalar from CR × RC elements."""
+        """MULT.VE.CR INT8: scalar from CR × RC elements."""
         # CR scalar byte = 3, RC elements = all 2 → each result = 3*2 = 6
         cyclic_data = bytes([2] * 512)
 
         state = _make_state(
             """\
-set lr0 0x1000;;
-set lr1 0;;
-ldr_cyclic_mult_reg lr0 cr0 lr1;;
-reset_acc;;
-set lr2 0;;
-set lr4 0;;
-mult.ve.cr lr2 0 lr4 cr1;
-acc;;
-bkpt;;
+SET lr0 0x1000;;
+SET lr1 0;;
+LDR_CYCLIC_MULT_REG lr0 cr0 lr1;;
+RESET_ACC;;
+SET lr2 0;;
+SET lr4 0;;
+MULT.VE.CR lr2 0 lr4 cr1;
+ACC;;
+BKPT;;
 """
         )
         state.regfile.set_cr(15, DType.INT8)
@@ -1320,21 +1320,21 @@ bkpt;;
             assert val == 6, f"acc word {i}: expected 6, got {val}"
 
     def test_mult_ve_cr_negative_int8(self):
-        """mult.ve.cr INT8: signed negative scalar × positive RC elements."""
+        """MULT.VE.CR INT8: signed negative scalar × positive RC elements."""
         # CR scalar byte = 0xFE = -2 (signed int8), RC elements = 5 → result = -10
         cyclic_data = bytes([5] * 512)
 
         state = _make_state(
             """\
-set lr0 0x1000;;
-set lr1 0;;
-ldr_cyclic_mult_reg lr0 cr0 lr1;;
-reset_acc;;
-set lr2 0;;
-set lr4 0;;
-mult.ve.cr lr2 0 lr4 cr2;
-acc;;
-bkpt;;
+SET lr0 0x1000;;
+SET lr1 0;;
+LDR_CYCLIC_MULT_REG lr0 cr0 lr1;;
+RESET_ACC;;
+SET lr2 0;;
+SET lr4 0;;
+MULT.VE.CR lr2 0 lr4 cr2;
+ACC;;
+BKPT;;
 """
         )
         state.regfile.set_cr(15, DType.INT8)
@@ -1348,7 +1348,7 @@ bkpt;;
             assert val == -10, f"acc word {i}: expected -10, got {val}"
 
     def test_mult_ve_cr_boundary_padding(self):
-        """mult.ve.cr: elements beyond RC boundary (512 bytes) are padded with int8 1."""
+        """MULT.VE.CR: elements beyond RC boundary (512 bytes) are padded with int8 1."""
         # cyclic_offset = 450, so first 62 bytes come from RC, remaining 66 are padded with 1
         rc_fill = 4  # RC filled with 4
         scalar = 7
@@ -1356,12 +1356,12 @@ bkpt;;
 
         state = _make_state(
             """\
-reset_acc;;
-set lr2 450;;
-set lr4 0;;
-mult.ve.cr lr2 0 lr4 cr3;
-acc;;
-bkpt;;
+RESET_ACC;;
+SET lr2 450;;
+SET lr4 0;;
+MULT.VE.CR lr2 0 lr4 cr3;
+ACC;;
+BKPT;;
 """
         )
         state.regfile.set_cr(15, DType.INT8)
@@ -1379,7 +1379,7 @@ bkpt;;
             assert val == scalar * 1, f"word {i} (padded): expected {scalar}, got {val}"
 
     def test_mult_ve_cr_fp8e4m3(self):
-        """mult.ve.cr fp8_e4: scalar 1.0 × RC elements 1.0 → result 1.0 each."""
+        """MULT.VE.CR fp8_e4: scalar 1.0 × RC elements 1.0 → result 1.0 each."""
         from ipu_emu.ipu_math import _float32_to_fp8_scalar
 
         one_fp8 = _float32_to_fp8_scalar(1.0, 4)
@@ -1387,15 +1387,15 @@ bkpt;;
 
         state = _make_state(
             """\
-set lr0 0x1000;;
-set lr1 0;;
-ldr_cyclic_mult_reg lr0 cr0 lr1;;
-reset_acc;;
-set lr2 0;;
-set lr4 0;;
-mult.ve.cr lr2 0 lr4 cr5;
-acc;;
-bkpt;;
+SET lr0 0x1000;;
+SET lr1 0;;
+LDR_CYCLIC_MULT_REG lr0 cr0 lr1;;
+RESET_ACC;;
+SET lr2 0;;
+SET lr4 0;;
+MULT.VE.CR lr2 0 lr4 cr5;
+ACC;;
+BKPT;;
 """
         )
         state.regfile.set_cr(15, DType.E4)
@@ -1409,7 +1409,7 @@ bkpt;;
             assert abs(val - 1.0) < 0.01, f"acc word {i}: expected 1.0, got {val}"
 
     def test_mult_ve_cr_boundary_padding_fp8e5m2(self):
-        """mult.ve.cr fp8_e5: boundary elements padded with FP8 1.0."""
+        """MULT.VE.CR fp8_e5: boundary elements padded with FP8 1.0."""
         from ipu_emu.ipu_math import _float32_to_fp8_scalar
 
         two_fp8 = _float32_to_fp8_scalar(2.0, 5)
@@ -1417,12 +1417,12 @@ bkpt;;
 
         state = _make_state(
             """\
-reset_acc;;
-set lr2 500;;
-set lr4 0;;
-mult.ve.cr lr2 0 lr4 cr6;
-acc;;
-bkpt;;
+RESET_ACC;;
+SET lr2 500;;
+SET lr4 0;;
+MULT.VE.CR lr2 0 lr4 cr6;
+ACC;;
+BKPT;;
 """
         )
         state.regfile.set_cr(15, DType.E5)
@@ -1440,25 +1440,25 @@ bkpt;;
             assert abs(val - 3.0) < 0.1, f"word {i} (padded): expected 3.0, got {val}"
 
     # ------------------------------------------------------------------
-    # mult.ve.aaq
+    # MULT.VE.AAQ
     # ------------------------------------------------------------------
 
     def test_mult_ve_aaq_int8(self):
-        """mult.ve.aaq INT8: scalar from AAQ × RC elements."""
+        """MULT.VE.AAQ INT8: scalar from AAQ × RC elements."""
         # AAQ scalar byte = 5, RC elements = all 3 → each result = 15
         cyclic_data = bytes([3] * 512)
 
         state = _make_state(
             """\
-set lr0 0x1000;;
-set lr1 0;;
-ldr_cyclic_mult_reg lr0 cr0 lr1;;
-reset_acc;;
-set lr2 0;;
-set lr4 0;;
-mult.ve.aaq lr2 0 lr4 aaq0;
-acc;;
-bkpt;;
+SET lr0 0x1000;;
+SET lr1 0;;
+LDR_CYCLIC_MULT_REG lr0 cr0 lr1;;
+RESET_ACC;;
+SET lr2 0;;
+SET lr4 0;;
+MULT.VE.AAQ lr2 0 lr4 aaq0;
+ACC;;
+BKPT;;
 """
         )
         state.regfile.set_cr(15, DType.INT8)
@@ -1472,18 +1472,18 @@ bkpt;;
             assert val == 15, f"acc word {i}: expected 15, got {val}"
 
     def test_mult_ve_aaq_boundary_padding(self):
-        """mult.ve.aaq: elements beyond RC boundary are padded with int8 1."""
+        """MULT.VE.AAQ: elements beyond RC boundary are padded with int8 1."""
         scalar = 2
         in_bounds = 112  # offset=400, 512-400=112 in bounds, 16 padded
 
         state = _make_state(
             """\
-reset_acc;;
-set lr2 400;;
-set lr4 0;;
-mult.ve.aaq lr2 0 lr4 aaq1;
-acc;;
-bkpt;;
+RESET_ACC;;
+SET lr2 400;;
+SET lr4 0;;
+MULT.VE.AAQ lr2 0 lr4 aaq1;
+ACC;;
+BKPT;;
 """
         )
         state.regfile.set_cr(15, DType.INT8)
@@ -1501,21 +1501,21 @@ bkpt;;
             assert val == scalar * 1, f"word {i} (padded): expected {scalar}, got {val}"
 
     def test_mult_ve_aaq_no_boundary(self):
-        """mult.ve.aaq: when cyclic_offset+128 <= 512, no padding applied."""
+        """MULT.VE.AAQ: when cyclic_offset+128 <= 512, no padding applied."""
         cyclic_data = bytes([7] * 512)
         scalar = 3
 
         state = _make_state(
             """\
-set lr0 0x1000;;
-set lr1 0;;
-ldr_cyclic_mult_reg lr0 cr0 lr1;;
-reset_acc;;
-set lr2 0;;
-set lr4 0;;
-mult.ve.aaq lr2 0 lr4 aaq2;
-acc;;
-bkpt;;
+SET lr0 0x1000;;
+SET lr1 0;;
+LDR_CYCLIC_MULT_REG lr0 cr0 lr1;;
+RESET_ACC;;
+SET lr2 0;;
+SET lr4 0;;
+MULT.VE.AAQ lr2 0 lr4 aaq2;
+ACC;;
+BKPT;;
 """
         )
         state.regfile.set_cr(15, DType.INT8)
@@ -1533,21 +1533,21 @@ bkpt;;
     # ------------------------------------------------------------------
 
     def test_backward_compat_mult_ee(self):
-        """mult.ee still works correctly after adding new mult variants."""
+        """MULT.EE still works correctly after adding new mult variants."""
         r0_data = bytes([4] * 128)
         cyclic_data = bytes([5] * 512)
 
         state = _make_state(
             """\
-set lr0 0x1000;;
-ldr_mult_reg r0 lr0 cr0;;
-set lr1 0x2000;;
-set lr2 0;;
-ldr_cyclic_mult_reg lr1 cr0 lr2;;
-reset_acc;;
-mult.ee r0 lr2 0 lr2;
-acc;;
-bkpt;;
+SET lr0 0x1000;;
+LDR_MULT_REG r0 lr0 cr0;;
+SET lr1 0x2000;;
+SET lr2 0;;
+LDR_CYCLIC_MULT_REG lr1 cr0 lr2;;
+RESET_ACC;;
+MULT.EE r0 lr2 0 lr2;
+ACC;;
+BKPT;;
 """
         )
         state.regfile.set_cr(15, DType.INT8)
@@ -1561,7 +1561,7 @@ bkpt;;
             assert val == 20, f"acc word {i}: expected 20, got {val}"
 
     def test_backward_compat_mult_ve(self):
-        """mult.ve.cyclic still works correctly after adding new mult variants."""
+        """MULT.VE.CYCLIC still works correctly after adding new mult variants."""
         cyclic_data = bytes([6] * 512)
         r0_data = bytes([0] * 128)
         r0_data = bytearray(r0_data)
@@ -1569,15 +1569,15 @@ bkpt;;
 
         state = _make_state(
             """\
-set lr0 0x1000;;
-ldr_mult_reg r0 lr0 cr0;;
-set lr1 0x2000;;
-set lr2 0;;
-ldr_cyclic_mult_reg lr1 cr0 lr2;;
-reset_acc;;
-mult.ve.cyclic lr2 0 lr2 lr2;
-acc;;
-bkpt;;
+SET lr0 0x1000;;
+LDR_MULT_REG r0 lr0 cr0;;
+SET lr1 0x2000;;
+SET lr2 0;;
+LDR_CYCLIC_MULT_REG lr1 cr0 lr2;;
+RESET_ACC;;
+MULT.VE.CYCLIC lr2 0 lr2 lr2;
+ACC;;
+BKPT;;
 """
         )
         state.regfile.set_cr(15, DType.INT8)
@@ -1591,7 +1591,7 @@ bkpt;;
             assert val == 18, f"acc word {i}: expected 18, got {val}"
 
     def test_mult_ve_cyclic_wrap_at_rc_boundary(self):
-        """mult.ve.cyclic: RC indices wrap modulo 512."""
+        """MULT.VE.CYCLIC: RC indices wrap modulo 512."""
         # cyclic_offset = 450, so without wrap we'd read past 512; with wrap, bytes
         # 450..511 then 0..65 of RC are used — all rc_fill.
         rc_fill = 4
@@ -1602,15 +1602,15 @@ bkpt;;
 
         state = _make_state(
             """\
-set lr0 0x1000;;
-ldr_mult_reg r0 lr0 cr0;;
-reset_acc;;
-set lr2 450;;
-set lr4 0;;
-set lr5 0;;
-mult.ve.cyclic lr2 0 lr4 lr5;
-acc;;
-bkpt;;
+SET lr0 0x1000;;
+LDR_MULT_REG r0 lr0 cr0;;
+RESET_ACC;;
+SET lr2 450;;
+SET lr4 0;;
+SET lr5 0;;
+MULT.VE.CYCLIC lr2 0 lr4 lr5;
+ACC;;
+BKPT;;
 """
         )
         state.regfile.set_cr(15, DType.INT8)
@@ -1624,7 +1624,7 @@ bkpt;;
             assert val == scalar * rc_fill, f"word {i}: expected {scalar * rc_fill}, got {val}"
 
     def test_mult_ve_padded_boundary(self):
-        """mult.ve.padded: elements past RC byte 511 use dtype 1."""
+        """MULT.VE.PADDED: elements past RC byte 511 use dtype 1."""
         rc_fill = 4
         scalar = 5
         pad_start = 62  # 512 - 450 = 62 elements in bounds before padding
@@ -1634,15 +1634,15 @@ bkpt;;
 
         state = _make_state(
             """\
-set lr0 0x1000;;
-ldr_mult_reg r0 lr0 cr0;;
-reset_acc;;
-set lr2 450;;
-set lr4 0;;
-set lr5 0;;
-mult.ve.padded lr2 0 lr4 lr5;
-acc;;
-bkpt;;
+SET lr0 0x1000;;
+LDR_MULT_REG r0 lr0 cr0;;
+RESET_ACC;;
+SET lr2 450;;
+SET lr4 0;;
+SET lr5 0;;
+MULT.VE.PADDED lr2 0 lr4 lr5;
+ACC;;
+BKPT;;
 """
         )
         state.regfile.set_cr(15, DType.INT8)
@@ -1659,7 +1659,7 @@ bkpt;;
             assert val == scalar * 1, f"word {i} (padded): expected {scalar}, got {val}"
 
     def test_mult_ve_r1_scalar(self):
-        """mult.ve.cyclic: fixed_idx in [128, 255] addresses R1[fixed_idx - 128] instead of R0."""
+        """MULT.VE.CYCLIC: fixed_idx in [128, 255] addresses R1[fixed_idx - 128] instead of R0."""
         r0_data = bytearray(128)  # all zeros — must not be picked
         r1_data = bytearray(128)
         r1_data[0] = 7  # fixed_idx=128 → r1[0] = 7
@@ -1667,18 +1667,18 @@ bkpt;;
 
         state = _make_state(
             """\
-set lr0 0x1000;;
-ldr_mult_reg r0 lr0 cr0;;
-set lr0 0x1100;;
-ldr_mult_reg r1 lr0 cr0;;
-set lr1 0x2000;;
-set lr2 0;;
-ldr_cyclic_mult_reg lr1 cr0 lr2;;
-reset_acc;;
-set lr3 128;;
-mult.ve.cyclic lr2 0 lr2 lr3;
-acc;;
-bkpt;;
+SET lr0 0x1000;;
+LDR_MULT_REG r0 lr0 cr0;;
+SET lr0 0x1100;;
+LDR_MULT_REG r1 lr0 cr0;;
+SET lr1 0x2000;;
+SET lr2 0;;
+LDR_CYCLIC_MULT_REG lr1 cr0 lr2;;
+RESET_ACC;;
+SET lr3 128;;
+MULT.VE.CYCLIC lr2 0 lr2 lr3;
+ACC;;
+BKPT;;
 """
         )
         state.regfile.set_cr(15, DType.INT8)
@@ -1713,7 +1713,7 @@ class TestAaqQuantize:
         state.regfile.set_cr(15, DType.INT8)
         self._set_acc_words(state, [i << 24 for i in range(128)])
 
-        encoded = assemble("aaq;;\nbkpt;;")
+        encoded = assemble("aaq;;\nBKPT;;")
         from ipu_emu.execute import decode_instruction_word
         from ipu_emu.emulator import load_program, run_until_complete
         decoded = [decode_instruction_word(w) for w in encoded]
@@ -1731,7 +1731,7 @@ class TestAaqQuantize:
         state.regfile.set_cr(15, DType.INT8)
         self._set_acc_words(state, [0] * 128)
 
-        encoded = assemble("aaq;;\nbkpt;;")
+        encoded = assemble("aaq;;\nBKPT;;")
         from ipu_emu.execute import decode_instruction_word
         from ipu_emu.emulator import load_program, run_until_complete
         decoded = [decode_instruction_word(w) for w in encoded]
@@ -1749,7 +1749,7 @@ class TestAaqQuantize:
         values = [0x7F000000] * 64 + [0x7FFFFFFF] * 64
         self._set_acc_words(state, values)
 
-        encoded = assemble("aaq;;\nbkpt;;")
+        encoded = assemble("aaq;;\nBKPT;;")
         from ipu_emu.execute import decode_instruction_word
         from ipu_emu.emulator import load_program, run_until_complete
         decoded = [decode_instruction_word(w) for w in encoded]
@@ -1769,7 +1769,7 @@ class TestAaqQuantize:
         state.regfile.set_cr(15, DType.INT8)
         self._set_acc_words(state, [(-1) << 24] * 128)
 
-        encoded = assemble("aaq;;\nbkpt;;")
+        encoded = assemble("aaq;;\nBKPT;;")
         from ipu_emu.execute import decode_instruction_word
         from ipu_emu.emulator import load_program, run_until_complete
         decoded = [decode_instruction_word(w) for w in encoded]
@@ -1783,7 +1783,7 @@ class TestAaqQuantize:
     def test_aaq_requires_int8_mode(self):
         """aaq raises EmulatorError when not in INT8 mode."""
         from ipu_emu.ipu import EmulatorError
-        state = _make_state("aaq;;\nbkpt;;")
+        state = _make_state("aaq;;\nBKPT;;")
         state.set_cr_dtype(DType.E4)
         with pytest.raises(EmulatorError, match="INT8 mode"):
             run_until_complete(state)
@@ -1798,9 +1798,9 @@ class TestAaqQuantize:
         encoded = assemble(
             """\
 aaq;;
-set lr0 0x4000;;
+SET lr0 0x4000;;
 xmem.store_aaq_result lr0 cr0;;
-bkpt;;
+BKPT;;
 """
         )
         from ipu_emu.execute import decode_instruction_word
@@ -1813,12 +1813,12 @@ bkpt;;
         for i in range(128):
             assert stored[i] == i, f"xmem byte {i}: expected {i}, got {stored[i]}"
 
-    def test_str_acc_reg_emits_warning(self):
-        """str_acc_reg emits a UserWarning about being debug-only."""
+    def test_STR_ACC_REG_emits_warning(self):
+        """STR_ACC_REG emits a UserWarning about being debug-only."""
         state = IpuState()
         state.regfile.set_cr(15, DType.INT8)
 
-        encoded = assemble("str_acc_reg lr0 cr0;;\nbkpt;;")
+        encoded = assemble("STR_ACC_REG lr0 cr0;;\nBKPT;;")
         from ipu_emu.execute import decode_instruction_word
         from ipu_emu.emulator import load_program, run_until_complete
         decoded = [decode_instruction_word(w) for w in encoded]

--- a/src/tools/ipu-emu-py/test/test_wide_vector_debug.py
+++ b/src/tools/ipu-emu-py/test/test_wide_vector_debug.py
@@ -1,7 +1,7 @@
 """Wide-vector debug mode (GitHub issue #33).
 
 XMEM transfer sizes stay architectural (128-byte loads for r in normal mode);
-in wide-vector mode ``ldr_mult_reg`` / ``ldr_cyclic_mult_reg`` consume 512 bytes
+in wide-vector mode ``LDR_MULT_REG`` / ``LDR_CYCLIC_MULT_REG`` consume 512 bytes
 per transfer as 128×32-bit lanes. LR/CR are unchanged.
 """
 
@@ -49,15 +49,15 @@ class TestWideVectorFp32:
         state.xmem.write_address(0x1000, r0)
         state.xmem.write_address(0x2000, rc)
         asm = """\
-set lr0 0x1000;;
-set lr1 0x2000;;
-set lr2 0;;
-ldr_mult_reg r0 lr0 cr0;;
-ldr_cyclic_mult_reg lr1 cr0 lr2;;
-reset_acc;;
-mult.ee r0 lr2 0 lr2;;
+SET lr0 0x1000;;
+SET lr1 0x2000;;
+SET lr2 0;;
+LDR_MULT_REG r0 lr0 cr0;;
+LDR_CYCLIC_MULT_REG lr1 cr0 lr2;;
+RESET_ACC;;
+MULT.EE r0 lr2 0 lr2;;
 acc.first;;
-bkpt;;
+BKPT;;
 """
         encoded = assemble(asm)
         load_program(state, [decode_instruction_word(w) for w in encoded])
@@ -70,16 +70,16 @@ bkpt;;
     def test_aaq_noop_unless_quantize_flag(self) -> None:
         state = _run_wide(
             """\
-set lr0 0x1000;;
-set lr1 0x2000;;
-set lr2 0;;
-ldr_mult_reg r0 lr0 cr0;;
-ldr_cyclic_mult_reg lr1 cr0 lr2;;
-reset_acc;;
-mult.ee r0 lr2 0 lr2;;
+SET lr0 0x1000;;
+SET lr1 0x2000;;
+SET lr2 0;;
+LDR_MULT_REG r0 lr0 cr0;;
+LDR_CYCLIC_MULT_REG lr1 cr0 lr2;;
+RESET_ACC;;
+MULT.EE r0 lr2 0 lr2;;
 acc.first;;
 aaq;;
-bkpt;;
+BKPT;;
 """,
         )
         assert state.regfile.get_aaq_result() == bytearray(128)
@@ -97,16 +97,16 @@ bkpt;;
         state.xmem.write_address(0x1000, r0)
         state.xmem.write_address(0x2000, rc)
         asm = """\
-set lr0 0x1000;;
-set lr1 0x2000;;
-set lr2 0;;
-ldr_mult_reg r0 lr0 cr0;;
-ldr_cyclic_mult_reg lr1 cr0 lr2;;
-reset_acc;;
-mult.ee r0 lr2 0 lr2;;
+SET lr0 0x1000;;
+SET lr1 0x2000;;
+SET lr2 0;;
+LDR_MULT_REG r0 lr0 cr0;;
+LDR_CYCLIC_MULT_REG lr1 cr0 lr2;;
+RESET_ACC;;
+MULT.EE r0 lr2 0 lr2;;
 acc.first;;
 aaq;;
-bkpt;;
+BKPT;;
 """
         encoded = assemble(asm)
         load_program(state, [decode_instruction_word(w) for w in encoded])
@@ -124,15 +124,15 @@ class TestWideVectorInt32:
         state.xmem.write_address(0x1000, r0)
         state.xmem.write_address(0x2000, rc)
         asm = """\
-set lr0 0x1000;;
-set lr1 0x2000;;
-set lr2 0;;
-ldr_mult_reg r0 lr0 cr0;;
-ldr_cyclic_mult_reg lr1 cr0 lr2;;
-reset_acc;;
-mult.ee r0 lr2 0 lr2;;
+SET lr0 0x1000;;
+SET lr1 0x2000;;
+SET lr2 0;;
+LDR_MULT_REG r0 lr0 cr0;;
+LDR_CYCLIC_MULT_REG lr1 cr0 lr2;;
+RESET_ACC;;
+MULT.EE r0 lr2 0 lr2;;
 acc.first;;
-bkpt;;
+BKPT;;
 """
         encoded = assemble(asm)
         load_program(state, [decode_instruction_word(w) for w in encoded])
@@ -161,17 +161,17 @@ class TestWideVectorR0R1Isolation:
             st.xmem.write_address(0x1100, r1)
             st.xmem.write_address(0x2000, rc)
             asm = f"""\
-set lr0 0x1000;;
-set lr1 0x1100;;
-set lr2 0x2000;;
-set lr3 0;;
-ldr_mult_reg r0 lr0 cr0;;
-ldr_mult_reg r1 lr1 cr0;;
-ldr_cyclic_mult_reg lr2 cr0 lr3;;
-reset_acc;;
-mult.ee {which} lr3 0 lr3;;
+SET lr0 0x1000;;
+SET lr1 0x1100;;
+SET lr2 0x2000;;
+SET lr3 0;;
+LDR_MULT_REG r0 lr0 cr0;;
+LDR_MULT_REG r1 lr1 cr0;;
+LDR_CYCLIC_MULT_REG lr2 cr0 lr3;;
+RESET_ACC;;
+MULT.EE {which} lr3 0 lr3;;
 acc.first;;
-bkpt;;
+BKPT;;
 """
             encoded = assemble(asm)
             load_program(st, [decode_instruction_word(w) for w in encoded])
@@ -183,7 +183,7 @@ bkpt;;
 
 
 class TestWideVectorCyclicIndex:
-    """``ldr_cyclic_mult_reg`` must honour ``index`` in wide mode (512-byte chunk)."""
+    """``LDR_CYCLIC_MULT_REG`` must honour ``index`` in wide mode (512-byte chunk)."""
 
     def test_ldr_cyclic_nonzero_index_fp32(self) -> None:
         zeros = struct.pack("<128f", *([0.0] * 128))
@@ -195,19 +195,19 @@ class TestWideVectorCyclicIndex:
         st.xmem.write_address(0x2200, nines)
         st.xmem.write_address(0x1000, twos)
         asm = """\
-set lr0 0x2000;;
-set lr1 0;;
-ldr_cyclic_mult_reg lr0 cr0 lr1;;
-set lr2 0x2200;;
-set lr3 512;;
-ldr_cyclic_mult_reg lr2 cr0 lr3;;
-set lr4 0x1000;;
-ldr_mult_reg r0 lr4 cr0;;
-set lr5 512;;
-reset_acc;;
-mult.ee r0 lr5 0 lr5;;
+SET lr0 0x2000;;
+SET lr1 0;;
+LDR_CYCLIC_MULT_REG lr0 cr0 lr1;;
+SET lr2 0x2200;;
+SET lr3 512;;
+LDR_CYCLIC_MULT_REG lr2 cr0 lr3;;
+SET lr4 0x1000;;
+LDR_MULT_REG r0 lr4 cr0;;
+SET lr5 512;;
+RESET_ACC;;
+MULT.EE r0 lr5 0 lr5;;
 acc.first;;
-bkpt;;
+BKPT;;
 """
         encoded = assemble(asm)
         load_program(st, [decode_instruction_word(w) for w in encoded])
@@ -230,12 +230,12 @@ class TestWideVectorPadding:
         st.regfile.set_cr(1, 2)  # low byte 2 → scalar 2.0 in wide FP32 path
         st.regfile.set_r_cyclic_at(0, buf)
         asm = """\
-set lr0 384;;
-set lr2 0;;
-mult.ve.cr lr0 0 lr2 cr1;;
-reset_acc;;
+SET lr0 384;;
+SET lr2 0;;
+MULT.VE.CR lr0 0 lr2 cr1;;
+RESET_ACC;;
 acc.first;;
-bkpt;;
+BKPT;;
 """
         encoded = assemble(asm)
         load_program(st, [decode_instruction_word(w) for w in encoded])
@@ -247,7 +247,7 @@ bkpt;;
             assert struct.unpack_from("<f", mult_res, i * 4)[0] == pytest.approx(2.0), f"lane {i}"
 
     def test_mult_ve_fp32_wide_cyclic_past_boundary(self) -> None:
-        """mult.ve.cyclic (wide FP32): RC lanes wrap at 512 bytes."""
+        """MULT.VE.CYCLIC (wide FP32): RC lanes wrap at 512 bytes."""
         buf = bytearray(512)
         for k in range(32):
             struct.pack_into("<f", buf, 384 + k * 4, 3.0)
@@ -259,15 +259,15 @@ bkpt;;
         st.regfile.set_r_cyclic_at(0, buf)
         st.xmem.write_address(0x1000, struct.pack("<128f", *([2.0] * 128)))
         asm = """\
-set lr4 0x1000;;
-ldr_mult_reg r0 lr4 cr0;;
-set lr0 384;;
-set lr2 0;;
-set lr3 0;;
-mult.ve.cyclic lr0 0 lr2 lr3;;
-reset_acc;;
+SET lr4 0x1000;;
+LDR_MULT_REG r0 lr4 cr0;;
+SET lr0 384;;
+SET lr2 0;;
+SET lr3 0;;
+MULT.VE.CYCLIC lr0 0 lr2 lr3;;
+RESET_ACC;;
 acc.first;;
-bkpt;;
+BKPT;;
 """
         encoded = assemble(asm)
         load_program(st, [decode_instruction_word(w) for w in encoded])
@@ -279,7 +279,7 @@ bkpt;;
             assert struct.unpack_from("<f", mult_res, i * 4)[0] == pytest.approx(10.0), f"lane {i}"
 
     def test_mult_ve_fp32_wide_padded_past_boundary(self) -> None:
-        """mult.ve.padded (wide FP32): lanes past byte 511 use ×1."""
+        """MULT.VE.PADDED (wide FP32): lanes past byte 511 use ×1."""
         buf = bytearray(512)
         for k in range(32):
             struct.pack_into("<f", buf, 384 + k * 4, 3.0)
@@ -291,15 +291,15 @@ bkpt;;
         st.regfile.set_r_cyclic_at(0, buf)
         st.xmem.write_address(0x1000, struct.pack("<128f", *([2.0] * 128)))
         asm = """\
-set lr4 0x1000;;
-ldr_mult_reg r0 lr4 cr0;;
-set lr0 384;;
-set lr2 0;;
-set lr3 0;;
-mult.ve.padded lr0 0 lr2 lr3;;
-reset_acc;;
+SET lr4 0x1000;;
+LDR_MULT_REG r0 lr4 cr0;;
+SET lr0 384;;
+SET lr2 0;;
+SET lr3 0;;
+MULT.VE.PADDED lr0 0 lr2 lr3;;
+RESET_ACC;;
 acc.first;;
-bkpt;;
+BKPT;;
 """
         encoded = assemble(asm)
         load_program(st, [decode_instruction_word(w) for w in encoded])
@@ -322,7 +322,7 @@ class TestWideVectorAggInt32:
         st.regfile.set_lr(1, 128)
         asm = """\
 agg sum inv lr1 cr0 aaq0;;
-bkpt;;
+BKPT;;
 """
         encoded = assemble(asm)
         load_program(st, [decode_instruction_word(w) for w in encoded])
@@ -337,15 +337,15 @@ class TestWideVectorAlignment:
         st.xmem.write_address(0x1000, struct.pack("<128f", *([1.0] * 128)))
         st.xmem.write_address(0x2000, struct.pack("<128f", *([2.0] * 128)))
         asm = """\
-set lr0 0x1000;;
-set lr1 0x2000;;
-set lr2 0;;
-ldr_mult_reg r0 lr0 cr0;;
-ldr_cyclic_mult_reg lr1 cr0 lr2;;
-set lr3 1;;
-reset_acc;;
-mult.ee r0 lr3 0 lr3;;
-bkpt;;
+SET lr0 0x1000;;
+SET lr1 0x2000;;
+SET lr2 0;;
+LDR_MULT_REG r0 lr0 cr0;;
+LDR_CYCLIC_MULT_REG lr1 cr0 lr2;;
+SET lr3 1;;
+RESET_ACC;;
+MULT.EE r0 lr3 0 lr3;;
+BKPT;;
 """
         encoded = assemble(asm)
         load_program(st, [decode_instruction_word(w) for w in encoded])


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This change applies a single naming convention across Markdown docs, generated-doc sources (`gen_docs.py`), `instruction_spec.py` metadata (including `InstructionDoc.syntax` / examples), emulator handler docstrings, the fully-connected sample ASM, and test assembly strings.

**Convention**

- Instruction mnemonics are written in **upper case** (including dotted names such as `MULT.EE`, `XMEM.STORE_AAQ_RESULT`).
- Operand **names** and register tokens in documentation stay **lower case** (`dest`, `lr0`, `r0`), including pseudo-code where practical.

**Compatibility**

`INSTRUCTION_SPEC` instruction **keys** are now upper case. Slot-type keys (`xmem`, `acc`, `break`, …) remain lower case. Assembly parsing accepts mnemonics in any case via case-insensitive opcode validation and `canonical_instruction_name()` for spec lookups.

**Also**

- `Inst` opcode routing uses encoded opcode indices so struct tables stay aligned with `enum_array()` order.
- Error text for out-of-range `INCR_MOD_POW2` **k** operands uses the upper-case mnemonic for consistency.

**CI / behaviour fixes**

1. **`_dispatch_lr_slots`**: compare `inst_name == "ADD"` (canonical names from `get_instruction_by_opcode`).
2. **Debug CLI vs assembler**: they are **not** the same API — assembly goes through Lark/`instruction_spec`; the debugger uses `cmd.Cmd` `do_*` handlers. **`DebugCLI.precmd`** now lowercases the first token when a matching `do_*` exists, so **`SET` / `GET`** work like uppercase mnemonics without parsing assembly.

Tests: `pytest` under `ipu-emu-py/test` (205 tests) passes locally with `PYTHONPATH` set.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-159b5398-79dc-4f84-a494-27e7452fc638"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-159b5398-79dc-4f84-a494-27e7452fc638"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

