### PR TITLE
Issue #77: Configure activation α on IpuState (no CR)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -93,10 +93,10 @@ LDR_MULT_REG R0, LR0, CR0; MULT.EE R0, LR1, 0, LR3; ACC; ADD LR0, LR0, 1; BNE LR
 
 | Slot | Instructions | Purpose |
 |------|-------------|---------|
-| XMEM | `LDR_MULT_REG`, `STR_ACC_REG`, `LDR_CYCLIC_MULT_REG`, … | Memory load/store |
+| XMEM | `LDR_MULT_REG`, `STR_ACC_REG`, `STR_POST_AAQ_REG`, `LDR_CYCLIC_MULT_REG`, … | Memory load/store |
 | MULT | `MULT.EE`, `MULT.VE.CYCLIC`, `MULT.VE.PADDED`, `MULT.VE.CR`, `MULT.VE.AAQ`, … | 8-bit vector multiply |
 | ACC | `ACC`, `ACC.STRIDE`, `ACC.MAX`, `ACC.MAX.FIRST`, `RESET_ACC` | Accumulate into `R_ACC` |
-| AAQ | `AGG` / `AGG.FIRST` (sum/max + post-fn + `valid_elements` mask), `AAQ`, `ACTIVATE` | Aggregate / quantize `R_ACC`; `ACTIVATE` is a Python-emulator AAQ-slot aid (see `docs/content/building-applications.md#activations-emulator`) |
+| AAQ | `AGG` / `AGG.FIRST` (sum/max + post-fn + `valid_elements` mask), `AAQ`, `ACTIVATE` | Aggregate / quantize `R_ACC`; `AAQ` → **`POST_AAQ_REG`**; **`STR_POST_AAQ_REG`** (XMEM) flushes it; `ACTIVATE` is emulator-only (see `docs/content/building-applications.md#activations-emulator`) |
 | LR (×3) | `SET`, `ADD`, `SUB`, `INCR_MOD_POW2` | Scalar loop register ops |
 | COND | `BEQ`, `BNE`, `BLT`, `BNZ`, `BZ`, `B`, `BR`, `BKPT` | Branches |
 | BREAK | `BREAK`, `BREAK.IFEQ` | Debug breakpoints |

--- a/SKILL.md
+++ b/SKILL.md
@@ -79,15 +79,15 @@ LDR_MULT_REG R0, LR0, CR0; MULT.EE R0, LR1, 0, LR3; ACC; ADD LR0, LR0, 1; BNE LR
 
 | Register | Size | Purpose |
 |----------|------|---------|
-| `r0`, `r1` | 128 bytes (128×INT8) | Multiply-stage inputs/outputs |
-| `r_cyclic` | 512 bytes | Cyclic-access variant of r0 |
-| `r_mask` | 128 bytes | Bit mask register |
-| `r_acc` | 512 bytes (128×INT32) | Accumulator |
-| `aaq0`–`aaq3` | 32-bit each | Activation & Quantization results |
-| `lr0`–`lr15` | 32-bit each | Loop/scalar registers |
-| `cr0`–`cr15` | 32-bit, read-only | Configuration (base addresses, params) |
+| `R0`, `R1` | 128 bytes (128×INT8) | Multiply-stage inputs/outputs |
+| `R_CYCLIC` | 512 bytes | Cyclic-access variant of `R0` |
+| `R_MASK` | 128 bytes | Bit mask register |
+| `R_ACC` | 512 bytes (128×INT32) | Accumulator |
+| `AAQ0`–`AAQ3` | 32-bit each | Activation & Quantization results |
+| `LR0`–`LR15` | 32-bit each | Loop/scalar registers |
+| `CR0`–`CR15` | 32-bit, read-only | Configuration (base addresses, params) |
 
-`cr15` is reserved for data type selection (INT8 / FP8_E4M3 / FP8_E5M2).
+`CR15` is reserved for data type selection (INT8 / FP8_E4M3 / FP8_E5M2).
 
 ### Instruction Slots
 
@@ -95,8 +95,8 @@ LDR_MULT_REG R0, LR0, CR0; MULT.EE R0, LR1, 0, LR3; ACC; ADD LR0, LR0, 1; BNE LR
 |------|-------------|---------|
 | XMEM | `LDR_MULT_REG`, `STR_ACC_REG`, `LDR_CYCLIC_MULT_REG`, … | Memory load/store |
 | MULT | `MULT.EE`, `MULT.VE.CYCLIC`, `MULT.VE.PADDED`, `MULT.VE.CR`, `MULT.VE.AAQ`, … | 8-bit vector multiply |
-| ACC | `ACC`, `ACC.STRIDE`, `ACC.MAX`, `ACC.MAX.FIRST`, `RESET_ACC` | Accumulate into r_acc |
-| AAQ | `AGG` / `AGG.FIRST` (sum/max + post-fn + `valid_elements` mask), `AAQ`, `ACTIVATE` | Aggregate / quantize `r_acc`; `ACTIVATE` applies keyword activations (see `docs/content/specs/stage-aaq.md` for α configuration) |
+| ACC | `ACC`, `ACC.STRIDE`, `ACC.MAX`, `ACC.MAX.FIRST`, `RESET_ACC` | Accumulate into `R_ACC` |
+| AAQ | `AGG` / `AGG.FIRST` (sum/max + post-fn + `valid_elements` mask), `AAQ`, `ACTIVATE` | Aggregate / quantize `R_ACC`; `ACTIVATE` applies keyword activations (see `docs/content/specs/stage-aaq.md` for α configuration) |
 | LR (×3) | `SET`, `ADD`, `SUB`, `INCR_MOD_POW2` | Scalar loop register ops |
 | COND | `BEQ`, `BNE`, `BLT`, `BNZ`, `BZ`, `B`, `BR`, `BKPT` | Branches |
 | BREAK | `BREAK`, `BREAK.IFEQ` | Debug breakpoints |
@@ -149,7 +149,7 @@ def _run(asm_code: str) -> IpuState:
     return state
 
 def test_my_instruction():
-    state = _run("MY_INST aaq0 r0;;")
+    state = _run("MY_INST AAQ0 R0;;")
     assert state.regfile.get_aaq(0) == expected
 ```
 
@@ -216,6 +216,6 @@ Interactive commands: `continue`, `step`, `get lr0`, `set lr0 100`, `save state.
 - **Never duplicate instruction metadata** — assembler and emulator both read `instruction_spec.py`
 - **Operand names in `execute_*` must exactly match** the names in `instruction_spec.py`
 - **Read-before-write**: slots with `"read": "snapshot"` see pre-cycle register values
-- **`cr15`** is reserved — never use it for application data
+- **`CR15`** is reserved — never use it for application data
 - The build system is **Bazel** — use `bazel build/test/run`, not pip/python directly
 - Data types (INT8, FP8_E4M3, FP8_E5M2) affect how register bytes are interpreted in math ops

--- a/SKILL.md
+++ b/SKILL.md
@@ -96,7 +96,7 @@ LDR_MULT_REG R0, LR0, CR0; MULT.EE R0, LR1, 0, LR3; ACC; ADD LR0, LR0, 1; BNE LR
 | XMEM | `LDR_MULT_REG`, `STR_ACC_REG`, `STR_POST_AAQ_REG`, `LDR_CYCLIC_MULT_REG`, … | Memory load/store |
 | MULT | `MULT.EE`, `MULT.VE.CYCLIC`, `MULT.VE.PADDED`, `MULT.VE.CR`, `MULT.VE.AAQ`, … | 8-bit vector multiply |
 | ACC | `ACC`, `ACC.STRIDE`, `ACC.MAX`, `ACC.MAX.FIRST`, `RESET_ACC` | Accumulate into `R_ACC` |
-| AAQ | `AGG` / `AGG.FIRST` (sum/max + post-fn + `valid_elements` mask), `AAQ`, `ACTIVATE` | `ACTIVATE` / agg work on **`R_ACC`** (512 B, 32b lanes). **`POST_AAQ_REG`** is **temporarily 512 B** (same footprint as `R_ACC`) until quant export is finalized; **`AAQ`** fills the **leading 128 B** with clamped INT8 in INT8 mode. **`STR_POST_AAQ_REG`** stores that **512-byte** register to XMEM (the Python emulator refreshes it from `R_ACC` at store time so exports match post-activation lanes). See `docs/content/building-applications.md#activations-emulator`. |
+| AAQ | `AGG` / `AGG.FIRST` (sum/max + post-fn + `valid_elements` mask), `AAQ`, `ACTIVATE` | **`AGG`** uses **`R_ACC`**. **`ACTIVATE`** reads **`R_ACC`** and writes activated **32b** lanes into **`POST_AAQ_REG`** (512 B staging). **`AAQ`** (INT8) quantizes wide lanes in **`POST_AAQ_REG`** into the leading **128 B**; **`STR_POST_AAQ_REG`** stores the full **512 B** register to XMEM. See `docs/content/building-applications.md#activations-emulator`. |
 | LR (×3) | `SET`, `ADD`, `SUB`, `INCR_MOD_POW2` | Scalar loop register ops (`SET` copies from a **`CR`** register) |
 | COND | `BEQ`, `BNE`, `BLT`, `BNZ`, `BZ`, `B`, `BR`, `BKPT` | Branches |
 | BREAK | `BREAK`, `BREAK.IFEQ` | Debug breakpoints |

--- a/SKILL.md
+++ b/SKILL.md
@@ -96,7 +96,7 @@ LDR_MULT_REG R0, LR0, CR0; MULT.EE R0, LR1, 0, LR3; ACC; ADD LR0, LR0, 1; BNE LR
 | XMEM | `LDR_MULT_REG`, `STR_ACC_REG`, `STR_POST_AAQ_REG`, `LDR_CYCLIC_MULT_REG`, … | Memory load/store |
 | MULT | `MULT.EE`, `MULT.VE.CYCLIC`, `MULT.VE.PADDED`, `MULT.VE.CR`, `MULT.VE.AAQ`, … | 8-bit vector multiply |
 | ACC | `ACC`, `ACC.STRIDE`, `ACC.MAX`, `ACC.MAX.FIRST`, `RESET_ACC` | Accumulate into `R_ACC` |
-| AAQ | `AGG` / `AGG.FIRST` (sum/max + post-fn + `valid_elements` mask), `AAQ`, `ACTIVATE` | `ACTIVATE` / agg work on **`R_ACC`** (512 B, 32b lanes); **`AAQ`** writes **128 B** quantized lanes into **`POST_AAQ_REG`** (staging shape still evolving); **`STR_POST_AAQ_REG`** **temporarily** dumps **512 B** from **`R_ACC`** to XMEM (will export **`POST_AAQ_REG`** after quant path is finalized). See `docs/content/building-applications.md#activations-emulator`. |
+| AAQ | `AGG` / `AGG.FIRST` (sum/max + post-fn + `valid_elements` mask), `AAQ`, `ACTIVATE` | `ACTIVATE` / agg work on **`R_ACC`** (512 B, 32b lanes). **`POST_AAQ_REG`** is **temporarily 512 B** (same footprint as `R_ACC`) until quant export is finalized; **`AAQ`** fills the **leading 128 B** with clamped INT8 in INT8 mode. **`STR_POST_AAQ_REG`** stores that **512-byte** register to XMEM (the Python emulator refreshes it from `R_ACC` at store time so exports match post-activation lanes). See `docs/content/building-applications.md#activations-emulator`. |
 | LR (×3) | `SET`, `ADD`, `SUB`, `INCR_MOD_POW2` | Scalar loop register ops (`SET` copies from a **`CR`** register) |
 | COND | `BEQ`, `BNE`, `BLT`, `BNZ`, `BZ`, `B`, `BR`, `BKPT` | Branches |
 | BREAK | `BREAK`, `BREAK.IFEQ` | Debug breakpoints |

--- a/SKILL.md
+++ b/SKILL.md
@@ -96,7 +96,7 @@ LDR_MULT_REG R0, LR0, CR0; MULT.EE R0, LR1, 0, LR3; ACC; ADD LR0, LR0, 1; BNE LR
 | XMEM | `LDR_MULT_REG`, `STR_ACC_REG`, `STR_POST_AAQ_REG`, `LDR_CYCLIC_MULT_REG`, … | Memory load/store |
 | MULT | `MULT.EE`, `MULT.VE.CYCLIC`, `MULT.VE.PADDED`, `MULT.VE.CR`, `MULT.VE.AAQ`, … | 8-bit vector multiply |
 | ACC | `ACC`, `ACC.STRIDE`, `ACC.MAX`, `ACC.MAX.FIRST`, `RESET_ACC` | Accumulate into `R_ACC` |
-| AAQ | `AGG` / `AGG.FIRST` (sum/max + post-fn + `valid_elements` mask), `AAQ`, `ACTIVATE` | Aggregate / quantize `R_ACC`; `AAQ` → **`POST_AAQ_REG`**; **`STR_POST_AAQ_REG`** (XMEM) flushes it; `ACTIVATE` is emulator-only (see `docs/content/building-applications.md#activations-emulator`) |
+| AAQ | `AGG` / `AGG.FIRST` (sum/max + post-fn + `valid_elements` mask), `AAQ`, `ACTIVATE` | `ACTIVATE` / agg work on **`R_ACC`** (512 B, 32b lanes); **`AAQ`** writes **128 B** quantized lanes into **`POST_AAQ_REG`** (staging shape still evolving); **`STR_POST_AAQ_REG`** **temporarily** dumps **512 B** from **`R_ACC`** to XMEM (will export **`POST_AAQ_REG`** after quant path is finalized). See `docs/content/building-applications.md#activations-emulator`. |
 | LR (×3) | `SET`, `ADD`, `SUB`, `INCR_MOD_POW2` | Scalar loop register ops (`SET` copies from a **`CR`** register) |
 | COND | `BEQ`, `BNE`, `BLT`, `BNZ`, `BZ`, `B`, `BR`, `BKPT` | Branches |
 | BREAK | `BREAK`, `BREAK.IFEQ` | Debug breakpoints |

--- a/SKILL.md
+++ b/SKILL.md
@@ -95,14 +95,14 @@ LDR_MULT_REG r0 lr0 cr0; MULT.EE r0 lr1 0 lr3; ACC; ADD lr0 lr0 1; BNE lr0 lr1 n
 | XMEM | `LDR_MULT_REG`, `STR_ACC_REG`, `LDR_CYCLIC_MULT_REG`, … | Memory load/store |
 | MULT | `MULT.EE`, `MULT.VE.CYCLIC`, `MULT.VE.PADDED`, `MULT.VE.CR`, `MULT.VE.AAQ`, … | 8-bit vector multiply |
 | ACC | `ACC`, `ACC.STRIDE`, `ACC.MAX`, `ACC.MAX.FIRST`, `RESET_ACC` | Accumulate into r_acc |
-| AAQ | `AGG` / `AGG.FIRST` (sum/max + post-fn + `valid_elements` mask), `AAQ` | Aggregate r_acc → aaq register |
+| AAQ | `AGG` / `AGG.FIRST` (sum/max + post-fn + `valid_elements` mask), `AAQ`, `ACTIVATE` | Aggregate / quantize `r_acc`; `ACTIVATE` applies keyword activations (see `docs/content/specs/stage-aaq.md` for α configuration) |
 | LR (×3) | `SET`, `ADD`, `SUB`, `INCR_MOD_POW2` | Scalar loop register ops |
 | COND | `BEQ`, `BNE`, `BLT`, `BNZ`, `BZ`, `B`, `BR`, `BKPT` | Branches |
 | BREAK | `BREAK`, `BREAK.IFEQ` | Debug breakpoints |
 
 ### Operand Types (defined in instruction_spec)
 
-`MultStageReg`, `LrIdx`, `CrIdx`, `LcrIdx`, `AddSubSrcB`, `AaqRegIdx`, `AggMode`, `PostFn`, `ElementsInRow`, `HorizontalStride`, `VerticalStride`, `Immediate`, `MultMaskOffsetImmediate`, `Label`
+`MultStageReg`, `LrIdx`, `CrIdx`, `LcrIdx`, `AddSubSrcB`, `AaqRegIdx`, `AggMode`, `PostFn`, `ActivationFn`, `ElementsInRow`, `HorizontalStride`, `VerticalStride`, `Immediate`, `MultMaskOffsetImmediate`, `Label`
 
 ---
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -96,7 +96,7 @@ LDR_MULT_REG R0, LR0, CR0; MULT.EE R0, LR1, 0, LR3; ACC; ADD LR0, LR0, 1; BNE LR
 | XMEM | `LDR_MULT_REG`, `STR_ACC_REG`, `LDR_CYCLIC_MULT_REG`, … | Memory load/store |
 | MULT | `MULT.EE`, `MULT.VE.CYCLIC`, `MULT.VE.PADDED`, `MULT.VE.CR`, `MULT.VE.AAQ`, … | 8-bit vector multiply |
 | ACC | `ACC`, `ACC.STRIDE`, `ACC.MAX`, `ACC.MAX.FIRST`, `RESET_ACC` | Accumulate into `R_ACC` |
-| AAQ | `AGG` / `AGG.FIRST` (sum/max + post-fn + `valid_elements` mask), `AAQ`, `ACTIVATE` | Aggregate / quantize `R_ACC`; `ACTIVATE` applies keyword activations (see `docs/content/specs/stage-aaq.md` for α configuration) |
+| AAQ | `AGG` / `AGG.FIRST` (sum/max + post-fn + `valid_elements` mask), `AAQ`, `ACTIVATE` | Aggregate / quantize `R_ACC`; `ACTIVATE` is a Python-emulator AAQ-slot aid (see `docs/content/building-applications.md#activations-emulator`) |
 | LR (×3) | `SET`, `ADD`, `SUB`, `INCR_MOD_POW2` | Scalar loop register ops |
 | COND | `BEQ`, `BNE`, `BLT`, `BNZ`, `BZ`, `B`, `BR`, `BKPT` | Branches |
 | BREAK | `BREAK`, `BREAK.IFEQ` | Debug breakpoints |

--- a/docs/content/building-applications.md
+++ b/docs/content/building-applications.md
@@ -22,7 +22,7 @@ The emulator can run multiply/accumulate paths with **128×32-bit lanes** (FP32 
 
 The [AAQ stage spec](specs/stage-aaq.md) describes how **real hardware** wires activation: a function id (for example from `act_cr_idx` and a `CR` read) and **α-like parameters** that are **not** VLIW immediates—they come from implementation-defined configuration (constants, fuses, side-band registers, etc.).
 
-The **Python emulator** in this repository adds a convenience AAQ-slot instruction **`ACTIVATE`** so programs can apply the same twelve activation shapes to **`R_ACC`** before aggregation or quantization, without modeling the full `act_cr_idx` path:
+The **Python emulator** in this repository adds a convenience AAQ-slot instruction **`ACTIVATE`** so programs can apply the same twelve activation shapes to lanes read from **`R_ACC`**, writing results into **`POST_AAQ_REG`** (without modifying **`R_ACC`**), without modeling the full `act_cr_idx` path:
 
 ```asm
 ACTIVATE LR0 relu;;
@@ -33,10 +33,11 @@ ACTIVATE LR0 relu;;
 
 ### `R_ACC`, `POST_AAQ_REG`, and `STR_POST_AAQ_REG` (staging vs export)
 
-- **Activation** applies element-wise **32→32** transforms in **`R_ACC`** (512 bytes = 128×32-bit lanes). **`ACTIVATE`** does this in the emulator; hardware uses the `act_cr_idx` path described in the AAQ spec.
-- **`POST_AAQ_REG`** is **temporarily a 512-byte** register (same lane footprint as **`R_ACC`**) until end-to-end quantization and export are finalized; the exact final width and packing may change once the quant path is decoupled from the wide accumulator view.
-- **`AAQ`** (INT8 mode) writes **128 bytes** of clamped INT8 lanes into the **leading** bytes of **`POST_AAQ_REG`** and clears the remainder of the register for now.
-- **`STR_POST_AAQ_REG`** stores **`POST_AAQ_REG`** — **512 bytes** — to XMEM. In the Python emulator the buffer is **refreshed from `R_ACC` immediately before the store** so the exported bytes match the current post-activation wide lanes; later hardware may instead flush a narrower quantized view once **`AAQ`** fully owns the buffer.
+- **Accumulation** stays in **`R_ACC`** (512 bytes = 128×32-bit lanes). **`AGG`** / **`AGG.FIRST`** still reduce **`R_ACC`**; hardware uses the `act_cr_idx` path described in the AAQ spec for activation selection.
+- **`ACTIVATE`** (emulator) reads **`R_ACC`** and writes element-wise **32→32** activated lanes into **`POST_AAQ_REG`**; **`R_ACC`** is left unchanged.
+- **`POST_AAQ_REG`** is **temporarily a 512-byte** wide staging register (same lane layout as **`R_ACC`**) until end-to-end quantization and export are finalized.
+- **`AAQ`** (INT8 mode) quantizes the **wide lanes currently in `POST_AAQ_REG`**, writing **128 bytes** of clamped INT8 into the **leading** bytes of **`POST_AAQ_REG`** and clearing the remainder for now. Typical flow: **`ACTIVATE`** (wide lanes) then **`AAQ`** (quantize in place into the same register’s byte prefix).
+- **`STR_POST_AAQ_REG`** stores **`POST_AAQ_REG`** — **512 bytes** — to XMEM (whatever wide or quantized layout that buffer holds at issue time).
 
 ### Virtual α in the emulator (leaky_relu, elu, prelu)
 

--- a/docs/content/building-applications.md
+++ b/docs/content/building-applications.md
@@ -326,7 +326,7 @@ Available fields:
 - `mult_active_cycles` — cycles whose MULT slot was not `MULT_NOP`
 - `acc_active_cycles` — cycles whose ACC slot was not `ACC_NOP`
 - `xmem_reads` — count of `LDR_MULT_REG`, `LDR_CYCLIC_MULT_REG`, `LDR_MULT_MASK_REG`
-- `xmem_writes` — count of `STR_ACC_REG`, `XMEM.STORE_AAQ_RESULT`
+- `xmem_writes` — count of `STR_ACC_REG`, `STR_POST_AAQ_REG`
 - `xmem_accesses` — sum of reads + writes
 - `mult_utilization`, `acc_utilization` — active-cycle fraction (0.0–1.0)
 

--- a/docs/content/building-applications.md
+++ b/docs/content/building-applications.md
@@ -16,7 +16,46 @@ Everything lives together in one directory.
 
 ## Wide-vector debug mode (optional)
 
-The emulator can run multiply/accumulate paths with **128×32-bit lanes** (FP32 or INT32) instead of 8-bit vectors, for debugging without quantization on that path. XMEM addresses stay the same; load sizes and alignment rules change. See **[Wide-vector debug mode](wide-vector-debug-mode.md)** for how to construct `IpuState`, prepare 512-byte loads, and use `aaq` / `str_acc_reg` in that mode.
+The emulator can run multiply/accumulate paths with **128×32-bit lanes** (FP32 or INT32) instead of 8-bit vectors, for debugging without quantization on that path. XMEM addresses stay the same; load sizes and alignment rules change. See **[Wide-vector debug mode](wide-vector-debug-mode.md)** for how to construct `IpuState`, prepare 512-byte loads, and use `AAQ` / `STR_ACC_REG` in that mode.
+
+## Activations, `ACTIVATE`, and virtual α (Python emulator) {#activations-emulator}
+
+The [AAQ stage spec](specs/stage-aaq.md) describes how **real hardware** wires activation: a function id (for example from `act_cr_idx` and a `CR` read) and **α-like parameters** that are **not** VLIW immediates—they come from implementation-defined configuration (constants, fuses, side-band registers, etc.).
+
+The **Python emulator** in this repository adds a convenience AAQ-slot instruction **`ACTIVATE`** so programs can apply the same twelve activation shapes to **`R_ACC`** before aggregation or quantization, without modeling the full `act_cr_idx` path:
+
+```asm
+ACTIVATE LR0 relu;;
+```
+
+- **Syntax:** `ACTIVATE` *valid_elements* *activation_fn*, where *valid_elements* is an `LR`/`CR` selector (same lane-count semantics as `AGG`) and *activation_fn* is a **keyword** (`identity`, `relu`, `relu6`, `leaky_relu`, `sigmoid`, `tanh`, `gelu`, `silu`, `softplus`, `elu`, `prelu`, `exp2`). The assembler also accepts **`swish`** as an alias for **`silu`**.
+- **Single source of truth:** keyword order and the pure-Python math live in `src/tools/ipu-common/src/ipu_common/activations.py` (`ACTIVATION_FN_NAMES`, `apply_activation`).
+
+### Virtual α in the emulator (leaky_relu, elu, prelu)
+
+The stock ISA does not expose α. In software, α is represented by **module-level constants** in the same file (not `CR` writes, not environment variables, not CLI flags):
+
+| Name | Activation | Default |
+|------|------------|---------|
+| `_LEAKY_ALPHA` | `leaky_relu` | `0.01` |
+| `_ELU_ALPHA` | `elu` | `1.0` |
+| `_PRELU_ALPHA` | `prelu` | `0.25` |
+
+These are **virtual** values: they stand in for whatever fixed calibration your RTL or chip would supply.
+
+### Overriding α (or the whole activation table) when you need to
+
+Pick the approach that matches how much isolation you need:
+
+1. **Edit `activations.py` and rebuild** — simplest for a long-lived fork or when you always want new defaults. Run `bazel test //…` (or your usual pytest targets) after changing `_LEAKY_ALPHA`, `_ELU_ALPHA`, or `_PRELU_ALPHA`.
+
+2. **Monkeypatch at import time (tests and one-off harnesses)** — after `import ipu_common.activations as act` but **before** the first `Ipu` run in that process, assign new floats, for example `act._LEAKY_ALPHA = 0.05`. `apply_activation` reads the module globals on each call, so patched values take effect immediately. Prefer doing this in a `conftest.py` autouse fixture or an app `setup()` that runs before `load_program`.
+
+3. **Shim `ipu_common` on `PYTHONPATH` (advanced)** — for CI matrix jobs without touching the main tree, prepend a directory that provides a replacement `ipu_common/activations.py` (or a tiny package that re-exports `apply_activation` with different constants). Keep the public API (`ACTIVATION_FN_NAMES`, `apply_activation` signature) compatible so the assembler and emulator imports keep working.
+
+4. **Vendor a copy for experiments** — for notebooks or papers, copy the small `apply_activation` body into your own module and drive `R_ACC` writes from Python; bypass `ACTIVATE` entirely if you are not assembling IPU binaries.
+
+For **multiple α values in one process**, prefer (2) inside distinct test cases, or separate subprocesses with different patches—constants are process-wide.
 
 ## Step 1: Write the Assembly Program
 

--- a/docs/content/building-applications.md
+++ b/docs/content/building-applications.md
@@ -34,8 +34,9 @@ ACTIVATE LR0 relu;;
 ### `R_ACC`, `POST_AAQ_REG`, and `STR_POST_AAQ_REG` (staging vs export)
 
 - **Activation** applies element-wise **32→32** transforms in **`R_ACC`** (512 bytes = 128×32-bit lanes). **`ACTIVATE`** does this in the emulator; hardware uses the `act_cr_idx` path described in the AAQ spec.
-- **Quantization** (target **32→8** per lane) is what **`AAQ`** approximates today: it writes **128 bytes** of clamped INT8 lanes into **`POST_AAQ_REG`**. That register’s **role and exact layout are still evolving** once quant is fully decoupled from the wide accumulator view.
-- **`STR_POST_AAQ_REG`** currently writes **512 bytes from `R_ACC`** to XMEM so you can snapshot **post-activation** lanes before the export is rewired to flush the **128-byte** quantized **`POST_AAQ_REG`** buffer instead.
+- **`POST_AAQ_REG`** is **temporarily a 512-byte** register (same lane footprint as **`R_ACC`**) until end-to-end quantization and export are finalized; the exact final width and packing may change once the quant path is decoupled from the wide accumulator view.
+- **`AAQ`** (INT8 mode) writes **128 bytes** of clamped INT8 lanes into the **leading** bytes of **`POST_AAQ_REG`** and clears the remainder of the register for now.
+- **`STR_POST_AAQ_REG`** stores **`POST_AAQ_REG`** — **512 bytes** — to XMEM. In the Python emulator the buffer is **refreshed from `R_ACC` immediately before the store** so the exported bytes match the current post-activation wide lanes; later hardware may instead flush a narrower quantized view once **`AAQ`** fully owns the buffer.
 
 ### Virtual α in the emulator (leaky_relu, elu, prelu)
 

--- a/docs/content/building-applications.md
+++ b/docs/content/building-applications.md
@@ -16,7 +16,7 @@ Everything lives together in one directory.
 
 ## Wide-vector debug mode (optional)
 
-The emulator can run multiply/accumulate paths with **128×32-bit lanes** (FP32 or INT32) instead of 8-bit vectors, for debugging without quantization on that path. XMEM addresses stay the same; load sizes and alignment rules change. See **[Wide-vector debug mode](wide-vector-debug-mode.md)** for how to construct `IpuState`, prepare 512-byte loads, and use `AAQ` / `STR_ACC_REG` in that mode.
+The emulator can run multiply/accumulate paths with **128×32-bit lanes** (FP32 or INT32) instead of 8-bit vectors, for debugging without quantization on that path. XMEM addresses stay the same; load sizes and alignment rules change. See **[Wide-vector debug mode](wide-vector-debug-mode.md)** for how to construct `IpuState`, prepare 512-byte loads, and use `AAQ` / **`STR_POST_AAQ_REG`** / `STR_ACC_REG` in that mode.
 
 ## Activations, `ACTIVATE`, and virtual α (Python emulator) {#activations-emulator}
 

--- a/docs/content/building-applications.md
+++ b/docs/content/building-applications.md
@@ -39,29 +39,45 @@ ACTIVATE LR0 relu;;
 
 ### Virtual α in the emulator (leaky_relu, elu, prelu)
 
-The stock ISA does not expose α. In software, α is represented by **module-level constants** in the same file (not `CR` writes, not environment variables, not CLI flags):
+The stock ISA does not expose α. Defaults live in `ipu_common/activations.py` as **`DEFAULT_LEAKY_ALPHA`**, **`DEFAULT_ELU_ALPHA`**, and **`DEFAULT_PRELU_ALPHA`** (the legacy names `_LEAKY_ALPHA`, `_ELU_ALPHA`, `_PRELU_ALPHA` point at the same floats). These are **virtual** values: they stand in for whatever fixed calibration your RTL or chip would supply.
 
-| Name | Activation | Default |
-|------|------------|---------|
-| `_LEAKY_ALPHA` | `leaky_relu` | `0.01` |
-| `_ELU_ALPHA` | `elu` | `1.0` |
-| `_PRELU_ALPHA` | `prelu` | `0.25` |
+**Preferred (per-run, like dtype on state, not over CR):** configure α on **`IpuState`** — at construction, via **`set_activation_alphas`**, or when using **`run_test`** / **`IpuApp.run`**:
 
-These are **virtual** values: they stand in for whatever fixed calibration your RTL or chip would supply.
+```python
+from ipu_emu.ipu_state import IpuState
+from ipu_emu.emulator import run_test
 
-### Overriding α (or the whole activation table) when you need to
+state = IpuState(leaky_relu_alpha=0.05, elu_alpha=1.0, prelu_alpha=0.3)
+# or after construction:
+state.set_activation_alphas(leaky_relu_alpha=0.05)
 
-Pick the approach that matches how much isolation you need:
+# High-level harness (optional kwargs mirror IpuState):
+state, cycles = run_test(
+    inst_path="prog.bin",
+    setup=my_setup,
+    leaky_relu_alpha=0.05,
+)
+```
 
-1. **Edit `activations.py` and rebuild** — simplest for a long-lived fork or when you always want new defaults. Run `bazel test //…` (or your usual pytest targets) after changing `_LEAKY_ALPHA`, `_ELU_ALPHA`, or `_PRELU_ALPHA`.
+Subclassing **`IpuApp`**, you can pass α through **`run(...)`** or store them on the app from **`__init__`** (same names as `run_test`); explicit **`run()`** arguments override stored attributes:
 
-2. **Monkeypatch at import time (tests and one-off harnesses)** — after `import ipu_common.activations as act` but **before** the first `Ipu` run in that process, assign new floats, for example `act._LEAKY_ALPHA = 0.05`. `apply_activation` reads the module globals on each call, so patched values take effect immediately. Prefer doing this in a `conftest.py` autouse fixture or an app `setup()` that runs before `load_program`.
+```python
+app = MyApp(inst_path="prog.bin", leaky_relu_alpha=0.05)
+state, cycles = app.run()  # uses 0.05
+state, cycles = app.run(leaky_relu_alpha=0.1)  # uses 0.1 for this run
+```
 
-3. **Shim `ipu_common` on `PYTHONPATH` (advanced)** — for CI matrix jobs without touching the main tree, prepend a directory that provides a replacement `ipu_common/activations.py` (or a tiny package that re-exports `apply_activation` with different constants). Keep the public API (`ACTIVATION_FN_NAMES`, `apply_activation` signature) compatible so the assembler and emulator imports keep working.
+### Other ways to override α when you need to
 
-4. **Vendor a copy for experiments** — for notebooks or papers, copy the small `apply_activation` body into your own module and drive `R_ACC` writes from Python; bypass `ACTIVATE` entirely if you are not assembling IPU binaries.
+1. **Edit `activations.py` and rebuild** — change **`DEFAULT_*`** when you want new tree-wide defaults. Run `bazel test //…` after edits.
 
-For **multiple α values in one process**, prefer (2) inside distinct test cases, or separate subprocesses with different patches—constants are process-wide.
+2. **Monkeypatch at import time (tests)** — after `import ipu_common.activations as act`, assign `act._LEAKY_ALPHA = 0.05` before the first `Ipu` run **only if** you are not relying on per-`IpuState` α (the emulator passes state α into `apply_activation`; omitted kwargs still read the module globals).
+
+3. **Shim `ipu_common` on `PYTHONPATH` (advanced)** — for CI matrix jobs without touching the main tree, prepend a directory that provides a compatible `ipu_common/activations.py`.
+
+4. **Vendor a copy for experiments** — bypass `ACTIVATE` and drive `R_ACC` from Python if you are not assembling IPU binaries.
+
+For **different α in the same process**, use **separate `IpuState` instances** (or `run_test(..., leaky_relu_alpha=...)` per call) instead of relying on process-wide module constants.
 
 ## Step 1: Write the Assembly Program
 

--- a/docs/content/building-applications.md
+++ b/docs/content/building-applications.md
@@ -31,6 +31,12 @@ ACTIVATE LR0 relu;;
 - **Syntax:** `ACTIVATE` *valid_elements* *activation_fn*, where *valid_elements* is an `LR`/`CR` selector (same lane-count semantics as `AGG`) and *activation_fn* is a **keyword** (`identity`, `relu`, `relu6`, `leaky_relu`, `sigmoid`, `tanh`, `gelu`, `silu`, `softplus`, `elu`, `prelu`, `exp2`). The assembler also accepts **`swish`** as an alias for **`silu`**.
 - **Single source of truth:** keyword order and the pure-Python math live in `src/tools/ipu-common/src/ipu_common/activations.py` (`ACTIVATION_FN_NAMES`, `apply_activation`).
 
+### `R_ACC`, `POST_AAQ_REG`, and `STR_POST_AAQ_REG` (staging vs export)
+
+- **Activation** applies element-wise **32→32** transforms in **`R_ACC`** (512 bytes = 128×32-bit lanes). **`ACTIVATE`** does this in the emulator; hardware uses the `act_cr_idx` path described in the AAQ spec.
+- **Quantization** (target **32→8** per lane) is what **`AAQ`** approximates today: it writes **128 bytes** of clamped INT8 lanes into **`POST_AAQ_REG`**. That register’s **role and exact layout are still evolving** once quant is fully decoupled from the wide accumulator view.
+- **`STR_POST_AAQ_REG`** currently writes **512 bytes from `R_ACC`** to XMEM so you can snapshot **post-activation** lanes before the export is rewired to flush the **128-byte** quantized **`POST_AAQ_REG`** buffer instead.
+
 ### Virtual α in the emulator (leaky_relu, elu, prelu)
 
 The stock ISA does not expose α. In software, α is represented by **module-level constants** in the same file (not `CR` writes, not environment variables, not CLI flags):

--- a/docs/content/specs/stage-aaq.md
+++ b/docs/content/specs/stage-aaq.md
@@ -9,8 +9,6 @@ vector for output. It produces:
 - Scalar results in `aaq0`–`aaq3` via `agg` and `agg.first`.
 - A 128-byte `aaq_result` vector via `aaq` (any 8-bit format: INT8 or FP8 e(x)m(7-x)).
 
-**Python emulator (interim):** the in-tree emulator models **`POST_AAQ_REG` as 512 bytes** (same footprint as `r_acc`) until end-to-end quantization export is finalized; **`STR_POST_AAQ_REG`** stores that full register to XMEM. The **128-byte** `aaq_result` description below remains the architectural quantized payload. See [Building Applications](../building-applications.md#activations-emulator).
-
 ## 2. Block Diagram
 
 ```mermaid

--- a/docs/content/specs/stage-aaq.md
+++ b/docs/content/specs/stage-aaq.md
@@ -155,6 +155,26 @@ Supported activation functions:
 | 10 | `prelu` | `f(x) = x if x ≥ 0 else α·x` | Like Leaky ReLU but α is a learned per-channel parameter. |
 | 11 | `exp2` | `f(x) = 2^x` | Used for dequantization, softmax and attention scaling. |
 
+#### Emulator: `ACTIVATE` and configuring α (“virtual” parameters)
+
+The block diagram and `act_cr_idx` discussion above describe the staged hardware view. In **this repository’s Python emulator**, element-wise activations on `r_acc` are issued with the **`ACTIVATE`** AAQ-slot instruction:
+
+```asm
+ACTIVATE lr0 relu;;
+```
+
+Syntax: **`ACTIVATE`** *valid_elements* *activation_fn*, where *valid_elements* is an `lr`/`cr` source (same masking rules as `AGG`) and *activation_fn* is a **keyword** (`identity`, `relu`, `relu6`, `leaky_relu`, `sigmoid`, `tanh`, `gelu`, `silu`, `softplus`, `elu`, `prelu`, `exp2`). The canonical spellings and encoding order live in `src/tools/ipu-common/src/ipu_common/activations.py` as `ACTIVATION_FN_NAMES`, next to `apply_activation`.
+
+**α for `leaky_relu`, `elu`, and `prelu`:** The ISA does not carry α. In software, α is **not** a register, environment variable, or CLI flag. It is fixed for the whole emulator by **module-level constants** in the same file:
+
+| Name in `activations.py` | Activation | Default |
+|---------------------------|--------------|---------|
+| `_LEAKY_ALPHA` | `leaky_relu` | `0.01` |
+| `_ELU_ALPHA` | `elu` | `1.0` |
+| `_PRELU_ALPHA` | `prelu` | `0.25` |
+
+To model different training or deployment assumptions, **edit those constants**, then run your usual checks (for example `bazel test //…`). That is the supported “virtual configuration” path: calibration is intentionally **outside** the instruction stream. For experiments that need several α values in one process, use separate builds, test-only copies of the helpers, or a harness that swaps a patched `activations` module before loading the emulator.
+
 ### 7.1 Aggregate (`agg`)
 
 **Assembly syntax:** `agg <agg_mode> <post_fn> <valid_elements> <cr_idx> <aaq_rf_idx>`

--- a/docs/content/specs/stage-aaq.md
+++ b/docs/content/specs/stage-aaq.md
@@ -6,8 +6,8 @@ The AAQ (Activation Aggregation and Quantization) stage collapses the 128-lane a
 into scalar activation values and/or quantizes the accumulator into an FP8
 vector for output. It produces:
 
-- Scalar results in `aaq0`–`aaq3` via `agg` and `agg.first`.
-- A 128-byte `aaq_result` vector via `aaq` (any 8-bit format: INT8 or FP8 e(x)m(7-x)).
+- Scalar results in `AAQ0`–`AAQ3` via `agg` and `agg.first`.
+- A 128-byte `AAQ_RESULT` vector via `aaq` (any 8-bit format: INT8 or FP8 e(x)m(7-x)).
 
 ## 2. Block Diagram
 
@@ -15,8 +15,8 @@ vector for output. It produces:
 flowchart LR
     mult_stage:::blue
     acc_stage:::blue
-    ACC(["r_acc 128x32bit"]):::yellow
-    OUT(["aaq_result 128x8bit || 8bit scale | 4bit repr_type"]):::red
+    ACC(["R_ACC 128x32bit"]):::yellow
+    OUT(["AAQ_RESULT 128x8bit || 8bit scale | 4bit repr_type"]):::red
     ACT["Activation"]:::teal
     QUANT["Quantization"]:::teal
     RED["Adder tree / Max tree"]:::teal
@@ -59,10 +59,10 @@ flowchart LR
 ```
                          ┌──────────────────────────────────────┐
               clk  ─────>│                                      │
-              rst  ─────>│                                      ├────> aaq_result        [1035:0]
+              rst  ─────>│                                      ├────> AAQ_RESULT        [1035:0]
             valid  ─────>│                                      │
                op  ─────>│                                      ├────> aaq_rf_to_acc[0..3] [31:0]
-            r_acc  ─────>│             AAQ Stage                │
+            R_ACC  ─────>│             AAQ Stage                │
          agg_mode  ─────>│                                      ├────> aaq_rf_to_mult[0..3][17:0]
           post_fn  ─────>│                                      │
            cr_idx  ─────>│                                      │
@@ -81,21 +81,21 @@ flowchart LR
 | `rst` | `input logic` | Synchronous reset. |
 | `valid` | `input logic` | Stage enable. When deasserted(valid = 0), the stage executes `aaq_nop` regardless of `op`. |
 | `op` | `input logic [2:0]` | Selects the AAQ operation: `agg`=1, `agg.first`=2, `aaq`=3. Sampled only when `valid`=1. |
-| `r_acc` | `input logic [127:0][31:0]` | 128-lane accumulator (128 × 32-bit). |
+| `R_ACC` | `input logic [127:0][31:0]` | 128-lane accumulator (128 × 32-bit). |
 | `agg_mode` | `input logic [0:0]` | Aggregation select: 0 = sum, 1 = max. |
 | `post_fn` | `input logic [1:0]` | Post-function select (see §8). |
 | `cr_idx` | `input logic [3:0]` | CR register index used by `value_cr` post function. |
 | `act_cr_idx` | `input logic [3:0]` | CR register index whose value selects the activation function (see §7.0). |
 | `aaq_rf_idx` | `input logic [1:0]` | AAQ register index (0–3). |
-| `cr15_dtype` | `input logic [2:0]` | Global data type from `cr15`; governs lane interpretation for all AAQ operations. Must be `DType.INT8` (0) for `aaq`. |
-| `valid_elements` | `input logic [4:0]` | Number of valid elements. Sourced from either an LR register (lr0–lr15) or a CR register (cr0–cr15); the 5-bit encoding selects among all 32 registers (16 LR + 16 CR). |
+| `cr15_dtype` | `input logic [2:0]` | Global data type from `CR15`; governs lane interpretation for all AAQ operations. Must be `DType.INT8` (0) for `aaq`. |
+| `valid_elements` | `input logic [4:0]` | Number of valid elements. Sourced from either an LR register (`LR0`–`LR15`) or a CR register (`CR0`–`CR15`); the 5-bit encoding selects among all 32 registers (16 LR + 16 CR). |
 
 ### 3.2 Outputs
 
 | Name | Type and Direction | Description |
 |------|--------------------|-------------|
-| `aaq_result` | `output logic [1035:0]` | Quantized output: 128 × 8-bit lanes (1024 bits) plus 12 bits of metadata: bits [1035:1028] = 8-bit scale factor, bits [1027:1024] = 4-bit representation type (e.g. INT8, e6m1). |
-| `aaq_rf_to_acc[0..3]` | `output logic [31:0]` | Full 32-bit view of the AAQ RF registers (`aaq0`–`aaq3`) fed back to the ACC stage. |
+| `AAQ_RESULT` | `output logic [1035:0]` | Quantized output: 128 × 8-bit lanes (1024 bits) plus 12 bits of metadata: bits [1035:1028] = 8-bit scale factor, bits [1027:1024] = 4-bit representation type (e.g. INT8, e6m1). |
+| `aaq_rf_to_acc[0..3]` | `output logic [31:0]` | Full 32-bit view of the AAQ RF registers (`AAQ0`–`AAQ3`) fed back to the ACC stage. |
 | `aaq_rf_to_mult[0..3]` | `output logic [17:0]` | Same AAQ RF registers as `aaq_rf_to_acc`, exposed to the MULT stage with only the lower 17/18 bits; the MULT stage does not require the full 32-bit precision. Exact width TBD. |
 
 ## 4. Parameters
@@ -104,16 +104,16 @@ flowchart LR
 |------|---------|-------------|
 | `LANES` | `128` | Number of accumulator lanes. |
 | `ACC_LANE_WIDTH` | `32` | Bits per accumulator lane. |
-| `AAQ_REG_COUNT` | `4` | Number of AAQ scalar registers (`aaq0`–`aaq3`). |
-| `AAQ_RESULT_BYTES` | `128` | Byte width of `aaq_result` output vector. |
+| `AAQ_REG_COUNT` | `4` | Number of AAQ scalar registers (`AAQ0`–`AAQ3`). |
+| `AAQ_RESULT_BYTES` | `128` | Byte width of `AAQ_RESULT` output vector. |
 | `AGG_MODE_COUNT` | `2` | Aggregation modes: 0 = sum, 1 = max. |
 | `POST_FN_COUNT` | `5` | Post functions: 0 = identity, 1 = value_cr, 2 = inv, 3 = inv_sqrt, 4 = sqrt. |
 
 ## 5. Data and Register Model
 
-- `r_acc` is 512 bytes (128 × 32-bit lanes). Lanes are always FP32.
-- `aaq0`–`aaq3` are 32-bit registers. They store float32 bit patterns.
-- `aaq_result` is produced only by `aaq`. It contains 128 × 8 bit quantized
+- `R_ACC` is 512 bytes (128 × 32-bit lanes). Lanes are always FP32.
+- `AAQ0`–`AAQ3` are 32-bit registers. They store float32 bit patterns.
+- `AAQ_RESULT` is produced only by `aaq`. It contains 128 × 8 bit quantized
   values (1024 bits) plus 12 bits of metadata appended by the Quantization
   block: bits [11:4] = 8-bit scale factor, bits [3:0] = 4-bit representation
   type (INT8, e6m1, e5m2, …). It is written to XMEM via `xmem.store_aaq_result`.
@@ -128,14 +128,14 @@ flowchart LR
 
 ### 7.0 Activation
 
-The Activation block applies an element-wise function to every valid lane of `r_acc` before the result is passed downstream — both to the Adder/Max tree (`agg`, `agg.first`) and to the Quantization block (`aaq`).
+The Activation block applies an element-wise function to every valid lane of `R_ACC` before the result is passed downstream — both to the Adder/Max tree (`agg`, `agg.first`) and to the Quantization block (`aaq`).
 
 The function is selected at runtime by reading the CR register indexed by `act_cr_idx`: `activation_fn = cr[act_cr_idx]`.
 
 ```text
 // Applied to all valid lanes before aggregation or quantization
 activation_fn = cr[act_cr_idx]
-activated[i]  = activation_fn(r_acc[i])   for i in 0..valid_elements-1
+activated[i]  = activation_fn(R_ACC[i])   for i in 0..valid_elements-1
 ```
 
 Supported activation functions:
@@ -157,13 +157,13 @@ Supported activation functions:
 
 #### Emulator: `ACTIVATE` and configuring α (“virtual” parameters)
 
-The block diagram and `act_cr_idx` discussion above describe the staged hardware view. In **this repository’s Python emulator**, element-wise activations on `r_acc` are issued with the **`ACTIVATE`** AAQ-slot instruction:
+The block diagram and `act_cr_idx` discussion above describe the staged hardware view. In **this repository’s Python emulator**, element-wise activations on `R_ACC` are issued with the **`ACTIVATE`** AAQ-slot instruction:
 
 ```asm
-ACTIVATE lr0 relu;;
+ACTIVATE LR0 relu;;
 ```
 
-Syntax: **`ACTIVATE`** *valid_elements* *activation_fn*, where *valid_elements* is an `lr`/`cr` source (same masking rules as `AGG`) and *activation_fn* is a **keyword** (`identity`, `relu`, `relu6`, `leaky_relu`, `sigmoid`, `tanh`, `gelu`, `silu`, `softplus`, `elu`, `prelu`, `exp2`). The canonical spellings and encoding order live in `src/tools/ipu-common/src/ipu_common/activations.py` as `ACTIVATION_FN_NAMES`, next to `apply_activation`.
+Syntax: **`ACTIVATE`** *valid_elements* *activation_fn*, where *valid_elements* is an `LR`/`CR` register selector (same masking rules as `AGG`) and *activation_fn* is a **keyword** (`identity`, `relu`, `relu6`, `leaky_relu`, `sigmoid`, `tanh`, `gelu`, `silu`, `softplus`, `elu`, `prelu`, `exp2`). The canonical spellings and encoding order live in `src/tools/ipu-common/src/ipu_common/activations.py` as `ACTIVATION_FN_NAMES`, next to `apply_activation`.
 
 **α for `leaky_relu`, `elu`, and `prelu`:** The ISA does not carry α. In software, α is **not** a register, environment variable, or CLI flag. It is fixed for the whole emulator by **module-level constants** in the same file:
 
@@ -179,11 +179,11 @@ To model different training or deployment assumptions, **edit those constants**,
 
 **Assembly syntax:** `agg <agg_mode> <post_fn> <valid_elements> <cr_idx> <aaq_rf_idx>`
 
-- `valid_elements`: any `lr0`–`lr15` or `cr0`–`cr15` operand (5-bit `LcrIdx` encoding). The **value** read from that register at cycle start is the number of `r_acc` lanes fed into the adder/max tree (unsigned, clamped to 0–128). Lanes from index `valid_elements` through 127 are masked out.
+- `valid_elements`: any `LR0`–`LR15` or `CR0`–`CR15` operand (5-bit `LcrIdx` encoding). The **value** read from that register at cycle start is the number of `R_ACC` lanes fed into the adder/max tree (unsigned, clamped to 0–128). Lanes from index `valid_elements` through 127 are masked out.
 
 ```text
-// r_acc lanes are always FP32; only the first valid_elements lanes are used
-values = [activation(r_acc[i]) for i in 0..valid_elements-1]
+// R_ACC lanes are always FP32; only the first valid_elements lanes are used
+values = [activation(R_ACC[i]) for i in 0..valid_elements-1]
 
 // Adder tree / max tree (feedback from RF included in max mode)
 if agg_mode == sum:
@@ -248,8 +248,8 @@ Same `valid_elements` masking rules as `agg`.
 Identical to `agg` except that `max` mode ignores the RF feedback value:
 
 ```text
-// r_acc lanes are always FP32; only the first valid_elements lanes are used
-values = [activation(r_acc[i]) for i in 0..valid_elements-1]
+// R_ACC lanes are always FP32; only the first valid_elements lanes are used
+values = [activation(R_ACC[i]) for i in 0..valid_elements-1]
 
 if agg_mode == sum:
     raw = sum(values)       // FP32 scalar; input to post_fn
@@ -266,31 +266,31 @@ reading stale data from the target register.
 
 ### 7.2 Quantize (`TBD`) Work in progress
 
-Requires INT8 mode (`cr15 == DType.INT8`). Takes no operands. Reads `r_acc`
+Requires INT8 mode (`CR15 == DType.INT8`). Takes no operands. Reads `R_ACC`
 lanes as FP32, quantizes to INT8, clamps, and writes the 128-byte result to
-`aaq_result`.
+`AAQ_RESULT`.
 
 ```text
-// cr15 must be DType.INT8; r_acc lanes are FP32
+// CR15 must be DType.INT8; R_ACC lanes are FP32
 for i in 0..127:
-    val            = r_acc[i]        // FP32
-    aaq_result[i]  = clamp(round(val), -128, 127)
+    val            = R_ACC[i]        // FP32
+    AAQ_RESULT[i]  = clamp(round(val), -128, 127)
 ```
 
 Notes:
 - The Quantization block appends 12 bits of metadata to the 1024-bit data
-  payload to form the full 1036-bit `aaq_result`: bits [11:4] = 8-bit scale
+  payload to form the full 1036-bit `AAQ_RESULT`: bits [11:4] = 8-bit scale
   factor, bits [3:0] = 4-bit representation type (INT8, e6m1, e5m2, …).
-- `aaq_result` must be flushed to XMEM with `XMEM.STORE_AAQ_RESULT offset base`
+- `AAQ_RESULT` must be flushed to XMEM with `XMEM.STORE_AAQ_RESULT offset base`
   before the next `AAQ` overwrites it.
 - In wide-vector debug mode `AAQ` is a no-op unless
   `wide_vector_quantize_output` is explicitly set (debug feature only).
 
-**ISA Interactions** — instructions in other slots that consume `aaq_result` written by `AAQ`:
+**ISA Interactions** — instructions in other slots that consume `AAQ_RESULT` written by `AAQ`:
 
 | Instruction | Slot | Operation |
 |-------------|------|-----------|
-| `XMEM.STORE_AAQ_RESULT offset base` | XMEM | Writes the 128-byte `aaq_result` register to XMEM at address `offset + base`. Must be issued before the next `AAQ` to avoid overwrite. |
+| `XMEM.STORE_AAQ_RESULT offset base` | XMEM | Writes the 128-byte `AAQ_RESULT` register to XMEM at address `offset + base`. Must be issued before the next `AAQ` to avoid overwrite. |
 
 ## 8. ISA 
 

--- a/docs/content/specs/stage-aaq.md
+++ b/docs/content/specs/stage-aaq.md
@@ -155,25 +155,9 @@ Supported activation functions:
 | 10 | `prelu` | `f(x) = x if x ≥ 0 else α·x` | Like Leaky ReLU but α is a learned per-channel parameter. |
 | 11 | `exp2` | `f(x) = 2^x` | Used for dequantization, softmax and attention scaling. |
 
-#### Emulator: `ACTIVATE` and configuring α (“virtual” parameters)
+#### α parameters (hardware)
 
-The block diagram and `act_cr_idx` discussion above describe the staged hardware view. In **this repository’s Python emulator**, element-wise activations on `R_ACC` are issued with the **`ACTIVATE`** AAQ-slot instruction:
-
-```asm
-ACTIVATE LR0 relu;;
-```
-
-Syntax: **`ACTIVATE`** *valid_elements* *activation_fn*, where *valid_elements* is an `LR`/`CR` register selector (same masking rules as `AGG`) and *activation_fn* is a **keyword** (`identity`, `relu`, `relu6`, `leaky_relu`, `sigmoid`, `tanh`, `gelu`, `silu`, `softplus`, `elu`, `prelu`, `exp2`). The canonical spellings and encoding order live in `src/tools/ipu-common/src/ipu_common/activations.py` as `ACTIVATION_FN_NAMES`, next to `apply_activation`.
-
-**α for `leaky_relu`, `elu`, and `prelu`:** The ISA does not carry α. In software, α is **not** a register, environment variable, or CLI flag. It is fixed for the whole emulator by **module-level constants** in the same file:
-
-| Name in `activations.py` | Activation | Default |
-|---------------------------|--------------|---------|
-| `_LEAKY_ALPHA` | `leaky_relu` | `0.01` |
-| `_ELU_ALPHA` | `elu` | `1.0` |
-| `_PRELU_ALPHA` | `prelu` | `0.25` |
-
-To model different training or deployment assumptions, **edit those constants**, then run your usual checks (for example `bazel test //…`). That is the supported “virtual configuration” path: calibration is intentionally **outside** the instruction stream. For experiments that need several α values in one process, use separate builds, test-only copies of the helpers, or a harness that swaps a patched `activations` module before loading the emulator.
+For `leaky_relu`, `elu`, and `prelu`, the scalar **α** is **not** carried in the AAQ opcode or in general-purpose `CR` operands shown in assembly. Real implementations source α from **implementation-defined configuration** (for example: a fixed design-time constant per SKU, efuses, a small side-band register file, or a microcode RAM entry selected with the activation). The same α applies to every valid lane for that operation. Integrators document the legal α values and how they are selected for each product.
 
 ### 7.1 Aggregate (`agg`)
 

--- a/docs/content/specs/stage-aaq.md
+++ b/docs/content/specs/stage-aaq.md
@@ -9,6 +9,8 @@ vector for output. It produces:
 - Scalar results in `aaq0`–`aaq3` via `agg` and `agg.first`.
 - A 128-byte `aaq_result` vector via `aaq` (any 8-bit format: INT8 or FP8 e(x)m(7-x)).
 
+**Python emulator (interim):** the in-tree emulator models **`POST_AAQ_REG` as 512 bytes** (same footprint as `r_acc`) until end-to-end quantization export is finalized; **`STR_POST_AAQ_REG`** stores that full register to XMEM. The **128-byte** `aaq_result` description below remains the architectural quantized payload. See [Building Applications](../building-applications.md#activations-emulator).
+
 ## 2. Block Diagram
 
 ```mermaid

--- a/docs/content/specs/stage-aaq.md
+++ b/docs/content/specs/stage-aaq.md
@@ -7,7 +7,7 @@ into scalar activation values and/or quantizes the accumulator into an FP8
 vector for output. It produces:
 
 - Scalar results in `AAQ0`–`AAQ3` via `agg` and `agg.first`.
-- A 128-byte `AAQ_RESULT` vector via `aaq` (any 8-bit format: INT8 or FP8 e(x)m(7-x)).
+- A 128-byte temporary staging register **POST_AAQ_REG** via `aaq` (8-bit lanes: INT8 or FP8 e(x)m(7-x)), written to XMEM with **`STR_POST_AAQ_REG`**. The full on-chip **`AAQ_RESULT`** bundle (§3.2) includes the same lane bytes plus scale/representation metadata.
 
 ## 2. Block Diagram
 
@@ -113,10 +113,7 @@ flowchart LR
 
 - `R_ACC` is 512 bytes (128 × 32-bit lanes). Lanes are always FP32.
 - `AAQ0`–`AAQ3` are 32-bit registers. They store float32 bit patterns.
-- `AAQ_RESULT` is produced only by `aaq`. It contains 128 × 8 bit quantized
-  values (1024 bits) plus 12 bits of metadata appended by the Quantization
-  block: bits [11:4] = 8-bit scale factor, bits [3:0] = 4-bit representation
-  type (INT8, e6m1, e5m2, …). It is written to XMEM via `xmem.store_aaq_result`.
+- After `aaq`, the **128 × 8-bit quantized lane payload** is held in the temporary staging register **`POST_AAQ_REG`** (overwritten by the next `aaq`). The Quantization block also forms the wider **`AAQ_RESULT`** output (1024 lane bits plus 12 bits of metadata: bits [11:4] = 8-bit scale factor, bits [3:0] = 4-bit representation type, INT8 / e6m1 / e5m2 / …). Flush the lane bytes to XMEM with **`STR_POST_AAQ_REG`** before issuing another `aaq` if you need the previous vector in memory.
 
 ## 6. Disclaimers
 
@@ -251,30 +248,30 @@ reading stale data from the target register.
 ### 7.2 Quantize (`TBD`) Work in progress
 
 Requires INT8 mode (`CR15 == DType.INT8`). Takes no operands. Reads `R_ACC`
-lanes as FP32, quantizes to INT8, clamps, and writes the 128-byte result to
-`AAQ_RESULT`.
+lanes as FP32, quantizes to INT8, clamps, and writes the 128-byte lane payload to
+`POST_AAQ_REG`.
 
 ```text
 // CR15 must be DType.INT8; R_ACC lanes are FP32
 for i in 0..127:
     val            = R_ACC[i]        // FP32
-    AAQ_RESULT[i]  = clamp(round(val), -128, 127)
+    POST_AAQ_REG[i]  = clamp(round(val), -128, 127)
 ```
 
 Notes:
 - The Quantization block appends 12 bits of metadata to the 1024-bit data
   payload to form the full 1036-bit `AAQ_RESULT`: bits [11:4] = 8-bit scale
   factor, bits [3:0] = 4-bit representation type (INT8, e6m1, e5m2, …).
-- `AAQ_RESULT` must be flushed to XMEM with `XMEM.STORE_AAQ_RESULT offset base`
-  before the next `AAQ` overwrites it.
+- `POST_AAQ_REG` must be flushed to XMEM with **`STR_POST_AAQ_REG offset base`**
+  before the next `aaq` overwrites it.
 - In wide-vector debug mode `AAQ` is a no-op unless
   `wide_vector_quantize_output` is explicitly set (debug feature only).
 
-**ISA Interactions** — instructions in other slots that consume `AAQ_RESULT` written by `AAQ`:
+**ISA Interactions** — instructions in other slots that consume `POST_AAQ_REG` written by `AAQ`:
 
 | Instruction | Slot | Operation |
 |-------------|------|-----------|
-| `XMEM.STORE_AAQ_RESULT offset base` | XMEM | Writes the 128-byte `AAQ_RESULT` register to XMEM at address `offset + base`. Must be issued before the next `AAQ` to avoid overwrite. |
+| `STR_POST_AAQ_REG offset base` | XMEM | Writes the 128-byte **`POST_AAQ_REG`** staging register to XMEM at address `offset + base`. Must be issued before the next `aaq` overwrites the staging latch. |
 
 ## 8. ISA 
 

--- a/docs/content/wide-vector-debug-mode.md
+++ b/docs/content/wide-vector-debug-mode.md
@@ -19,7 +19,7 @@ Construct [`IpuState`](https://github.com/rechefe/ipu-emulator/blob/master/src/t
 |-----------|---------|---------|
 | `wide_vector_debug` | `False` | Turn wide-vector mode on. |
 | `wide_vector_arithmetic` | `WideVectorArithmetic.FP32` | `FP32` or `INT32` lane arithmetic. |
-| `wide_vector_quantize_output` | `False` | If `True`, the `AAQ` instruction writes `aaq_result` from wide lanes for comparison with the real quantized path. If `False`, `AAQ` does nothing in wide mode (results stay in `r_acc`). |
+| `wide_vector_quantize_output` | `False` | If `True`, the `AAQ` instruction writes `AAQ_RESULT` from wide lanes for comparison with the real quantized path. If `False`, `AAQ` does nothing in wide mode (results stay in `R_ACC`). |
 
 ```python
 from ipu_emu.ipu_state import IpuState, WideVectorArithmetic
@@ -32,7 +32,7 @@ state = IpuState(
     wide_vector_arithmetic=WideVectorArithmetic.FP32,
     wide_vector_quantize_output=False,
 )
-# load program, set cr15 / XMEM as usual, then:
+# load program, set CR15 / XMEM as usual, then:
 run_until_complete(state)
 ```
 
@@ -62,7 +62,7 @@ Wide mode unpacks `r_cyclic` as 128 consecutive 32-bit lanes starting at a **byt
 ## Semantics that differ from normal mode
 
 - **Multiply masks** (`mask_offset` immediate slot 0–7 / `mask_shift` LR): mask-and-shift on `mult_res` is **disabled** in wide mode, because the 128-bit mask layout does not map to 128 FP32/INT32 lanes.
-- **`AAQ`**: unless `wide_vector_quantize_output=True`, **`AAQ` is a no-op** in wide mode; full lane results remain in **`r_acc`**. Use the existing debug-only **`STR_ACC_REG`** instruction (or read `r_acc` in Python) to dump 512 elements of accumulator data.
+- **`AAQ`**: unless `wide_vector_quantize_output=True`, **`AAQ` is a no-op** in wide mode; full lane results remain in **`R_ACC`**. Use the existing debug-only **`STR_ACC_REG`** instruction (or read `R_ACC` in Python) to dump 512 elements of accumulator data.
 - **LR and CR** are **not** widened; scalars such as **`MULT.VE.CR`** still use the **low byte** of a CR as a signed value in the wide path.
 
 ## INT32 vs FP32

--- a/docs/content/wide-vector-debug-mode.md
+++ b/docs/content/wide-vector-debug-mode.md
@@ -19,7 +19,7 @@ Construct [`IpuState`](https://github.com/rechefe/ipu-emulator/blob/master/src/t
 |-----------|---------|---------|
 | `wide_vector_debug` | `False` | Turn wide-vector mode on. |
 | `wide_vector_arithmetic` | `WideVectorArithmetic.FP32` | `FP32` or `INT32` lane arithmetic. |
-| `wide_vector_quantize_output` | `False` | If `True`, the `AAQ` instruction writes `AAQ_RESULT` from wide lanes for comparison with the real quantized path. If `False`, `AAQ` does nothing in wide mode (results stay in `R_ACC`). |
+| `wide_vector_quantize_output` | `False` | If `True`, the `AAQ` instruction writes `POST_AAQ_REG` from wide lanes for comparison with the real quantized path. If `False`, `AAQ` does nothing in wide mode (results stay in `R_ACC`). |
 
 ```python
 from ipu_emu.ipu_state import IpuState, WideVectorArithmetic

--- a/docs/content/wide-vector-debug-mode.md
+++ b/docs/content/wide-vector-debug-mode.md
@@ -19,7 +19,7 @@ Construct [`IpuState`](https://github.com/rechefe/ipu-emulator/blob/master/src/t
 |-----------|---------|---------|
 | `wide_vector_debug` | `False` | Turn wide-vector mode on. |
 | `wide_vector_arithmetic` | `WideVectorArithmetic.FP32` | `FP32` or `INT32` lane arithmetic. |
-| `wide_vector_quantize_output` | `False` | If `True`, the `AAQ` instruction writes the **leading 128 bytes** of **`POST_AAQ_REG`** (a **512-byte** interim register) from wide lanes for comparison with the real quantized path. If `False`, `AAQ` does nothing in wide mode (results stay in `R_ACC`). |
+| `wide_vector_quantize_output` | `False` | If `True`, `AAQ` quantizes the **wide lanes in `POST_AAQ_REG`** (typically filled with **`ACTIVATE`** from `r_acc`, e.g. **`ACTIVATE` … `identity`** to copy) into the **leading 128 bytes** of that register. If `False`, `AAQ` does nothing in wide mode (wide lanes stay in `R_ACC` until you stage them). |
 
 ```python
 from ipu_emu.ipu_state import IpuState, WideVectorArithmetic

--- a/docs/content/wide-vector-debug-mode.md
+++ b/docs/content/wide-vector-debug-mode.md
@@ -19,7 +19,7 @@ Construct [`IpuState`](https://github.com/rechefe/ipu-emulator/blob/master/src/t
 |-----------|---------|---------|
 | `wide_vector_debug` | `False` | Turn wide-vector mode on. |
 | `wide_vector_arithmetic` | `WideVectorArithmetic.FP32` | `FP32` or `INT32` lane arithmetic. |
-| `wide_vector_quantize_output` | `False` | If `True`, the `AAQ` instruction writes `POST_AAQ_REG` from wide lanes for comparison with the real quantized path. If `False`, `AAQ` does nothing in wide mode (results stay in `R_ACC`). |
+| `wide_vector_quantize_output` | `False` | If `True`, the `AAQ` instruction writes the **leading 128 bytes** of **`POST_AAQ_REG`** (a **512-byte** interim register) from wide lanes for comparison with the real quantized path. If `False`, `AAQ` does nothing in wide mode (results stay in `R_ACC`). |
 
 ```python
 from ipu_emu.ipu_state import IpuState, WideVectorArithmetic

--- a/src/tools/ipu-apps/src/ipu_apps/base.py
+++ b/src/tools/ipu-apps/src/ipu_apps/base.py
@@ -36,7 +36,9 @@ class IpuApp:
     Args:
         inst_path:   Path to the assembled instruction binary.
         output_path: Optional path to write output data.
-        **kwargs:    Any extra fields are stored as attributes.
+        **kwargs:    Any extra fields are stored as attributes (for example
+            ``leaky_relu_alpha`` / ``elu_alpha`` / ``prelu_alpha`` for
+            :meth:`run`).
     """
 
     def __init__(
@@ -62,12 +64,34 @@ class IpuApp:
         *,
         max_cycles: int = 1_000_000,
         debug_callback: DebugCallback | None = None,
+        state: "IpuState | None" = None,
+        leaky_relu_alpha: float | None = None,
+        elu_alpha: float | None = None,
+        prelu_alpha: float | None = None,
     ) -> tuple["IpuState", int]:
-        """Run the app end-to-end. Returns ``(state, cycles)``."""
+        """Run the app end-to-end. Returns ``(state, cycles)``.
+
+        Optional ``leaky_relu_alpha`` / ``elu_alpha`` / ``prelu_alpha`` match
+        :func:`ipu_emu.emulator.run_test`: they configure emulator-only activation
+        α (not CR). Explicit arguments win; otherwise attributes stored on the
+        app from ``__init__(**kwargs)`` (for example ``MyApp(..., leaky_relu_alpha=0.05)``)
+        are used when present.
+        """
+        lr = (
+            leaky_relu_alpha
+            if leaky_relu_alpha is not None
+            else getattr(self, "leaky_relu_alpha", None)
+        )
+        ea = elu_alpha if elu_alpha is not None else getattr(self, "elu_alpha", None)
+        pa = prelu_alpha if prelu_alpha is not None else getattr(self, "prelu_alpha", None)
         return run_test(
             inst_path=self.inst_path,
             setup=self.setup,
             teardown=self.teardown,
             max_cycles=max_cycles,
             debug_callback=debug_callback,
+            state=state,
+            leaky_relu_alpha=lr,
+            elu_alpha=ea,
+            prelu_alpha=pa,
         )

--- a/src/tools/ipu-as-py/src/ipu_as/gen_docs.py
+++ b/src/tools/ipu-as-py/src/ipu_as/gen_docs.py
@@ -58,7 +58,8 @@ OPERAND_TYPE_DETAILS: dict[str, str] = {
     "ActivationFn": (
         "AAQ-slot keyword on **`ACTIVATE`**: one of **identity**, **relu**, **relu6**, **leaky_relu**, "
         "**sigmoid**, **tanh**, **gelu**, **silu** (alias **swish**), **softplus**, **elu**, **prelu**, **exp2** "
-        "(see ``ACTIVATION_FN_NAMES`` in ``ipu_common.activations``)."
+        "(see ``ACTIVATION_FN_NAMES`` in ``ipu_common.activations``). Emulator-only calibration (including α) "
+        "is covered in **Building Applications** (`docs/content/building-applications.md#activations-emulator`)."
     ),
     "Immediate": (
         "Signed **16-bit** immediate carried in the LR slot (sign-extended by the emulator for "
@@ -70,7 +71,7 @@ OPERAND_TYPE_DETAILS: dict[str, str] = {
     ),
     "MultMaskOffsetImmediate": (
         "Unsigned **3-bit** immediate on multiply instructions: **`mask_offset`** selects slot "
-        "**`0`**–**`7`**, each a **128-bit** region of **`r_mask`** (eight mask slots total). "
+        "**`0`**–**`7`**, each a **128-bit** region of **`R_MASK`** (eight mask slots total). "
         "**`mask_shift`** remains an **`LrIdx`**."
     ),
     "BreakImmediate": "16-bit value for **`BREAK`** / breakpoint slot conditions.",

--- a/src/tools/ipu-as-py/src/ipu_as/gen_docs.py
+++ b/src/tools/ipu-as-py/src/ipu_as/gen_docs.py
@@ -60,7 +60,8 @@ OPERAND_TYPE_DETAILS: dict[str, str] = {
         "AAQ-slot keyword on **`ACTIVATE`**: one of **identity**, **relu**, **relu6**, **leaky_relu**, "
         "**sigmoid**, **tanh**, **gelu**, **silu** (alias **swish**), **softplus**, **elu**, **prelu**, **exp2** "
         "(see ``ACTIVATION_FN_NAMES`` in ``ipu_common.activations``). Emulator-only calibration (including α) "
-        "is covered in **Building Applications** (`docs/content/building-applications.md#activations-emulator`)."
+        "and the temporary **`STR_POST_AAQ_REG` → `R_ACC` (512 B)** export are described in **Building Applications** "
+        "(`docs/content/building-applications.md#activations-emulator`)."
     ),
     "LrModPow2KImmediate": (
         "Four-bit immediate for **`INCR_MOD_POW2`**: encodes exponent **k** with semantic "

--- a/src/tools/ipu-as-py/src/ipu_as/gen_docs.py
+++ b/src/tools/ipu-as-py/src/ipu_as/gen_docs.py
@@ -55,9 +55,10 @@ OPERAND_TYPE_DETAILS: dict[str, str] = {
         "AAQ-slot immediate: post-aggregation function selector (identity, inverse sqrt, etc.); "
         "see `acc_agg_enums`."
     ),
-    "ActivationFnId": (
-        "AAQ-slot **4-bit** unsigned immediate on **`ACTIVATE`**: ids **0**–**11** select the "
-        "activation (see `ipu_common.activations`); **12**–**15** are reserved and decode as identity."
+    "ActivationFn": (
+        "AAQ-slot keyword on **`ACTIVATE`**: one of **identity**, **relu**, **relu6**, **leaky_relu**, "
+        "**sigmoid**, **tanh**, **gelu**, **silu** (alias **swish**), **softplus**, **elu**, **prelu**, **exp2** "
+        "(see ``ACTIVATION_FN_NAMES`` in ``ipu_common.activations``)."
     ),
     "Immediate": (
         "Signed **16-bit** immediate carried in the LR slot (sign-extended by the emulator for "

--- a/src/tools/ipu-as-py/src/ipu_as/gen_docs.py
+++ b/src/tools/ipu-as-py/src/ipu_as/gen_docs.py
@@ -55,6 +55,10 @@ OPERAND_TYPE_DETAILS: dict[str, str] = {
         "AAQ-slot immediate: post-aggregation function selector (identity, inverse sqrt, etc.); "
         "see `acc_agg_enums`."
     ),
+    "ActivationFnId": (
+        "AAQ-slot **4-bit** unsigned immediate on **`ACTIVATE`**: ids **0**–**11** select the "
+        "activation (see `ipu_common.activations`); **12**–**15** are reserved and decode as identity."
+    ),
     "Immediate": (
         "Signed **16-bit** immediate carried in the LR slot (sign-extended by the emulator for "
         "`SET`)."

--- a/src/tools/ipu-as-py/src/ipu_as/gen_docs.py
+++ b/src/tools/ipu-as-py/src/ipu_as/gen_docs.py
@@ -60,7 +60,8 @@ OPERAND_TYPE_DETAILS: dict[str, str] = {
         "AAQ-slot keyword on **`ACTIVATE`**: one of **identity**, **relu**, **relu6**, **leaky_relu**, "
         "**sigmoid**, **tanh**, **gelu**, **silu** (alias **swish**), **softplus**, **elu**, **prelu**, **exp2** "
         "(see ``ACTIVATION_FN_NAMES`` in ``ipu_common.activations``). Emulator-only calibration (including α) "
-        "and the temporary **`STR_POST_AAQ_REG` → `R_ACC` (512 B)** export are described in **Building Applications** "
+        "and how **`POST_AAQ_REG`** (interim **512 B**) and **`STR_POST_AAQ_REG`** (store to XMEM) "
+        "are described in **Building Applications** "
         "(`docs/content/building-applications.md#activations-emulator`)."
     ),
     "LrModPow2KImmediate": (

--- a/src/tools/ipu-as-py/src/ipu_as/immediate.py
+++ b/src/tools/ipu-as-py/src/ipu_as/immediate.py
@@ -102,6 +102,39 @@ class MultMaskOffsetImmediate(ipu_token.IpuToken):
         return str(value)
 
 
+class ActivationFnIdField(ipu_token.IpuToken):
+    """Unsigned activation selector for ``ACTIVATE`` (ids ``0`` through ``11``)."""
+
+    _FIELD_BITS = 4
+    _MAX_ENCODED = (1 << _FIELD_BITS) - 1  # 0..15; ids >= 12 are identity at runtime
+
+    @classmethod
+    def bits(cls) -> int:
+        return cls._FIELD_BITS
+
+    @classmethod
+    def default(cls) -> "ipu_token.IpuToken":
+        return cls(ipu_token.AnnotatedToken(lark.Token("NUMBER", "0"), 0))
+
+    def __init__(self, token: ipu_token.AnnotatedToken):
+        super().__init__(token)
+        try:
+            self.int = int(token.token.value, 0)
+        except ValueError:
+            self._raise_error(f"Value {self.token.value} is not a valid integer")
+        if not (0 <= self.int <= self._MAX_ENCODED):
+            self._raise_error(
+                f"Activation function id must be in [0, {self._MAX_ENCODED}], got {self.int}"
+            )
+
+    def encode(self) -> int:
+        return self.int
+
+    @classmethod
+    def decode(cls, value: int) -> str:
+        return str(value)
+
+
 # Encoding matches LcrIdx for register indices 0–31; values ≥32 encode IMM5 (payload in low 5 bits).
 _ADD_SUB_SRC_B_REGS: tuple[str, ...] = tuple(
     [f"lr{i}" for i in range(16)] + [f"cr{i}" for i in range(16)]

--- a/src/tools/ipu-as-py/src/ipu_as/immediate.py
+++ b/src/tools/ipu-as-py/src/ipu_as/immediate.py
@@ -102,37 +102,27 @@ class MultMaskOffsetImmediate(ipu_token.IpuToken):
         return str(value)
 
 
-class ActivationFnIdField(ipu_token.IpuToken):
-    """Unsigned activation selector for ``ACTIVATE`` (ids ``0`` through ``11``)."""
+from ipu_common.activations import ACTIVATION_FN_NAMES
 
-    _FIELD_BITS = 4
-    _MAX_ENCODED = (1 << _FIELD_BITS) - 1  # 0..15; ids >= 12 are identity at runtime
 
-    @classmethod
-    def bits(cls) -> int:
-        return cls._FIELD_BITS
+class ActivationFnField(ipu_token.EnumToken):
+    """Activation keyword for ``ACTIVATE`` (names from ``ACTIVATION_FN_NAMES``)."""
+
+    _TOKEN_ALIASES: dict[str, str] = {"swish": "silu"}
 
     @classmethod
-    def default(cls) -> "ipu_token.IpuToken":
-        return cls(ipu_token.AnnotatedToken(lark.Token("NUMBER", "0"), 0))
+    def enum_array(cls) -> list[str]:
+        return list(ACTIVATION_FN_NAMES)
 
     def __init__(self, token: ipu_token.AnnotatedToken):
-        super().__init__(token)
-        try:
-            self.int = int(token.token.value, 0)
-        except ValueError:
-            self._raise_error(f"Value {self.token.value} is not a valid integer")
-        if not (0 <= self.int <= self._MAX_ENCODED):
-            self._raise_error(
-                f"Activation function id must be in [0, {self._MAX_ENCODED}], got {self.int}"
+        raw = token.token.value.lower()
+        if raw in self._TOKEN_ALIASES:
+            t = token.token
+            token = ipu_token.AnnotatedToken(
+                lark.Token(t.type, self._TOKEN_ALIASES[raw], t.line, t.column),
+                token.instr_id,
             )
-
-    def encode(self) -> int:
-        return self.int
-
-    @classmethod
-    def decode(cls, value: int) -> str:
-        return str(value)
+        super().__init__(token)
 
 
 # Encoding matches LcrIdx for register indices 0–31; values ≥32 encode IMM5 (payload in low 5 bits).

--- a/src/tools/ipu-as-py/src/ipu_as/inst.py
+++ b/src/tools/ipu-as-py/src/ipu_as/inst.py
@@ -39,6 +39,7 @@ OPERAND_TYPE_MAP: dict[str, type[ipu_token.IpuToken]] = {
     "Immediate": immediate.LrImmediateType,
     "LrModPow2KImmediate": immediate.LrModPow2KImmediate,
     "MultMaskOffsetImmediate": immediate.MultMaskOffsetImmediate,
+    "ActivationFnId": immediate.ActivationFnIdField,
     "BreakImmediate": immediate.BreakImmediateType,
     "Label": ipu_token.LabelToken,
 }
@@ -442,6 +443,7 @@ class AaqInst(Inst):
             immediate.PostFnField,
             reg.LcrRegField,
             reg.CrRegField,
+            immediate.ActivationFnIdField,
             reg.AaqRegField,
         ]
 

--- a/src/tools/ipu-as-py/src/ipu_as/inst.py
+++ b/src/tools/ipu-as-py/src/ipu_as/inst.py
@@ -469,7 +469,7 @@ class AaqInst(Inst):
     def description(cls) -> str:
         return cls._render_instruction_docs(
             heading="AAQ Instructions",
-            intro="Activation and quantization: aggregate r_acc into AAQ registers.",
+            intro="Activation and quantization: aggregate r_acc into AAQ registers; ACTIVATE applies element-wise activations in place.",
             slot_type="aaq",
         )
 

--- a/src/tools/ipu-as-py/src/ipu_as/inst.py
+++ b/src/tools/ipu-as-py/src/ipu_as/inst.py
@@ -39,7 +39,7 @@ OPERAND_TYPE_MAP: dict[str, type[ipu_token.IpuToken]] = {
     "Immediate": immediate.LrImmediateType,
     "LrModPow2KImmediate": immediate.LrModPow2KImmediate,
     "MultMaskOffsetImmediate": immediate.MultMaskOffsetImmediate,
-    "ActivationFnId": immediate.ActivationFnIdField,
+    "ActivationFn": immediate.ActivationFnField,
     "BreakImmediate": immediate.BreakImmediateType,
     "Label": ipu_token.LabelToken,
 }
@@ -443,7 +443,7 @@ class AaqInst(Inst):
             immediate.PostFnField,
             reg.LcrRegField,
             reg.CrRegField,
-            immediate.ActivationFnIdField,
+            immediate.ActivationFnField,
             reg.AaqRegField,
         ]
 

--- a/src/tools/ipu-as-py/src/ipu_as/inst.py
+++ b/src/tools/ipu-as-py/src/ipu_as/inst.py
@@ -466,7 +466,7 @@ class AaqInst(Inst):
     def description(cls) -> str:
         return cls._render_instruction_docs(
             heading="AAQ Instructions",
-            intro="Activation and quantization: aggregate r_acc into AAQ registers; ACTIVATE applies element-wise activations in place.",
+            intro="Activation and quantization: aggregate r_acc into AAQ registers; ACTIVATE writes activated lanes from r_acc into POST_AAQ_REG; AAQ quantizes POST_AAQ_REG.",
             slot_type="aaq",
         )
 

--- a/src/tools/ipu-common/src/ipu_common/activations.py
+++ b/src/tools/ipu-common/src/ipu_common/activations.py
@@ -1,8 +1,10 @@
 """Element-wise activation functions for IPU accumulator lanes.
 
-Encodings match ``docs/content/specs/stage-aaq.md`` §7.0. Alpha parameters for
+Encodings match ``docs/content/specs/stage-aaq.md`` section 7.0. Alpha parameters for
 ``leaky_relu``, ``elu``, and ``prelu`` are fixed simulator constants (not part
-of the ISA); extend :func:`apply_activation` when adding new kinds.
+of the ISA). The ``ACTIVATE`` instruction passes the function id as a 4-bit
+immediate; values **12**–**15** are reserved and :func:`apply_activation` treats
+them as identity.
 """
 
 from __future__ import annotations

--- a/src/tools/ipu-common/src/ipu_common/activations.py
+++ b/src/tools/ipu-common/src/ipu_common/activations.py
@@ -4,7 +4,8 @@ Encodings match ``docs/content/specs/stage-aaq.md`` section 7.0. Alpha parameter
 ``leaky_relu``, ``elu``, and ``prelu`` are fixed simulator constants (not part
 of the ISA). Assembly uses ``ACTIVATE … <name>`` where ``<name>`` is one of the
 strings in ``ACTIVATION_FN_NAMES`` (same order as ids **0**–**11**). Emulator
-calibration (including α) is described in ``docs/content/building-applications.md#activations-emulator``.
+calibration (including α) and how ``STR_POST_AAQ_REG`` temporarily exports ``R_ACC``
+(512 B) vs ``POST_AAQ_REG`` are described in ``docs/content/building-applications.md#activations-emulator``.
 """
 
 from __future__ import annotations

--- a/src/tools/ipu-common/src/ipu_common/activations.py
+++ b/src/tools/ipu-common/src/ipu_common/activations.py
@@ -1,0 +1,85 @@
+"""Element-wise activation functions for IPU accumulator lanes.
+
+Encodings match ``docs/content/specs/stage-aaq.md`` §7.0. Alpha parameters for
+``leaky_relu``, ``elu``, and ``prelu`` are fixed simulator constants (not part
+of the ISA); extend :func:`apply_activation` when adding new kinds.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Final
+
+ACTIVATION_IDENTITY = 0
+ACTIVATION_RELU = 1
+ACTIVATION_RELU6 = 2
+ACTIVATION_LEAKY_RELU = 3
+ACTIVATION_SIGMOID = 4
+ACTIVATION_TANH = 5
+ACTIVATION_GELU = 6
+ACTIVATION_SILU = 7
+ACTIVATION_SOFTPLUS = 8
+ACTIVATION_ELU = 9
+ACTIVATION_PRELU = 10
+ACTIVATION_EXP2 = 11
+
+ACTIVATION_COUNT = 12
+
+# Fixed α values — virtual configuration outside the ISA (issue #77).
+_LEAKY_ALPHA: Final[float] = 0.01
+_ELU_ALPHA: Final[float] = 1.0
+_PRELU_ALPHA: Final[float] = 0.25
+
+
+def _sigmoid(x: float) -> float:
+    if x >= 0.0:
+        z = math.exp(-x)
+        return 1.0 / (1.0 + z)
+    z = math.exp(x)
+    return z / (1.0 + z)
+
+
+def _norm_cdf(x: float) -> float:
+    return 0.5 * (1.0 + math.erf(x / math.sqrt(2.0)))
+
+
+def _softplus(x: float) -> float:
+    # log(1+exp(x)); stable for large |x|
+    if x > 20.0:
+        return x
+    if x < -20.0:
+        return math.exp(x)
+    return math.log1p(math.exp(x))
+
+
+def apply_activation(fn_id: int, x: float) -> float:
+    """Apply activation ``fn_id`` (0–11) to scalar ``x``. Unknown ids → identity."""
+    k = int(fn_id) & 0xFFFFFFFF
+    if k >= ACTIVATION_COUNT:
+        return x
+
+    if k == ACTIVATION_IDENTITY:
+        return x
+    if k == ACTIVATION_RELU:
+        return x if x > 0.0 else 0.0
+    if k == ACTIVATION_RELU6:
+        return min(max(x, 0.0), 6.0)
+    if k == ACTIVATION_LEAKY_RELU:
+        return x if x >= 0.0 else _LEAKY_ALPHA * x
+    if k == ACTIVATION_SIGMOID:
+        return _sigmoid(x)
+    if k == ACTIVATION_TANH:
+        return math.tanh(x)
+    if k == ACTIVATION_GELU:
+        return x * _norm_cdf(x)
+    if k == ACTIVATION_SILU:
+        return x * _sigmoid(x)
+    if k == ACTIVATION_SOFTPLUS:
+        return _softplus(x)
+    if k == ACTIVATION_ELU:
+        return x if x >= 0.0 else _ELU_ALPHA * (math.exp(x) - 1.0)
+    if k == ACTIVATION_PRELU:
+        return x if x >= 0.0 else _PRELU_ALPHA * x
+    if k == ACTIVATION_EXP2:
+        return math.exp(x * math.log(2.0))
+    return x

--- a/src/tools/ipu-common/src/ipu_common/activations.py
+++ b/src/tools/ipu-common/src/ipu_common/activations.py
@@ -89,9 +89,9 @@ def apply_activation(
 ) -> float:
     """Apply activation ``fn_id`` (0–11) to scalar ``x``. Unknown ids → identity.
 
-    α arguments default to module-level ``DEFAULT_*`` / ``_*`` (so monkeypatching
-    ``_LEAKY_ALPHA`` etc. still affects calls that omit overrides). The emulator
-    passes per-:class:`ipu_emu.ipu_state.IpuState` values from ``execute_activate``.
+    If an α keyword is omitted, the value comes from the module ``DEFAULT_*``
+    constants (snapshotted onto :class:`ipu_emu.ipu_state.IpuState` at construction
+    for ``ACTIVATE``). Passing explicit α overrides those defaults for this call.
     """
     k = int(fn_id) & 0xFFFFFFFF
     if k >= ACTIVATION_COUNT:

--- a/src/tools/ipu-common/src/ipu_common/activations.py
+++ b/src/tools/ipu-common/src/ipu_common/activations.py
@@ -5,10 +5,10 @@ Encodings match ``docs/content/specs/stage-aaq.md`` section 7.0. α for
 override per run via :class:`ipu_emu.ipu_state.IpuState` constructor or
 :meth:`IpuState.set_activation_alphas` (not CR-visible). Assembly uses
 ``ACTIVATE … <name>`` where ``<name>`` is one of the strings in
-``ACTIVATION_FN_NAMES`` (same order as ids **0**–**11**). See
+``ACTIVATION_FN_NAMES`` (same order as ids **0**–**11**); the emulator writes
+activated lanes into ``POST_AAQ_REG``. See
 ``docs/content/building-applications.md#activations-emulator`` for calibration,
-``POST_AAQ_REG`` (interim **512 B**, same width as ``R_ACC``), and
-``STR_POST_AAQ_REG`` (store that register to XMEM).
+``STR_POST_AAQ_REG`` (store that register to XMEM), and pipeline notes.
 """
 
 from __future__ import annotations

--- a/src/tools/ipu-common/src/ipu_common/activations.py
+++ b/src/tools/ipu-common/src/ipu_common/activations.py
@@ -2,9 +2,8 @@
 
 Encodings match ``docs/content/specs/stage-aaq.md`` section 7.0. Alpha parameters for
 ``leaky_relu``, ``elu``, and ``prelu`` are fixed simulator constants (not part
-of the ISA). The ``ACTIVATE`` instruction passes the function id as a 4-bit
-immediate; values **12**–**15** are reserved and :func:`apply_activation` treats
-them as identity.
+of the ISA). Assembly uses ``ACTIVATE … <name>`` where ``<name>`` is one of the
+strings in ``ACTIVATION_FN_NAMES`` (same order as ids **0**–**11**).
 """
 
 from __future__ import annotations
@@ -26,6 +25,22 @@ ACTIVATION_PRELU = 10
 ACTIVATION_EXP2 = 11
 
 ACTIVATION_COUNT = 12
+
+# Assembly / encoding order (id = index); must match ACTIVATION_* constants above.
+ACTIVATION_FN_NAMES: tuple[str, ...] = (
+    "identity",
+    "relu",
+    "relu6",
+    "leaky_relu",
+    "sigmoid",
+    "tanh",
+    "gelu",
+    "silu",
+    "softplus",
+    "elu",
+    "prelu",
+    "exp2",
+)
 
 # Fixed α values — virtual configuration outside the ISA (issue #77).
 _LEAKY_ALPHA: Final[float] = 0.01

--- a/src/tools/ipu-common/src/ipu_common/activations.py
+++ b/src/tools/ipu-common/src/ipu_common/activations.py
@@ -1,17 +1,19 @@
 """Element-wise activation functions for IPU accumulator lanes.
 
-Encodings match ``docs/content/specs/stage-aaq.md`` section 7.0. Alpha parameters for
-``leaky_relu``, ``elu``, and ``prelu`` are fixed simulator constants (not part
-of the ISA). Assembly uses ``ACTIVATE … <name>`` where ``<name>`` is one of the
-strings in ``ACTIVATION_FN_NAMES`` (same order as ids **0**–**11**). Emulator
-calibration (including α) and how ``STR_POST_AAQ_REG`` temporarily exports ``R_ACC``
-(512 B) vs ``POST_AAQ_REG`` are described in ``docs/content/building-applications.md#activations-emulator``.
+Encodings match ``docs/content/specs/stage-aaq.md`` section 7.0. α for
+``leaky_relu``, ``elu``, and ``prelu`` defaults to ``DEFAULT_*`` constants below;
+override per run via :class:`ipu_emu.ipu_state.IpuState` constructor or
+:meth:`IpuState.set_activation_alphas` (not CR-visible). Assembly uses
+``ACTIVATE … <name>`` where ``<name>`` is one of the strings in
+``ACTIVATION_FN_NAMES`` (same order as ids **0**–**11**). See
+``docs/content/building-applications.md#activations-emulator`` for calibration
+and how ``STR_POST_AAQ_REG`` temporarily exports ``R_ACC`` (512 B) vs
+``POST_AAQ_REG``.
 """
 
 from __future__ import annotations
 
 import math
-from typing import Final
 
 ACTIVATION_IDENTITY = 0
 ACTIVATION_RELU = 1
@@ -44,10 +46,16 @@ ACTIVATION_FN_NAMES: tuple[str, ...] = (
     "exp2",
 )
 
-# Fixed α values — virtual configuration outside the ISA (issue #77).
-_LEAKY_ALPHA: Final[float] = 0.01
-_ELU_ALPHA: Final[float] = 1.0
-_PRELU_ALPHA: Final[float] = 0.25
+# Default α values — virtual configuration outside the ISA (issue #77).
+# Mutable so tests can monkeypatch; ``IpuState`` normally snapshots these at init.
+DEFAULT_LEAKY_ALPHA: float = 0.01
+DEFAULT_ELU_ALPHA: float = 1.0
+DEFAULT_PRELU_ALPHA: float = 0.25
+
+# Legacy private names (same objects) for older monkeypatch patterns.
+_LEAKY_ALPHA = DEFAULT_LEAKY_ALPHA
+_ELU_ALPHA = DEFAULT_ELU_ALPHA
+_PRELU_ALPHA = DEFAULT_PRELU_ALPHA
 
 
 def _sigmoid(x: float) -> float:
@@ -71,11 +79,27 @@ def _softplus(x: float) -> float:
     return math.log1p(math.exp(x))
 
 
-def apply_activation(fn_id: int, x: float) -> float:
-    """Apply activation ``fn_id`` (0–11) to scalar ``x``. Unknown ids → identity."""
+def apply_activation(
+    fn_id: int,
+    x: float,
+    *,
+    leaky_relu_alpha: float | None = None,
+    elu_alpha: float | None = None,
+    prelu_alpha: float | None = None,
+) -> float:
+    """Apply activation ``fn_id`` (0–11) to scalar ``x``. Unknown ids → identity.
+
+    α arguments default to module-level ``DEFAULT_*`` / ``_*`` (so monkeypatching
+    ``_LEAKY_ALPHA`` etc. still affects calls that omit overrides). The emulator
+    passes per-:class:`ipu_emu.ipu_state.IpuState` values from ``execute_activate``.
+    """
     k = int(fn_id) & 0xFFFFFFFF
     if k >= ACTIVATION_COUNT:
         return x
+
+    la = _LEAKY_ALPHA if leaky_relu_alpha is None else float(leaky_relu_alpha)
+    ea = _ELU_ALPHA if elu_alpha is None else float(elu_alpha)
+    pa = _PRELU_ALPHA if prelu_alpha is None else float(prelu_alpha)
 
     if k == ACTIVATION_IDENTITY:
         return x
@@ -84,7 +108,7 @@ def apply_activation(fn_id: int, x: float) -> float:
     if k == ACTIVATION_RELU6:
         return min(max(x, 0.0), 6.0)
     if k == ACTIVATION_LEAKY_RELU:
-        return x if x >= 0.0 else _LEAKY_ALPHA * x
+        return x if x >= 0.0 else la * x
     if k == ACTIVATION_SIGMOID:
         return _sigmoid(x)
     if k == ACTIVATION_TANH:
@@ -96,9 +120,9 @@ def apply_activation(fn_id: int, x: float) -> float:
     if k == ACTIVATION_SOFTPLUS:
         return _softplus(x)
     if k == ACTIVATION_ELU:
-        return x if x >= 0.0 else _ELU_ALPHA * (math.exp(x) - 1.0)
+        return x if x >= 0.0 else ea * (math.exp(x) - 1.0)
     if k == ACTIVATION_PRELU:
-        return x if x >= 0.0 else _PRELU_ALPHA * x
+        return x if x >= 0.0 else pa * x
     if k == ACTIVATION_EXP2:
         return math.exp(x * math.log(2.0))
     return x

--- a/src/tools/ipu-common/src/ipu_common/activations.py
+++ b/src/tools/ipu-common/src/ipu_common/activations.py
@@ -3,7 +3,9 @@
 Encodings match ``docs/content/specs/stage-aaq.md`` section 7.0. Alpha parameters for
 ``leaky_relu``, ``elu``, and ``prelu`` are fixed simulator constants (not part
 of the ISA). Assembly uses ``ACTIVATE … <name>`` where ``<name>`` is one of the
-strings in ``ACTIVATION_FN_NAMES`` (same order as ids **0**–**11**).
+strings in ``ACTIVATION_FN_NAMES`` (same order as ids **0**–**11**). How to change
+the virtual α constants is documented in ``docs/content/specs/stage-aaq.md``
+(Emulator: `ACTIVATE` and configuring α).
 """
 
 from __future__ import annotations

--- a/src/tools/ipu-common/src/ipu_common/activations.py
+++ b/src/tools/ipu-common/src/ipu_common/activations.py
@@ -3,9 +3,8 @@
 Encodings match ``docs/content/specs/stage-aaq.md`` section 7.0. Alpha parameters for
 ``leaky_relu``, ``elu``, and ``prelu`` are fixed simulator constants (not part
 of the ISA). Assembly uses ``ACTIVATE … <name>`` where ``<name>`` is one of the
-strings in ``ACTIVATION_FN_NAMES`` (same order as ids **0**–**11**). How to change
-the virtual α constants is documented in ``docs/content/specs/stage-aaq.md``
-(Emulator: `ACTIVATE` and configuring α).
+strings in ``ACTIVATION_FN_NAMES`` (same order as ids **0**–**11**). Emulator
+calibration (including α) is described in ``docs/content/building-applications.md#activations-emulator``.
 """
 
 from __future__ import annotations

--- a/src/tools/ipu-common/src/ipu_common/activations.py
+++ b/src/tools/ipu-common/src/ipu_common/activations.py
@@ -6,9 +6,9 @@ override per run via :class:`ipu_emu.ipu_state.IpuState` constructor or
 :meth:`IpuState.set_activation_alphas` (not CR-visible). Assembly uses
 ``ACTIVATE … <name>`` where ``<name>`` is one of the strings in
 ``ACTIVATION_FN_NAMES`` (same order as ids **0**–**11**). See
-``docs/content/building-applications.md#activations-emulator`` for calibration
-and how ``STR_POST_AAQ_REG`` temporarily exports ``R_ACC`` (512 B) vs
-``POST_AAQ_REG``.
+``docs/content/building-applications.md#activations-emulator`` for calibration,
+``POST_AAQ_REG`` (interim **512 B**, same width as ``R_ACC``), and
+``STR_POST_AAQ_REG`` (store that register to XMEM).
 """
 
 from __future__ import annotations

--- a/src/tools/ipu-common/src/ipu_common/instruction_spec.py
+++ b/src/tools/ipu-common/src/ipu_common/instruction_spec.py
@@ -757,8 +757,11 @@ INSTRUCTION_SPEC = {
                 summary=(
                     "Apply an element-wise activation to the first valid_elements lanes of "
                     "R_ACC; lanes beyond the active prefix are unchanged. The activation is "
-                    "selected by keyword (see ACTIVATION_FN_NAMES; see AAQ stage spec section 7.0). "
-                    "The binary encoding uses four bits; values not listed in the enum are treated as identity."
+                    "selected by keyword (see ACTIVATION_FN_NAMES). Behaviour matches the activation "
+                    "table in the AAQ stage spec (section 7.0). The selector uses four bits; "
+                    "encodings outside the twelve named activations behave as identity. For Python "
+                    "emulator calibration (including virtual α), see "
+                    "docs/content/building-applications.md#activations-emulator."
                 ),
                 syntax="ACTIVATE valid_elements activation_fn",
                 operands=[
@@ -768,7 +771,9 @@ INSTRUCTION_SPEC = {
                 operation=(
                     "Let n = min(valid_elements, 128) and k = encoded activation index. "
                     "For i in [0, n): R_ACC[i] = activation_k(R_ACC[i]). "
-                    "Alpha for leaky_relu / elu / prelu is fixed in the emulator (not ISA)."
+                    "The selector uses four bits; encodings outside the twelve named activations behave as identity. "
+                    "α for leaky_relu, elu, and prelu is not an ISA operand; see "
+                    "docs/content/building-applications.md#activations-emulator."
                 ),
                 example="ACTIVATE LR0 relu;;",
             ),

--- a/src/tools/ipu-common/src/ipu_common/instruction_spec.py
+++ b/src/tools/ipu-common/src/ipu_common/instruction_spec.py
@@ -30,7 +30,7 @@ OPERAND TYPE NAMES (resolved by ipu_as into actual token classes):
   - "Immediate": 16-bit signed integer for LR immediates (LrImmediateType)
   - "LrModPow2KImmediate": k operand for INCR_MOD_POW2 (semantic k ∈ [1, 9]; encoded as k−1 in 4 bits)
   - "MultMaskOffsetImmediate": mask slot index for mult masking (0–7; eight 128-bit slots in r_mask)
-  - "ActivationFnId": unsigned 4-bit immediate on `ACTIVATE` (0–15 wire; 0–11 are defined activations)
+  - "ActivationFn": keyword on `ACTIVATE` (see ``ACTIVATION_FN_NAMES`` in ``activations.py``)
   - "BreakImmediate": 16-bit BREAK condition value (BreakImmediateType)
   - "Label": Branch target label (LabelToken)
 
@@ -125,7 +125,7 @@ SLOT_BINARY_LAYOUT: dict[str, list[str]] = {
     "xmem": ["MultStageReg", "LrIdx", "LrIdx", "CrIdx"],
     "mult": ["MultStageReg", "LrIdx", "MultMaskOffsetImmediate", "LrIdx", "LrIdx", "CrIdx", "AaqRegIdx"],
     "acc": ["AaqRegIdx", "ElementsInRow", "HorizontalStride", "VerticalStride", "LrIdx"],
-    "aaq": ["AggMode", "PostFn", "LcrIdx", "CrIdx", "ActivationFnId", "AaqRegIdx"],
+    "aaq": ["AggMode", "PostFn", "LcrIdx", "CrIdx", "ActivationFn", "AaqRegIdx"],
     "lr": ["LrIdx", "LrIdx", "LcrIdx", "AddSubSrcB", "Immediate", "LrModPow2KImmediate"],
     "cond": ["LcrIdx", "LcrIdx", "Label"],
     "break": ["LrIdx", "BreakImmediate"],
@@ -750,27 +750,27 @@ INSTRUCTION_SPEC = {
                     "type": "LcrIdx",
                     "read": "snapshot",
                 },
-                {"name": "activation_fn", "type": "ActivationFnId"},
+                {"name": "activation_fn", "type": "ActivationFn"},
             ],
             "doc": InstructionDoc(
                 title="Accumulator Activation",
                 summary=(
                     "Apply an element-wise activation to the first valid_elements lanes of "
-                    "r_acc; lanes beyond the active prefix are unchanged. The activation id "
-                    "(0–11) is an immediate in the instruction word (see AAQ stage spec section 7.0; "
-                    "values 12–15 are reserved and behave as identity)."
+                    "r_acc; lanes beyond the active prefix are unchanged. The activation is "
+                    "selected by keyword (see ACTIVATION_FN_NAMES; see AAQ stage spec section 7.0). "
+                    "The binary encoding uses four bits; values not listed in the enum are treated as identity."
                 ),
                 syntax="ACTIVATE valid_elements activation_fn",
                 operands=[
                     "valid_elements: lane count from an LR or CR register (unsigned, clamped to 0–128)",
-                    "activation_fn: unsigned 4-bit immediate 0–15 (ids 0–11 per spec; 12–15 treated as identity)",
+                    "activation_fn: keyword naming the activation (e.g. relu, gelu, silu; see ACTIVATION_FN_NAMES)",
                 ],
                 operation=(
-                    "Let n = min(valid_elements, 128) and k = activation_fn (12–15 → identity). "
+                    "Let n = min(valid_elements, 128) and k = encoded activation index. "
                     "For i in [0, n): r_acc[i] = activation_k(r_acc[i]). "
                     "Alpha for leaky_relu / elu / prelu is fixed in the emulator (not ISA)."
                 ),
-                example="ACTIVATE lr0 1;;",
+                example="ACTIVATE lr0 relu;;",
             ),
             "execute_fn": "execute_activate",
         },
@@ -1189,7 +1189,7 @@ VALID_OPERAND_TYPES: frozenset[str] = frozenset(
         "Immediate",
         "LrModPow2KImmediate",
         "MultMaskOffsetImmediate",
-        "ActivationFnId",
+        "ActivationFn",
         "BreakImmediate",
         "Label",
         "AddSubSrcB",

--- a/src/tools/ipu-common/src/ipu_common/instruction_spec.py
+++ b/src/tools/ipu-common/src/ipu_common/instruction_spec.py
@@ -246,19 +246,20 @@ INSTRUCTION_SPEC = {
                 {"name": "base", "type": "CrIdx", "read": "live"},
             ],
             "doc": InstructionDoc(
-                title="Store Post-AAQ (temporary R_ACC export)",
+                title="Store Post-AAQ register",
                 summary=(
-                    "**Temporary:** write **512 bytes** from **`R_ACC`** (128×32-bit post-activation "
-                    "lanes) to external memory. Intended final behavior is to export the **128-byte** "
-                    "**`POST_AAQ_REG`** buffer after **quantization** (32→8 per lane); the register "
-                    "width and store source will be aligned when that path is fully implemented."
+                    "Write **512 bytes** of **`POST_AAQ_REG`** to external memory. **Interim:** "
+                    "the post-AAQ buffer is sized like **`R_ACC`** (128×32-bit lanes) until "
+                    "quantization export is finalized; the Python emulator refreshes "
+                    "`POST_AAQ_REG` from `R_ACC` at store time so XMEM sees the current "
+                    "post-activation lanes."
                 ),
                 syntax="STR_POST_AAQ_REG offset, base",
                 operands=[
                     "offset: Offset register (LR0–LR15)",
                     "base: Base address register (CR0–CR15)",
                 ],
-                operation="Memory[offset + base] = R_ACC (512 bytes); temporary until export reads POST_AAQ_REG (128 bytes) after quant split",
+                operation="Memory[offset + base] = POST_AAQ_REG (512 bytes); interim staging register",
                 example="STR_POST_AAQ_REG LR0, CR0;;",
             ),
             "execute_fn": "execute_str_post_aaq_reg",
@@ -761,16 +762,17 @@ INSTRUCTION_SPEC = {
             "doc": InstructionDoc(
                 title="AAQ Quantize",
                 summary=(
-                    "Quantize the 128-word accumulator from INT32 to INT8, storing clamped results in the "
-                    "POST_AAQ_REG staging register (128 bytes; layout may evolve when quant is fully split from "
-                    "R_ACC). Requires INT8 mode. STR_POST_AAQ_REG currently exports 512 bytes from R_ACC instead—"
-                    "see docs/content/building-applications.md#activations-emulator."
+                    "Quantize the 128-word accumulator from INT32 to INT8, storing clamped results "
+                    "in the **leading 128 bytes** of **`POST_AAQ_REG`**. The register is **512 bytes** "
+                    "for now (tail cleared); **`STR_POST_AAQ_REG`** exports the full register to XMEM. "
+                    "Requires INT8 mode."
                 ),
                 syntax="AAQ",
                 operands=[],
                 operation=(
                     "Requires INT8 mode (CR15 == DType.INT8). "
-                    "For i in [0, 128): POST_AAQ_REG[i] = clamp(trunc(R_ACC[i]), -128, 127)"
+                    "For i in [0, 128): POST_AAQ_REG[i] = clamp(trunc(R_ACC[i]), -128, 127); "
+                    "POST_AAQ_REG[128..511] = 0"
                 ),
                 example="AAQ;;",
             ),

--- a/src/tools/ipu-common/src/ipu_common/instruction_spec.py
+++ b/src/tools/ipu-common/src/ipu_common/instruction_spec.py
@@ -641,7 +641,7 @@ INSTRUCTION_SPEC = {
 
     # =========================================================================
     # AAQ Slot (Activation and Quantization)
-    # Opcode = position: AAQ_NOP=0, AGG=1, AGG.FIRST=2
+    # Opcode = position: AAQ_NOP=0, AGG=1, AGG.FIRST=2, AAQ=3, ACTIVATE=4
     # =========================================================================
     "aaq": {
         "AAQ_NOP": {
@@ -741,6 +741,36 @@ INSTRUCTION_SPEC = {
                 example="AAQ;;",
             ),
             "execute_fn": "execute_aaq",
+        },
+        "ACTIVATE": {
+            "operands": [
+                {
+                    "name": "valid_elements",
+                    "type": "LcrIdx",
+                    "read": "snapshot",
+                },
+                {"name": "act_cr_idx", "type": "CrIdx"},
+            ],
+            "doc": InstructionDoc(
+                title="Accumulator Activation",
+                summary=(
+                    "Apply an element-wise activation to the first valid_elements lanes of "
+                    "r_acc; lanes beyond the active prefix are unchanged. The activation id "
+                    "(0–11) is read from cr[act_cr_idx] at cycle start."
+                ),
+                syntax="ACTIVATE valid_elements act_cr_idx",
+                operands=[
+                    "valid_elements: lane count from an LR or CR register (unsigned, clamped to 0–128)",
+                    "act_cr_idx: which CR holds the activation function id (see AAQ stage spec section 7.0)",
+                ],
+                operation=(
+                    "Let n = min(valid_elements, 128) and k = cr[act_cr_idx]. "
+                    "For i in [0, n): r_acc[i] = activation_k(r_acc[i]). "
+                    "Alpha for leaky_relu / elu / prelu is fixed in the emulator (not ISA)."
+                ),
+                example="ACTIVATE lr0 cr2;;",
+            ),
+            "execute_fn": "execute_activate",
         },
     },
 

--- a/src/tools/ipu-common/src/ipu_common/instruction_spec.py
+++ b/src/tools/ipu-common/src/ipu_common/instruction_spec.py
@@ -249,10 +249,7 @@ INSTRUCTION_SPEC = {
                 title="Store Post-AAQ register",
                 summary=(
                     "Write **512 bytes** of **`POST_AAQ_REG`** to external memory. **Interim:** "
-                    "the post-AAQ buffer is sized like **`R_ACC`** (128×32-bit lanes) until "
-                    "quantization export is finalized; the Python emulator refreshes "
-                    "`POST_AAQ_REG` from `R_ACC` at store time so XMEM sees the current "
-                    "post-activation lanes."
+                    "the buffer is **512 bytes** (128×32-bit lanes) until quantization export is finalized."
                 ),
                 syntax="STR_POST_AAQ_REG offset, base",
                 operands=[
@@ -762,16 +759,16 @@ INSTRUCTION_SPEC = {
             "doc": InstructionDoc(
                 title="AAQ Quantize",
                 summary=(
-                    "Quantize the 128-word accumulator from INT32 to INT8, storing clamped results "
-                    "in the **leading 128 bytes** of **`POST_AAQ_REG`**. The register is **512 bytes** "
-                    "for now (tail cleared); **`STR_POST_AAQ_REG`** exports the full register to XMEM. "
-                    "Requires INT8 mode."
+                    "Quantize the 128 wide lanes in **`POST_AAQ_REG`** (INT32 per lane in INT8 mode) "
+                    "to INT8, storing clamped bytes in the **leading 128 bytes** of **`POST_AAQ_REG`** "
+                    "and clearing the rest of the register. Wide lanes are normally produced by "
+                    "**`ACTIVATE`** (from ``r_acc``). Requires INT8 mode."
                 ),
                 syntax="AAQ",
                 operands=[],
                 operation=(
                     "Requires INT8 mode (CR15 == DType.INT8). "
-                    "For i in [0, 128): POST_AAQ_REG[i] = clamp(trunc(R_ACC[i]), -128, 127); "
+                    "For i in [0, 128): POST_AAQ_REG[i] = clamp(trunc(POST_AAQ_REG wide lane i), -128, 127); "
                     "POST_AAQ_REG[128..511] = 0"
                 ),
                 example="AAQ;;",
@@ -790,12 +787,13 @@ INSTRUCTION_SPEC = {
             "doc": InstructionDoc(
                 title="Accumulator Activation",
                 summary=(
-                    "Apply an element-wise activation to the first valid_elements lanes of "
-                    "R_ACC; lanes beyond the active prefix are unchanged. The activation is "
+                    "Read each of the first ``valid_elements`` lanes from ``r_acc``, apply the "
+                    "selected element-wise activation, and write results into the same lane indices "
+                    "of ``POST_AAQ_REG`` (``r_acc`` is unchanged). The activation is "
                     "selected by keyword (see ACTIVATION_FN_NAMES). Behaviour matches the activation "
                     "table in the AAQ stage spec (section 7.0). The selector uses four bits; "
                     "encodings outside the twelve named activations behave as identity. For Python "
-                    "emulator calibration (including virtual α), see "
+                    "emulator calibration (virtual α), see "
                     "docs/content/building-applications.md#activations-emulator."
                 ),
                 syntax="ACTIVATE valid_elements activation_fn",
@@ -805,8 +803,9 @@ INSTRUCTION_SPEC = {
                 ],
                 operation=(
                     "Let n = min(valid_elements, 128) and k = encoded activation index. "
-                    "For i in [0, n): R_ACC[i] = activation_k(R_ACC[i]). "
-                    "The selector uses four bits; encodings outside the twelve named activations behave as identity. "
+                    "For i in [0, n): POST_AAQ_REG[i] = activation_k(R_ACC[i]) (same 32-bit lane format as R_ACC). "
+                    "R_ACC is not modified. The selector uses four bits; encodings outside the twelve named "
+                    "activations behave as identity. "
                     "α for leaky_relu, elu, and prelu is not an ISA operand; see "
                     "docs/content/building-applications.md#activations-emulator."
                 ),

--- a/src/tools/ipu-common/src/ipu_common/instruction_spec.py
+++ b/src/tools/ipu-common/src/ipu_common/instruction_spec.py
@@ -22,14 +22,14 @@ KEY DESIGN PRINCIPLES:
      - ``"live"``     → read from the current (post-write) register file
 
 OPERAND TYPE NAMES (resolved by ipu_as into actual token classes):
-  - "MultStageReg": r0 or r1 (MultStageRegField); 2-bit encoding in the VLIW word
-  - "LrIdx": lr0-lr15 (LrRegField)  
-  - "CrIdx": cr0-cr15 (CrRegField)
-  - "LcrIdx": lr0-lr15 or cr0-cr15 (LcrRegField)
-  - "AddSubSrcB": second operand for ADD/SUB — lr, cr, or unsigned IMM5 (AddSubSrcBField; 6-bit encoding)
+  - "MultStageReg": R0 or R1 (MultStageRegField); 2-bit encoding in the VLIW word
+  - "LrIdx": LR0–LR15 (LrRegField)  
+  - "CrIdx": CR0–CR15 (CrRegField)
+  - "LcrIdx": LR0–LR15 or CR0–CR15 (LcrRegField)
+  - "AddSubSrcB": second operand for ADD/SUB — LR, CR, or unsigned IMM5 (AddSubSrcBField; 6-bit encoding)
   - "Immediate": 16-bit signed integer for LR immediates (LrImmediateType)
   - "LrModPow2KImmediate": k operand for INCR_MOD_POW2 (semantic k ∈ [1, 9]; encoded as k−1 in 4 bits)
-  - "MultMaskOffsetImmediate": mask slot index for mult masking (0–7; eight 128-bit slots in r_mask)
+  - "MultMaskOffsetImmediate": mask slot index for mult masking (0–7; eight 128-bit slots in R_MASK)
   - "ActivationFn": keyword on `ACTIVATE` (see ``ACTIVATION_FN_NAMES`` in ``activations.py``)
   - "BreakImmediate": 16-bit BREAK condition value (BreakImmediateType)
   - "Label": Branch target label (LabelToken)
@@ -167,13 +167,13 @@ INSTRUCTION_SPEC = {
                 summary="Store accumulator to memory.",
                 syntax="STR_ACC_REG offset, base",
                 operands=[
-                    "offset: Offset register (lr0-lr15)",
-                    "base: Base address register (cr0-cr15)",
+                    "offset: Offset register (LR0–LR15)",
+                    "base: Base address register (CR0–CR15)",
                 ],
-                operation="Memory[offset + base] = r_acc",
+                operation="Memory[offset + base] = R_ACC",
                 example="STR_ACC_REG CR0, CR1;;",
             ),
-            "execute_fn": "execute_str_acc_reg",
+            "execute_fn": "execute_stR_ACC_reg",
         },
         "LDR_MULT_REG": {
             "operands": [
@@ -203,16 +203,16 @@ INSTRUCTION_SPEC = {
             ],
             "doc": InstructionDoc(
                 title="Load Cyclic Register",
-                summary="Load with cyclic addressing into r_cyclic.",
+                summary="Load with cyclic addressing into R_CYCLIC.",
                 syntax="LDR_CYCLIC_MULT_REG offset, base, index",
                 operands=[
-                    "offset: Offset register (lr0-lr15)",
-                    "base: Base address register (cr0-cr15)",
-                    "index: Index inside cyclic register (lr0-lr15)",
+                    "offset: Offset register (LR0–LR15)",
+                    "base: Base address register (CR0–CR15)",
+                    "index: Index inside cyclic register (LR0–LR15)",
                 ],
-                operation="r_cyclic[index % 512:128] = Memory[offset + base]",
+                operation="R_CYCLIC[index % 512:128] = Memory[offset + base]",
             ),
-            "execute_fn": "execute_ldr_cyclic_mult_reg",
+            "execute_fn": "execute_ldR_CYCLIC_mult_reg",
         },
         "LDR_MULT_MASK_REG": {
             "operands": [
@@ -224,10 +224,10 @@ INSTRUCTION_SPEC = {
                 summary="Load mask data from memory.",
                 syntax="LDR_MULT_MASK_REG offset, base, mask_idx",
                 operands=[
-                    "offset: Offset register (lr0-lr15)",
-                    "base: Base address register (cr0-cr15)",
+                    "offset: Offset register (LR0–LR15)",
+                    "base: Base address register (CR0–CR15)",
                 ],
-                operation="r_mask = Memory[offset + base]",
+                operation="R_MASK = Memory[offset + base]",
             ),
             "execute_fn": "execute_ldr_mult_mask_reg",
         },
@@ -251,13 +251,13 @@ INSTRUCTION_SPEC = {
                 summary="Write the 128-byte AAQ quantization result register to external memory.",
                 syntax="XMEM.STORE_AAQ_RESULT offset, base",
                 operands=[
-                    "offset: Offset register (lr0-lr15)",
-                    "base: Base address register (cr0-cr15)",
+                    "offset: Offset register (LR0–LR15)",
+                    "base: Base address register (CR0–CR15)",
                 ],
-                operation="Memory[offset + base] = aaq_result  # 128 elements",
+                operation="Memory[offset + base] = AAQ_RESULT  # 128 elements",
                 example="XMEM.STORE_AAQ_RESULT LR0, CR0;;",
             ),
-            "execute_fn": "execute_xmem_store_aaq_result",
+            "execute_fn": "execute_xmem_store_AAQ_RESULT",
         },
     },
     
@@ -276,7 +276,7 @@ INSTRUCTION_SPEC = {
                 summary="Set a loop register to an immediate value.",
                 syntax="SET reg, value",
                 operands=[
-                    "reg: Loop register (lr0-lr15)",
+                    "reg: Loop register (LR0–LR15)",
                     "value: 32-bit immediate value",
                 ],
                 operation="reg = value",
@@ -298,9 +298,9 @@ INSTRUCTION_SPEC = {
                 ),
                 syntax="ADD dest, src_a, src_b",
                 operands=[
-                    "dest: Destination local register (lr0-lr15)",
-                    "src_a: First source local register (lr0-lr15)",
-                    "src_b: Second source — lr0-lr15, cr0-cr15, or unsigned immediate 0–31",
+                    "dest: Destination local register (LR0–LR15)",
+                    "src_a: First source local register (LR0–LR15)",
+                    "src_b: Second source — LR0–LR15, CR0–CR15, or unsigned immediate 0–31",
                 ],
                 operation="dest = src_a + src_b",
                 example="ADD LR0, LR1, LR2;;\nADD LR3, LR1, CR5;;\nADD LR4, LR1, 7;;",
@@ -321,9 +321,9 @@ INSTRUCTION_SPEC = {
                 ),
                 syntax="SUB dest, src_a, src_b",
                 operands=[
-                    "dest: Destination local register (lr0-lr15)",
-                    "src_a: First source local register (lr0-lr15)",
-                    "src_b: Second source — lr0-lr15, cr0-cr15, or unsigned immediate 0–31",
+                    "dest: Destination local register (LR0–LR15)",
+                    "src_a: First source local register (LR0–LR15)",
+                    "src_b: Second source — LR0–LR15, CR0–CR15, or unsigned immediate 0–31",
                 ],
                 operation="dest = src_a - src_b",
                 example="SUB LR0, LR1, LR2;;\nSUB LR3, LR1, CR5;;\nSUB LR4, LR1, 7;;",
@@ -344,8 +344,8 @@ INSTRUCTION_SPEC = {
                 ),
                 syntax="INCR_MOD_POW2 dst, step, k",
                 operands=[
-                    "dst: Destination loop register (lr0-lr15); read and written",
-                    "step: Signed 32-bit increment from lr0-lr15 or cr0-cr15",
+                    "dst: Destination loop register (LR0–LR15); read and written",
+                    "step: Signed 32-bit increment from LR0–LR15 or CR0–CR15",
                     "k: Immediate in [1, 9]; encoded in 4 bits as (k − 1); mask = (1 << k) - 1",
                 ],
                 operation="dst <- (dst + step) & ((1 << k) - 1)",
@@ -374,11 +374,11 @@ INSTRUCTION_SPEC = {
                 syntax="MULT.EE ra, cyclic_offset, mask_offset, mask_shift",
                 operands=[
                     "`ra`: **`R0`** | **`R1`** — multiplicand mult-stage register (same cycle as `LDR_MULT_REG` into **`R0`**/**`R1`** is allowed).",
-                    "`cyclic_offset`: **`LR0`**…**`LR15`** — base byte offset into **`r_cyclic`**.",
-                    "`mask_offset`: immediate mask slot **`0`**…**`7`** — selects one of eight 128-bit masks in **`r_mask`**.",
+                    "`cyclic_offset`: **`LR0`**…**`LR15`** — base byte offset into **`R_CYCLIC`**.",
+                    "`mask_offset`: immediate mask slot **`0`**…**`7`** — selects one of eight 128-bit masks in **`R_MASK`**.",
                     "`mask_shift`: **`LR0`**…**`LR15`** — shift applied to the mask register.",
                 ],
-                operation="For each lane i: mult_res[i] = ipu_mult(ra[i], r_cyclic[cyclic_offset + i]); then apply mask and shift.",
+                operation="For each lane i: MULT_RES[i] = ipu_mult(ra[i], R_CYCLIC[cyclic_offset + i]); then apply mask and shift.",
                 example="MULT.EE R0, LR0, 0, LR2;;",
             ),
             "execute_fn": "execute_mult_ee",
@@ -393,18 +393,18 @@ INSTRUCTION_SPEC = {
             "doc": InstructionDoc(
                 title="Vector-Element Multiply (cyclic RC)",
                 summary=(
-                    "Multiply a fixed element from r0 or r1 against r_cyclic[cyclic_offset:cyclic_offset+128]. "
-                    "`fixed_idx` 0..127 selects `r0[fixed_idx]`, 128..255 selects `r1[fixed_idx - 128]`. "
-                    "r_cyclic is addressed cyclically modulo 512 elements (no padding with 1 past the boundary)."
+                    "Multiply a fixed element from R0 or R1 against R_CYCLIC[cyclic_offset:cyclic_offset+128]. "
+                    "`fixed_idx` 0..127 selects `R0[fixed_idx]`, 128..255 selects `R1[fixed_idx - 128]`. "
+                    "R_CYCLIC is addressed cyclically modulo 512 elements (no padding with 1 past the boundary)."
                 ),
                 syntax="MULT.VE.CYCLIC cyclic_offset, mask_offset, mask_shift, fixed_idx",
                 operands=[
-                    "`cyclic_offset`: **`LR0`**…**`LR15`** — base byte offset into **`r_cyclic`** (reduced mod 512).",
-                    "`mask_offset`: immediate mask slot **`0`**…**`7`** — selects one of eight 128-bit masks in **`r_mask`**.",
+                    "`cyclic_offset`: **`LR0`**…**`LR15`** — base byte offset into **`R_CYCLIC`** (reduced mod 512).",
+                    "`mask_offset`: immediate mask slot **`0`**…**`7`** — selects one of eight 128-bit masks in **`R_MASK`**.",
                     "`mask_shift`: **`LR0`**…**`LR15`** — shift applied to the mask register.",
                     "`fixed_idx`: **`LR0`**…**`LR15`** (value read live) — scalar index into **`R0`**/**`R1`**.",
                 ],
-                operation="For i in [0, 128): rb = r_cyclic[(cyclic_offset + i) % 512]; scalar from R0/R1 via fixed_idx; mult_res[i] = scalar * rb (then mask/shift).",
+                operation="For i in [0, 128): rb = R_CYCLIC[(cyclic_offset + i) % 512]; scalar from R0/R1 via fixed_idx; MULT_RES[i] = scalar * rb (then mask/shift).",
                 example="MULT.VE.CYCLIC LR0, 0, LR2, LR3;;",
             ),
             "execute_fn": "execute_mult_ve_cyclic",
@@ -424,12 +424,12 @@ INSTRUCTION_SPEC = {
                 ),
                 syntax="MULT.VE.PADDED cyclic_offset, mask_offset, mask_shift, fixed_idx",
                 operands=[
-                    "`cyclic_offset`: **`LR0`**…**`LR15`** — base byte offset into `r_cyclic`; out-of-range lanes use dtype 1.",
-                    "`mask_offset`: immediate mask slot **`0`**…**`7`** — selects one of eight 128-bit masks in `r_mask`.",
+                    "`cyclic_offset`: **`LR0`**…**`LR15`** — base byte offset into `R_CYCLIC`; out-of-range lanes use dtype 1.",
+                    "`mask_offset`: immediate mask slot **`0`**…**`7`** — selects one of eight 128-bit masks in `R_MASK`.",
                     "`mask_shift`: **`LR0`**…**`LR15`** — shift applied to the mask register.",
                     "`fixed_idx`: **`LR0`**…**`LR15`** (value read live) — scalar index into **`R0`**/**`R1`**.",
                 ],
-                operation="For i in [0, 128): rb = r_cyclic[cyclic_offset + i] if in bounds else dtype_one; scalar from R0/R1; mult_res[i] = scalar * rb (then mask/shift).",
+                operation="For i in [0, 128): rb = R_CYCLIC[cyclic_offset + i] if in bounds else dtype_one; scalar from R0/R1; MULT_RES[i] = scalar * rb (then mask/shift).",
                 example="MULT.VE.PADDED LR0, 0, LR2, LR3;;",
             ),
             "execute_fn": "execute_mult_ve_padded",
@@ -457,11 +457,11 @@ INSTRUCTION_SPEC = {
                 syntax="MULT.VE.CR cyclic_offset, mask_offset, mask_shift, cr_idx",
                 operands=[
                     "cyclic_offset: Base offset into RC (cyclic register); non-cyclic — out-of-bounds elements are padded with 1",
-                    "mask_offset: Immediate mask slot 0–7 (128-bit slice of r_mask)",
+                    "mask_offset: Immediate mask slot 0–7 (128-bit slice of R_MASK)",
                     "mask_shift: Shift applied to the mask (from LR)",
-                    "cr_idx: CR register whose low byte supplies the fixed scalar multiplier (cr0-cr15)",
+                    "cr_idx: CR register whose low byte supplies the fixed scalar multiplier (CR0–CR15)",
                 ],
-                operation="For i in [0,128): rb = RC[cyclic_offset+i] if in bounds else dtype_one; mult_res[i] = CR[cr_idx][0] * rb",
+                operation="For i in [0,128): rb = RC[cyclic_offset+i] if in bounds else dtype_one; MULT_RES[i] = CR[cr_idx][0] * rb",
                 example="MULT.VE.CR LR0, 0, LR15, CR3;;",
             ),
             "execute_fn": "execute_mult_ve_cr",
@@ -479,11 +479,11 @@ INSTRUCTION_SPEC = {
                 syntax="MULT.VE.AAQ cyclic_offset, mask_offset, mask_shift, aaq_rf_idx",
                 operands=[
                     "cyclic_offset: Base offset into RC (cyclic register); non-cyclic — out-of-bounds elements are padded with 1",
-                    "mask_offset: Immediate mask slot 0–7 (128-bit slice of r_mask)",
+                    "mask_offset: Immediate mask slot 0–7 (128-bit slice of R_MASK)",
                     "mask_shift: Shift applied to the mask (from LR)",
-                    "aaq_rf_idx: AAQ register whose low byte supplies the fixed scalar multiplier (aaq0-aaq3)",
+                    "aaq_rf_idx: AAQ register whose low byte supplies the fixed scalar multiplier (AAQ0–AAQ3)",
                 ],
-                operation="For i in [0,128): rb = RC[cyclic_offset+i] if in bounds else dtype_one; mult_res[i] = AAQ[aaq_rf_idx][0] * rb",
+                operation="For i in [0,128): rb = RC[cyclic_offset+i] if in bounds else dtype_one; MULT_RES[i] = AAQ[aaq_rf_idx][0] * rb",
                 example="MULT.VE.AAQ LR0, 0, LR15, AAQ1;;",
             ),
             "execute_fn": "execute_mult_ve_aaq",
@@ -502,7 +502,7 @@ INSTRUCTION_SPEC = {
                 summary="Accumulate multiply result.",
                 syntax="ACC",
                 operands=[],
-                operation="r_acc += multiply_result",
+                operation="R_ACC += multiply_result",
             ),
             "execute_fn": "execute_acc",
         },
@@ -510,10 +510,10 @@ INSTRUCTION_SPEC = {
             "operands": [],
             "doc": InstructionDoc(
                 title="Accumulate First",
-                summary="Set accumulator to multiply result (do not ADD to previous r_acc).",
+                summary="Set accumulator to multiply result (do not ADD to previous R_ACC).",
                 syntax="ACC.FIRST",
                 operands=[],
-                operation="r_acc = multiply_result",
+                operation="R_ACC = multiply_result",
                 example="ACC.FIRST;;",
             ),
             "execute_fn": "execute_acc_first",
@@ -525,7 +525,7 @@ INSTRUCTION_SPEC = {
                 summary="Reset accumulator to zero.",
                 syntax="RESET_ACC",
                 operands=[],
-                operation="r_acc = 0",
+                operation="R_ACC = 0",
             ),
             "execute_fn": "execute_reset_acc",
         },
@@ -548,11 +548,11 @@ INSTRUCTION_SPEC = {
                 summary="Accumulate multiply result, then ADD the selected AAQ register (32-bit) to each of the 128 accumulator words.",
                 syntax="ACC.ADD_AAQ aaq_rf_idx",
                 operands=[
-                    "aaq_rf_idx: AAQ register index (aaq0-aaq3)",
+                    "aaq_rf_idx: AAQ register index (AAQ0–AAQ3)",
                 ],
                 operation=(
-                    "r_acc += multiply_result;\n"
-                    "for i in [0, 128): r_acc[i] += aaq_regs[aaq_rf_idx]"
+                    "R_ACC += multiply_result;\n"
+                    "for i in [0, 128): R_ACC[i] += AAQ_REGS[aaq_rf_idx]"
                 ),
                 example="ACC.ADD_AAQ AAQ0;;",
             ),
@@ -564,14 +564,14 @@ INSTRUCTION_SPEC = {
             ],
             "doc": InstructionDoc(
                 title="Accumulate and Add AAQ (First)",
-                summary="Set accumulator to multiply result plus selected AAQ register (do not ADD to previous r_acc).",
+                summary="Set accumulator to multiply result plus selected AAQ register (do not ADD to previous R_ACC).",
                 syntax="ACC.ADD_AAQ.FIRST aaq_rf_idx",
                 operands=[
-                    "aaq_rf_idx: AAQ register index (aaq0-aaq3)",
+                    "aaq_rf_idx: AAQ register index (AAQ0–AAQ3)",
                 ],
                 operation=(
-                    "r_acc = multiply_result;\n"
-                    "for i in [0, 128): r_acc[i] += aaq_regs[aaq_rf_idx]"
+                    "R_ACC = multiply_result;\n"
+                    "for i in [0, 128): R_ACC[i] += AAQ_REGS[aaq_rf_idx]"
                 ),
                 example="ACC.ADD_AAQ.FIRST AAQ0;;",
             ),
@@ -583,13 +583,13 @@ INSTRUCTION_SPEC = {
             ],
             "doc": InstructionDoc(
                 title="Accumulator Max",
-                summary="For each element, SET r_acc[i] = max(r_acc[i], mult_res[i], aaq_reg[aaq_rf_idx]).",
+                summary="For each element, SET R_ACC[i] = max(R_ACC[i], MULT_RES[i], AAQ_REGS[aaq_rf_idx]).",
                 syntax="ACC.MAX aaq_rf_idx",
                 operands=[
-                    "aaq_rf_idx: AAQ register index (aaq0-aaq3)",
+                    "aaq_rf_idx: AAQ register index (AAQ0–AAQ3)",
                 ],
                 operation=(
-                    "for i in [0, 128): r_acc[i] = max(r_acc[i], mult_res[i], aaq_regs[aaq_rf_idx])"
+                    "for i in [0, 128): R_ACC[i] = max(R_ACC[i], MULT_RES[i], AAQ_REGS[aaq_rf_idx])"
                 ),
                 example="ACC.MAX AAQ0;;",
             ),
@@ -601,13 +601,13 @@ INSTRUCTION_SPEC = {
             ],
             "doc": InstructionDoc(
                 title="Accumulator Max (First)",
-                summary="For each element, SET r_acc[i] = max(mult_res[i], aaq_reg[aaq_rf_idx]). Previous r_acc is ignored (treated as 0).",
+                summary="For each element, SET R_ACC[i] = max(MULT_RES[i], AAQ_REGS[aaq_rf_idx]). Previous R_ACC is ignored (treated as 0).",
                 syntax="ACC.MAX.FIRST aaq_rf_idx",
                 operands=[
-                    "aaq_rf_idx: AAQ register index (aaq0-aaq3)",
+                    "aaq_rf_idx: AAQ register index (AAQ0–AAQ3)",
                 ],
                 operation=(
-                    "for i in [0, 128): r_acc[i] = max(mult_res[i], aaq_regs[aaq_rf_idx])"
+                    "for i in [0, 128): R_ACC[i] = max(MULT_RES[i], AAQ_REGS[aaq_rf_idx])"
                 ),
                 example="ACC.MAX.FIRST AAQ0;;",
             ),
@@ -622,7 +622,7 @@ INSTRUCTION_SPEC = {
             ],
             "doc": InstructionDoc(
                 title="Accumulator Stride",
-                summary="Reorder the multiplication result into r_acc using horizontal/vertical stride decimation. Only updates the RACC indexes written; leaves the rest unchanged.",
+                summary="Reorder the multiplication result into R_ACC using horizontal/vertical stride decimation. Only updates the RACC indexes written; leaves the rest unchanged.",
                 syntax="ACC.STRIDE elements_in_row, horizontal_stride, vertical_stride, offset",
                 operands=[
                     "elements_in_row: Elements per row (8, 16, 32, or 64)",
@@ -631,8 +631,8 @@ INSTRUCTION_SPEC = {
                     "offset: LR register; value % 4 gives start index in RACC (0, 32, 64, or 96)",
                 ],
                 operation=(
-                    "Decimate mult_res as rows×cols; apply horizontal stride (take every 2nd column, optional expand); "
-                    "then vertical stride (take every 2nd row). Write result into r_acc[start:start+N] where start = (offset%4)*32, N = 32|64|128."
+                    "Decimate MULT_RES as rows×cols; apply horizontal stride (take every 2nd column, optional expand); "
+                    "then vertical stride (take every 2nd row). Write result into R_ACC[start:start+N] where start = (offset%4)*32, N = 32|64|128."
                 ),
                 example="ACC.STRIDE 8, off, off, LR0;;",
             ),
@@ -670,7 +670,7 @@ INSTRUCTION_SPEC = {
             "doc": InstructionDoc(
                 title="Accumulator Aggregate",
                 summary=(
-                    "Collapse r_acc lanes into one value (SUM or MAX), using only the first "
+                    "Collapse R_ACC lanes into one value (SUM or MAX), using only the first "
                     "valid_elements words for the tree; apply post function; store to selected AAQ register."
                 ),
                 syntax="AGG agg_mode, post_fn, valid_elements, cr_idx, aaq_rf_idx",
@@ -679,13 +679,13 @@ INSTRUCTION_SPEC = {
                     "post_fn: value, value_cr, inv, or inv_sqrt",
                     "valid_elements: lane count from an LR or CR register (value read at cycle start; "
                     "unsigned, clamped to 0–128; indices [valid_elements..127] are masked out)",
-                    "cr_idx: CR register for value_cr post function (cr0-cr15)",
-                    "aaq_rf_idx: AAQ register to store result (aaq0-aaq3)",
+                    "cr_idx: CR register for value_cr post function (CR0–CR15)",
+                    "aaq_rf_idx: AAQ register to store result (AAQ0–AAQ3)",
                 ],
                 operation=(
                     "Let n = min(valid_elements, 128). "
-                    "If sum: v = sum(r_acc[0..n-1]). "
-                    "If max: v = max(r_acc[0..n-1], AAQ[aaq_rf_idx]). "
+                    "If sum: v = sum(R_ACC[0..n-1]). "
+                    "If max: v = max(R_ACC[0..n-1], AAQ[aaq_rf_idx]). "
                     "Apply post_fn(v): value→v, value_cr→v*cr[cr_idx], inv→1/v, inv_sqrt→1/sqrt(v). "
                     "AAQ[aaq_rf_idx] = result."
                 ),
@@ -714,13 +714,13 @@ INSTRUCTION_SPEC = {
                     "post_fn: value, value_cr, inv, or inv_sqrt",
                     "valid_elements: lane count from an LR or CR register (value read at cycle start; "
                     "unsigned, clamped to 0–128; indices [valid_elements..127] are masked out)",
-                    "cr_idx: CR register for value_cr post function (cr0-cr15)",
-                    "aaq_rf_idx: AAQ register to store result (aaq0-aaq3)",
+                    "cr_idx: CR register for value_cr post function (CR0–CR15)",
+                    "aaq_rf_idx: AAQ register to store result (AAQ0–AAQ3)",
                 ],
                 operation=(
                     "Let n = min(valid_elements, 128). "
-                    "If sum: v = sum(r_acc[0..n-1]). "
-                    "If max: v = max(r_acc[0..n-1]) (previous AAQ value is NOT included). "
+                    "If sum: v = sum(R_ACC[0..n-1]). "
+                    "If max: v = max(R_ACC[0..n-1]) (previous AAQ value is NOT included). "
                     "Apply post_fn(v): value→v, value_cr→v*cr[cr_idx], inv→1/v, inv_sqrt→1/sqrt(v). "
                     "AAQ[aaq_rf_idx] = result."
                 ),
@@ -732,12 +732,12 @@ INSTRUCTION_SPEC = {
             "operands": [],
             "doc": InstructionDoc(
                 title="AAQ Quantize",
-                summary="Quantize the 128-word accumulator from INT32 to INT8, storing clamped results in the aaq_result register. Requires INT8 mode.",
+                summary="Quantize the 128-word accumulator from INT32 to INT8, storing clamped results in the AAQ_RESULT register. Requires INT8 mode.",
                 syntax="AAQ",
                 operands=[],
                 operation=(
-                    "Requires INT8 mode (cr15 == DType.INT8). "
-                    "For i in [0, 128): aaq_result[i] = clamp(trunc(r_acc[i]), -128, 127)"
+                    "Requires INT8 mode (CR15 == DType.INT8). "
+                    "For i in [0, 128): AAQ_RESULT[i] = clamp(trunc(R_ACC[i]), -128, 127)"
                 ),
                 example="AAQ;;",
             ),
@@ -756,7 +756,7 @@ INSTRUCTION_SPEC = {
                 title="Accumulator Activation",
                 summary=(
                     "Apply an element-wise activation to the first valid_elements lanes of "
-                    "r_acc; lanes beyond the active prefix are unchanged. The activation is "
+                    "R_ACC; lanes beyond the active prefix are unchanged. The activation is "
                     "selected by keyword (see ACTIVATION_FN_NAMES; see AAQ stage spec section 7.0). "
                     "The binary encoding uses four bits; values not listed in the enum are treated as identity."
                 ),
@@ -767,10 +767,10 @@ INSTRUCTION_SPEC = {
                 ],
                 operation=(
                     "Let n = min(valid_elements, 128) and k = encoded activation index. "
-                    "For i in [0, n): r_acc[i] = activation_k(r_acc[i]). "
+                    "For i in [0, n): R_ACC[i] = activation_k(R_ACC[i]). "
                     "Alpha for leaky_relu / elu / prelu is fixed in the emulator (not ISA)."
                 ),
-                example="ACTIVATE lr0 relu;;",
+                example="ACTIVATE LR0 relu;;",
             ),
             "execute_fn": "execute_activate",
         },
@@ -792,8 +792,8 @@ INSTRUCTION_SPEC = {
                 summary="Branch if two registers are equal.",
                 syntax="BEQ reg1, reg2, label",
                 operands=[
-                    "reg1: First register to compare (lr0-lr15 or cr0-cr15)",
-                    "reg2: Second register to compare (lr0-lr15 or cr0-cr15)",
+                    "reg1: First register to compare (LR0–LR15 or CR0–CR15)",
+                    "reg2: Second register to compare (LR0–LR15 or CR0–CR15)",
                     "label: Branch target label",
                 ],
                 operation="if (reg1 == reg2) PC = label",
@@ -812,8 +812,8 @@ INSTRUCTION_SPEC = {
                 summary="Branch if two registers are not equal.",
                 syntax="BNE reg1, reg2, label",
                 operands=[
-                    "reg1: First register to compare (lr0-lr15 or cr0-cr15)",
-                    "reg2: Second register to compare (lr0-lr15 or cr0-cr15)",
+                    "reg1: First register to compare (LR0–LR15 or CR0–CR15)",
+                    "reg2: Second register to compare (LR0–LR15 or CR0–CR15)",
                     "label: Branch target label",
                 ],
                 operation="if (reg1 != reg2) PC = label",
@@ -832,8 +832,8 @@ INSTRUCTION_SPEC = {
                 summary="Branch if first register is less than second.",
                 syntax="BLT reg1, reg2, label",
                 operands=[
-                    "reg1: First register to compare (lr0-lr15 or cr0-cr15)",
-                    "reg2: Second register to compare (lr0-lr15 or cr0-cr15)",
+                    "reg1: First register to compare (LR0–LR15 or CR0–CR15)",
+                    "reg2: Second register to compare (LR0–LR15 or CR0–CR15)",
                     "label: Branch target label",
                 ],
                 operation="if (reg1 < reg2) PC = label",
@@ -852,8 +852,8 @@ INSTRUCTION_SPEC = {
                 summary="Branch if test register not equal to base register.",
                 syntax="BNZ test_reg, base_reg, label",
                 operands=[
-                    "test_reg: Register to test (lr0-lr15 or cr0-cr15)",
-                    "base_reg: Base comparison register (lr0-lr15 or cr0-cr15)",
+                    "test_reg: Register to test (LR0–LR15 or CR0–CR15)",
+                    "base_reg: Base comparison register (LR0–LR15 or CR0–CR15)",
                     "label: Branch target label",
                 ],
                 operation="if (test_reg != base_reg) PC = label",
@@ -872,8 +872,8 @@ INSTRUCTION_SPEC = {
                 summary="Branch if test register equals base register.",
                 syntax="BZ test_reg, base_reg, label",
                 operands=[
-                    "test_reg: Register to test (lr0-lr15 or cr0-cr15)",
-                    "base_reg: Base comparison register (lr0-lr15 or cr0-cr15)",
+                    "test_reg: Register to test (LR0–LR15 or CR0–CR15)",
+                    "base_reg: Base comparison register (LR0–LR15 or CR0–CR15)",
                     "label: Branch target label",
                 ],
                 operation="if (test_reg == base_reg) PC = label",
@@ -903,7 +903,7 @@ INSTRUCTION_SPEC = {
                 title="Branch Register",
                 summary="Branch to address in register.",
                 syntax="BR reg",
-                operands=["reg: Register containing target address (lr0-lr15 or cr0-cr15)"],
+                operands=["reg: Register containing target address (LR0–LR15 or CR0–CR15)"],
                 operation="PC = reg",
             ),
             "execute_fn": "execute_br",
@@ -947,7 +947,7 @@ INSTRUCTION_SPEC = {
                 summary="Break execution if register equals value.",
                 syntax="BREAK.IFEQ reg, value",
                 operands=[
-                    "reg: Register to test (lr0-lr15)",
+                    "reg: Register to test (LR0–LR15)",
                     "value: Immediate value to compare against",
                 ],
                 operation="if (reg == value) BREAK",

--- a/src/tools/ipu-common/src/ipu_common/instruction_spec.py
+++ b/src/tools/ipu-common/src/ipu_common/instruction_spec.py
@@ -246,17 +246,19 @@ INSTRUCTION_SPEC = {
                 {"name": "base", "type": "CrIdx", "read": "live"},
             ],
             "doc": InstructionDoc(
-                title="Store Post-AAQ Staging Register",
+                title="Store Post-AAQ (temporary R_ACC export)",
                 summary=(
-                    "Write the 128-byte temporary `POST_AAQ_REG` staging register (quantized "
-                    "lanes produced by `AAQ`) to external memory."
+                    "**Temporary:** write **512 bytes** from **`R_ACC`** (128×32-bit post-activation "
+                    "lanes) to external memory. Intended final behavior is to export the **128-byte** "
+                    "**`POST_AAQ_REG`** buffer after **quantization** (32→8 per lane); the register "
+                    "width and store source will be aligned when that path is fully implemented."
                 ),
                 syntax="STR_POST_AAQ_REG offset, base",
                 operands=[
                     "offset: Offset register (LR0–LR15)",
                     "base: Base address register (CR0–CR15)",
                 ],
-                operation="Memory[offset + base] = POST_AAQ_REG  # 128 elements",
+                operation="Memory[offset + base] = R_ACC (512 bytes); temporary until export reads POST_AAQ_REG (128 bytes) after quant split",
                 example="STR_POST_AAQ_REG LR0, CR0;;",
             ),
             "execute_fn": "execute_str_post_aaq_reg",
@@ -758,7 +760,12 @@ INSTRUCTION_SPEC = {
             "operands": [],
             "doc": InstructionDoc(
                 title="AAQ Quantize",
-                summary="Quantize the 128-word accumulator from INT32 to INT8, storing clamped results in the POST_AAQ_REG staging register. Requires INT8 mode.",
+                summary=(
+                    "Quantize the 128-word accumulator from INT32 to INT8, storing clamped results in the "
+                    "POST_AAQ_REG staging register (128 bytes; layout may evolve when quant is fully split from "
+                    "R_ACC). Requires INT8 mode. STR_POST_AAQ_REG currently exports 512 bytes from R_ACC instead—"
+                    "see docs/content/building-applications.md#activations-emulator."
+                ),
                 syntax="AAQ",
                 operands=[],
                 operation=(

--- a/src/tools/ipu-common/src/ipu_common/instruction_spec.py
+++ b/src/tools/ipu-common/src/ipu_common/instruction_spec.py
@@ -173,7 +173,7 @@ INSTRUCTION_SPEC = {
                 operation="Memory[offset + base] = R_ACC",
                 example="STR_ACC_REG CR0, CR1;;",
             ),
-            "execute_fn": "execute_stR_ACC_reg",
+            "execute_fn": "execute_str_acc_reg",
         },
         "LDR_MULT_REG": {
             "operands": [
@@ -212,7 +212,7 @@ INSTRUCTION_SPEC = {
                 ],
                 operation="R_CYCLIC[index % 512:128] = Memory[offset + base]",
             ),
-            "execute_fn": "execute_ldR_CYCLIC_mult_reg",
+            "execute_fn": "execute_ldr_cyclic_mult_reg",
         },
         "LDR_MULT_MASK_REG": {
             "operands": [
@@ -241,23 +241,26 @@ INSTRUCTION_SPEC = {
             ),
             "execute_fn": "execute_xmem_nop",
         },
-        "XMEM.STORE_AAQ_RESULT": {
+        "STR_POST_AAQ_REG": {
             "operands": [
                 {"name": "offset", "type": "LrIdx", "read": "live"},
                 {"name": "base", "type": "CrIdx", "read": "live"},
             ],
             "doc": InstructionDoc(
-                title="Store AAQ Result",
-                summary="Write the 128-byte AAQ quantization result register to external memory.",
-                syntax="XMEM.STORE_AAQ_RESULT offset, base",
+                title="Store Post-AAQ Staging Register",
+                summary=(
+                    "Write the 128-byte temporary `POST_AAQ_REG` staging register (quantized "
+                    "lanes produced by `AAQ`) to external memory."
+                ),
+                syntax="STR_POST_AAQ_REG offset, base",
                 operands=[
                     "offset: Offset register (LR0–LR15)",
                     "base: Base address register (CR0–CR15)",
                 ],
-                operation="Memory[offset + base] = AAQ_RESULT  # 128 elements",
-                example="XMEM.STORE_AAQ_RESULT LR0, CR0;;",
+                operation="Memory[offset + base] = POST_AAQ_REG  # 128 elements",
+                example="STR_POST_AAQ_REG LR0, CR0;;",
             ),
-            "execute_fn": "execute_xmem_store_AAQ_RESULT",
+            "execute_fn": "execute_str_post_aaq_reg",
         },
     },
     
@@ -732,12 +735,12 @@ INSTRUCTION_SPEC = {
             "operands": [],
             "doc": InstructionDoc(
                 title="AAQ Quantize",
-                summary="Quantize the 128-word accumulator from INT32 to INT8, storing clamped results in the AAQ_RESULT register. Requires INT8 mode.",
+                summary="Quantize the 128-word accumulator from INT32 to INT8, storing clamped results in the POST_AAQ_REG staging register. Requires INT8 mode.",
                 syntax="AAQ",
                 operands=[],
                 operation=(
                     "Requires INT8 mode (CR15 == DType.INT8). "
-                    "For i in [0, 128): AAQ_RESULT[i] = clamp(trunc(R_ACC[i]), -128, 127)"
+                    "For i in [0, 128): POST_AAQ_REG[i] = clamp(trunc(R_ACC[i]), -128, 127)"
                 ),
                 example="AAQ;;",
             ),

--- a/src/tools/ipu-common/src/ipu_common/instruction_spec.py
+++ b/src/tools/ipu-common/src/ipu_common/instruction_spec.py
@@ -30,6 +30,7 @@ OPERAND TYPE NAMES (resolved by ipu_as into actual token classes):
   - "Immediate": 16-bit signed integer for LR immediates (LrImmediateType)
   - "LrModPow2KImmediate": k operand for INCR_MOD_POW2 (semantic k ∈ [1, 9]; encoded as k−1 in 4 bits)
   - "MultMaskOffsetImmediate": mask slot index for mult masking (0–7; eight 128-bit slots in r_mask)
+  - "ActivationFnId": unsigned 4-bit immediate on `ACTIVATE` (0–15 wire; 0–11 are defined activations)
   - "BreakImmediate": 16-bit BREAK condition value (BreakImmediateType)
   - "Label": Branch target label (LabelToken)
 
@@ -124,7 +125,7 @@ SLOT_BINARY_LAYOUT: dict[str, list[str]] = {
     "xmem": ["MultStageReg", "LrIdx", "LrIdx", "CrIdx"],
     "mult": ["MultStageReg", "LrIdx", "MultMaskOffsetImmediate", "LrIdx", "LrIdx", "CrIdx", "AaqRegIdx"],
     "acc": ["AaqRegIdx", "ElementsInRow", "HorizontalStride", "VerticalStride", "LrIdx"],
-    "aaq": ["AggMode", "PostFn", "LcrIdx", "CrIdx", "AaqRegIdx"],
+    "aaq": ["AggMode", "PostFn", "LcrIdx", "CrIdx", "ActivationFnId", "AaqRegIdx"],
     "lr": ["LrIdx", "LrIdx", "LcrIdx", "AddSubSrcB", "Immediate", "LrModPow2KImmediate"],
     "cond": ["LcrIdx", "LcrIdx", "Label"],
     "break": ["LrIdx", "BreakImmediate"],
@@ -749,26 +750,27 @@ INSTRUCTION_SPEC = {
                     "type": "LcrIdx",
                     "read": "snapshot",
                 },
-                {"name": "act_cr_idx", "type": "CrIdx"},
+                {"name": "activation_fn", "type": "ActivationFnId"},
             ],
             "doc": InstructionDoc(
                 title="Accumulator Activation",
                 summary=(
                     "Apply an element-wise activation to the first valid_elements lanes of "
                     "r_acc; lanes beyond the active prefix are unchanged. The activation id "
-                    "(0–11) is read from cr[act_cr_idx] at cycle start."
+                    "(0–11) is an immediate in the instruction word (see AAQ stage spec section 7.0; "
+                    "values 12–15 are reserved and behave as identity)."
                 ),
-                syntax="ACTIVATE valid_elements act_cr_idx",
+                syntax="ACTIVATE valid_elements activation_fn",
                 operands=[
                     "valid_elements: lane count from an LR or CR register (unsigned, clamped to 0–128)",
-                    "act_cr_idx: which CR holds the activation function id (see AAQ stage spec section 7.0)",
+                    "activation_fn: unsigned 4-bit immediate 0–15 (ids 0–11 per spec; 12–15 treated as identity)",
                 ],
                 operation=(
-                    "Let n = min(valid_elements, 128) and k = cr[act_cr_idx]. "
+                    "Let n = min(valid_elements, 128) and k = activation_fn (12–15 → identity). "
                     "For i in [0, n): r_acc[i] = activation_k(r_acc[i]). "
                     "Alpha for leaky_relu / elu / prelu is fixed in the emulator (not ISA)."
                 ),
-                example="ACTIVATE lr0 cr2;;",
+                example="ACTIVATE lr0 1;;",
             ),
             "execute_fn": "execute_activate",
         },
@@ -1187,6 +1189,7 @@ VALID_OPERAND_TYPES: frozenset[str] = frozenset(
         "Immediate",
         "LrModPow2KImmediate",
         "MultMaskOffsetImmediate",
+        "ActivationFnId",
         "BreakImmediate",
         "Label",
         "AddSubSrcB",

--- a/src/tools/ipu-common/src/ipu_common/registers.py
+++ b/src/tools/ipu-common/src/ipu_common/registers.py
@@ -90,12 +90,11 @@ REGISTER_DEFINITIONS = {
         "encoding_class": "AaqRegField",
     },
     # Post-AAQ staging: **temporarily 512 bytes** (128×32-bit lanes, same footprint as
-    # `R_ACC`) until end-to-end quantization lands; then this register is expected to
-    # hold the narrower quantized export buffer instead. `AAQ` already writes the leading
-    # **128 bytes** with clamped INT8 lanes; the emulator clears the tail. XMEM
-    # **`STR_POST_AAQ_REG`** stores **this register** (512 bytes) to memory. In the
-    # Python emulator, `STR_POST_AAQ_REG` **refreshes** `post_aaq_reg` from `R_ACC`
-    # immediately before the store so exports match post-activation wide lanes (see `ipu.py`).
+    # `R_ACC`) until end-to-end quantization lands; then this register may hold a
+    # narrower quantized export buffer instead. **`ACTIVATE`** writes activated wide
+    # lanes (sourced from `r_acc`) here. **`AAQ`** (INT8) reads those wide lanes and
+    # replaces the register with 128 clamped INT8 bytes plus a cleared tail.
+    # **`STR_POST_AAQ_REG`** stores the full **512 bytes** to XMEM (see `ipu.py`).
     "post_aaq_reg": {
         "kind": RegKind.AAQ,
         "vector": True,

--- a/src/tools/ipu-common/src/ipu_common/registers.py
+++ b/src/tools/ipu-common/src/ipu_common/registers.py
@@ -89,16 +89,17 @@ REGISTER_DEFINITIONS = {
         "assembler_values": [f"aaq{i}" for i in range(4)],
         "encoding_class": "AaqRegField",
     },
-    # Staging for post-quantization byte lanes (128 × INT8) written by `AAQ`.
-    # Intended pipeline: activation is 32→32 per lane in `R_ACC`, then quantization
-    # 32→8 into this register. The **128-byte width is temporary** in the sense that the
-    # exact packing / metadata may evolve when quant is fully separated from `R_ACC`.
-    # XMEM `STR_POST_AAQ_REG` currently dumps **512 bytes from `R_ACC`** (see `ipu.py`);
-    # it will switch to this buffer once the export path matches the quant output.
+    # Post-AAQ staging: **temporarily 512 bytes** (128×32-bit lanes, same footprint as
+    # `R_ACC`) until end-to-end quantization lands; then this register is expected to
+    # hold the narrower quantized export buffer instead. `AAQ` already writes the leading
+    # **128 bytes** with clamped INT8 lanes; the emulator clears the tail. XMEM
+    # **`STR_POST_AAQ_REG`** stores **this register** (512 bytes) to memory. In the
+    # Python emulator, `STR_POST_AAQ_REG` **refreshes** `post_aaq_reg` from `R_ACC`
+    # immediately before the store so exports match post-activation wide lanes (see `ipu.py`).
     "post_aaq_reg": {
         "kind": RegKind.AAQ,
         "vector": True,
-        "size_bytes": 128,
+        "size_bytes": 512,
         "count": 1,
         "dtype": RegDtype.UINT8,
         "debug_aliases": ("aaq_result",),

--- a/src/tools/ipu-common/src/ipu_common/registers.py
+++ b/src/tools/ipu-common/src/ipu_common/registers.py
@@ -89,13 +89,14 @@ REGISTER_DEFINITIONS = {
         "assembler_values": [f"aaq{i}" for i in range(4)],
         "encoding_class": "AaqRegField",
     },
-    # AAQ quantization result — 128 × INT8 output of the aaq instruction
-    "aaq_result": {
+    # Temporary staging: 128 × INT8 quantized lanes after `AAQ` (before XMEM store).
+    "post_aaq_reg": {
         "kind": RegKind.AAQ,
         "vector": True,
         "size_bytes": 128,
         "count": 1,
         "dtype": RegDtype.UINT8,
+        "debug_aliases": ("aaq_result",),
     },
     # -----------------------------------------------------------------------
     # LR / CR scalar registers

--- a/src/tools/ipu-common/src/ipu_common/registers.py
+++ b/src/tools/ipu-common/src/ipu_common/registers.py
@@ -90,6 +90,8 @@ REGISTER_DEFINITIONS = {
         "encoding_class": "AaqRegField",
     },
     # Temporary staging: 128 × INT8 quantized lanes after `AAQ` (before XMEM store).
+    # Contrast `r_acc`: 512 bytes (128×32-bit FP32/INT32 lanes) is the quantize *input*;
+    # this register is the packed 128×8-bit *output* (one byte per lane).
     "post_aaq_reg": {
         "kind": RegKind.AAQ,
         "vector": True,

--- a/src/tools/ipu-common/src/ipu_common/registers.py
+++ b/src/tools/ipu-common/src/ipu_common/registers.py
@@ -89,9 +89,12 @@ REGISTER_DEFINITIONS = {
         "assembler_values": [f"aaq{i}" for i in range(4)],
         "encoding_class": "AaqRegField",
     },
-    # Temporary staging: 128 × INT8 quantized lanes after `AAQ` (before XMEM store).
-    # Contrast `r_acc`: 512 bytes (128×32-bit FP32/INT32 lanes) is the quantize *input*;
-    # this register is the packed 128×8-bit *output* (one byte per lane).
+    # Staging for post-quantization byte lanes (128 × INT8) written by `AAQ`.
+    # Intended pipeline: activation is 32→32 per lane in `R_ACC`, then quantization
+    # 32→8 into this register. The **128-byte width is temporary** in the sense that the
+    # exact packing / metadata may evolve when quant is fully separated from `R_ACC`.
+    # XMEM `STR_POST_AAQ_REG` currently dumps **512 bytes from `R_ACC`** (see `ipu.py`);
+    # it will switch to this buffer once the export path matches the quant output.
     "post_aaq_reg": {
         "kind": RegKind.AAQ,
         "vector": True,

--- a/src/tools/ipu-emu-py/src/ipu_emu/emulator.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/emulator.py
@@ -239,18 +239,38 @@ def run_test(
     teardown: Callable[[IpuState], None] | None = None,
     max_cycles: int = 1_000_000,
     debug_callback: DebugCallback | None = None,
+    state: IpuState | None = None,
+    leaky_relu_alpha: float | None = None,
+    elu_alpha: float | None = None,
+    prelu_alpha: float | None = None,
 ) -> tuple[IpuState, int]:
     """Full test harness matching the C ``emulator__run_test`` pattern.
 
-    1. Creates a fresh :class:`IpuState`.
+    1. Creates a fresh :class:`IpuState` (unless *state* is provided).
     2. Loads the instruction binary.
     3. Calls *setup(state)* (e.g. to load data into XMEM).
     4. Runs the program.
     5. Calls *teardown(state)* (e.g. to dump XMEM results).
 
     Returns ``(state, cycles)`` so callers can inspect final state.
+
+    Optional ``leaky_relu_alpha`` / ``elu_alpha`` / ``prelu_alpha`` configure the
+    emulator-only activation α values (same idea as dtype setup, but not via CR).
+    They are applied when constructing a new ``IpuState``; if *state* is passed,
+    non-``None`` α arguments are forwarded to :meth:`IpuState.set_activation_alphas`.
     """
-    state = IpuState()
+    if state is None:
+        state = IpuState(
+            leaky_relu_alpha=leaky_relu_alpha,
+            elu_alpha=elu_alpha,
+            prelu_alpha=prelu_alpha,
+        )
+    elif any(v is not None for v in (leaky_relu_alpha, elu_alpha, prelu_alpha)):
+        state.set_activation_alphas(
+            leaky_relu_alpha=leaky_relu_alpha,
+            elu_alpha=elu_alpha,
+            prelu_alpha=prelu_alpha,
+        )
     load_program_from_binary(state, inst_path)
 
     if setup is not None:

--- a/src/tools/ipu-emu-py/src/ipu_emu/execute.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/execute.py
@@ -16,6 +16,7 @@ C struct field names produced by ``CompoundInst.get_fields()``, e.g.::
     {
         "break_inst_token_0_break_inst_opcode": 2,   # BREAK_NOP
         "xmem_inst_token_0_xmem_inst_opcode": 4,     # XMEM_NOP
+        # … `STR_POST_AAQ_REG` is opcode 5 in the xmem slot when present
         ...
     }
 

--- a/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
@@ -97,7 +97,7 @@ _TYPE_FIELD_SUFFIX = {
     "Immediate": "lr_immediate_type",
     "LrModPow2KImmediate": "lr_mod_pow2_k_immediate",
     "MultMaskOffsetImmediate": "mult_mask_offset_immediate",
-    "ActivationFnId": "activation_fn_id_field",
+    "ActivationFn": "activation_fn_field",
     "BreakImmediate": "break_immediate_type",
     "Label": "label_token",
 }
@@ -1178,7 +1178,7 @@ class Ipu:
     def execute_activate(self, *, valid_elements: int, activation_fn: int) -> None:
         """Apply element-wise activation to the first ``valid_elements`` lanes of ``r_acc``.
 
-        The activation id (0–11) is ``activation_fn`` from the instruction word.
+        ``activation_fn`` is the encoded enum index (0–11) from the instruction word.
         Lanes at indices ``>=`` the active lane count are left unchanged.
         """
         fn_id = int(activation_fn) & 0xFFFFFFFF

--- a/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
@@ -1213,7 +1213,13 @@ class Ipu:
 
         for i in range(active):
             raw = struct.unpack_from(fmt, acc_buf, i * 4)[0]
-            y = apply_activation(fn_id, float(raw))
+            y = apply_activation(
+                fn_id,
+                float(raw),
+                leaky_relu_alpha=self.state.leaky_relu_alpha,
+                elu_alpha=self.state.elu_alpha,
+                prelu_alpha=self.state.prelu_alpha,
+            )
             if fmt == "<i":
                 yi = int(round(y))
                 if yi < -2147483648:

--- a/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
@@ -97,6 +97,7 @@ _TYPE_FIELD_SUFFIX = {
     "Immediate": "lr_immediate_type",
     "LrModPow2KImmediate": "lr_mod_pow2_k_immediate",
     "MultMaskOffsetImmediate": "mult_mask_offset_immediate",
+    "ActivationFnId": "activation_fn_id_field",
     "BreakImmediate": "break_immediate_type",
     "Label": "label_token",
 }
@@ -1174,13 +1175,13 @@ class Ipu:
             result[i] = clamped & 0xFF
         self.state.regfile.set_aaq_result(result)
 
-    def execute_activate(self, *, valid_elements: int, act_cr_idx: int) -> None:
+    def execute_activate(self, *, valid_elements: int, activation_fn: int) -> None:
         """Apply element-wise activation to the first ``valid_elements`` lanes of ``r_acc``.
 
-        The activation id (0–11) is read from ``cr[act_cr_idx]`` using the cycle-start
-        snapshot. Lanes at indices ``>=`` the active lane count are left unchanged.
+        The activation id (0–11) is ``activation_fn`` from the instruction word.
+        Lanes at indices ``>=`` the active lane count are left unchanged.
         """
-        fn_id = self.snapshot.get_cr(act_cr_idx) & 0xFFFFFFFF
+        fn_id = int(activation_fn) & 0xFFFFFFFF
         active = self._agg_active_lane_count(valid_elements)
         fmt = self._acc_agg_lane_fmt()
         acc_buf = self.state.regfile.raw("r_acc")

--- a/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
@@ -48,6 +48,7 @@ from ipu_common.acc_agg_enums import (
 )
 from ipu_common.incr_mod_pow2_k import LR_MOD_POW2_K_ENCODED_MAX, LR_MOD_POW2_K_MIN
 from ipu_common.registers import get_register_sizes, get_mult_stage_map
+from ipu_common.activations import apply_activation
 
 # ---------------------------------------------------------------------------
 # Errors
@@ -1172,6 +1173,30 @@ class Ipu:
             clamped = max(-128, min(127, truncated))
             result[i] = clamped & 0xFF
         self.state.regfile.set_aaq_result(result)
+
+    def execute_activate(self, *, valid_elements: int, act_cr_idx: int) -> None:
+        """Apply element-wise activation to the first ``valid_elements`` lanes of ``r_acc``.
+
+        The activation id (0–11) is read from ``cr[act_cr_idx]`` using the cycle-start
+        snapshot. Lanes at indices ``>=`` the active lane count are left unchanged.
+        """
+        fn_id = self.snapshot.get_cr(act_cr_idx) & 0xFFFFFFFF
+        active = self._agg_active_lane_count(valid_elements)
+        fmt = self._acc_agg_lane_fmt()
+        acc_buf = self.state.regfile.raw("r_acc")
+
+        for i in range(active):
+            raw = struct.unpack_from(fmt, acc_buf, i * 4)[0]
+            y = apply_activation(fn_id, float(raw))
+            if fmt == "<i":
+                yi = int(round(y))
+                if yi < -2147483648:
+                    yi = -2147483648
+                elif yi > 2147483647:
+                    yi = 2147483647
+                struct.pack_into("<i", acc_buf, i * 4, yi)
+            else:
+                struct.pack_into("<f", acc_buf, i * 4, float(y))
 
     def execute_xmem_store_aaq_result(self, *, offset: int, base: int) -> None:
         """Execute XMEM.STORE_AAQ_RESULT: Write 128-byte aaq_result to xmem."""

--- a/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
@@ -1132,11 +1132,11 @@ class Ipu:
         self.state.regfile.set_aaq(aaq_rf_idx, self._wide_pack_aaq_bits(fmt, result_val))
 
     def execute_aaq(self) -> None:
-        """Execute AAQ: Quantize r_acc (128 × INT32) → aaq_result (128 × INT8).
+        """Execute AAQ: Quantize r_acc (128 × INT32) → POST_AAQ_REG (128 × INT8).
 
         Requires INT8 mode. Each 32-bit word is truncated (top 8 bits taken via
         arithmetic right-shift by 24) then clamped to [-128, 127] and stored as
-        a signed byte in the aaq_result register.
+        a signed byte in the post_aaq_reg staging register.
 
         In wide-vector debug mode, ``aaq`` is normally a no-op (results stay in
         ``r_acc`` as 32-bit lanes; use ``STR_ACC_REG`` to dump them). Set
@@ -1163,7 +1163,7 @@ class Ipu:
                     truncated = val >> 24
                     clamped = max(-128, min(127, truncated))
                     result[i] = clamped & 0xFF
-            self.state.regfile.set_aaq_result(result)
+            self.state.regfile.set_post_aaq_reg(result)
             return
 
         acc_buf = self.state.regfile.raw("r_acc")
@@ -1173,7 +1173,7 @@ class Ipu:
             truncated = val >> 24  # arithmetic right-shift: keeps top 8 bits, range [-128, 127]
             clamped = max(-128, min(127, truncated))
             result[i] = clamped & 0xFF
-        self.state.regfile.set_aaq_result(result)
+        self.state.regfile.set_post_aaq_reg(result)
 
     def execute_activate(self, *, valid_elements: int, activation_fn: int) -> None:
         """Apply element-wise activation to the first ``valid_elements`` lanes of ``r_acc``.
@@ -1199,10 +1199,10 @@ class Ipu:
             else:
                 struct.pack_into("<f", acc_buf, i * 4, float(y))
 
-    def execute_xmem_store_aaq_result(self, *, offset: int, base: int) -> None:
-        """Execute XMEM.STORE_AAQ_RESULT: Write 128-byte aaq_result to xmem."""
+    def execute_str_post_aaq_reg(self, *, offset: int, base: int) -> None:
+        """Execute STR_POST_AAQ_REG: Write 128-byte POST_AAQ_REG staging buffer to XMEM."""
         addr = offset + base
-        data = self.state.regfile.get_aaq_result()
+        data = self.state.regfile.get_post_aaq_reg()
         self.state.xmem.write_address(addr, data)
 
     # -----------------------------------------------------------------------

--- a/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
@@ -1225,9 +1225,15 @@ class Ipu:
                 struct.pack_into("<f", acc_buf, i * 4, float(y))
 
     def execute_str_post_aaq_reg(self, *, offset: int, base: int) -> None:
-        """Execute STR_POST_AAQ_REG: Write 128-byte POST_AAQ_REG staging buffer to XMEM."""
+        """Write **512 bytes** from ``R_ACC`` to XMEM (temporary export).
+
+        Intended pipeline: **activation** (32→32 per lane, in ``R_ACC``) then
+        **quantization** (32→8) into ``POST_AAQ_REG``. Until the XMEM path is switched
+        to the quantized buffer, this instruction mirrors the post-activation
+        accumulator so harnesses can snapshot full lanes.
+        """
         addr = offset + base
-        data = self.state.regfile.get_post_aaq_reg()
+        data = self.state.regfile.get_r_acc_bytes()
         self.state.xmem.write_address(addr, data)
 
     # -----------------------------------------------------------------------

--- a/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
@@ -1146,17 +1146,18 @@ class Ipu:
         self.state.regfile.set_aaq(aaq_rf_idx, self._wide_pack_aaq_bits(fmt, result_val))
 
     def execute_aaq(self) -> None:
-        """Execute AAQ: Quantize r_acc (128 × INT32) → leading bytes of POST_AAQ_REG.
+        """Execute AAQ: Quantize wide lanes in ``POST_AAQ_REG`` (128 × 32-bit) → leading bytes.
 
-        Requires INT8 mode. Each 32-bit word is truncated (top 8 bits taken via
-        arithmetic right-shift by 24) then clamped to [-128, 127] and stored as
-        a signed byte in the **first 128 bytes** of ``post_aaq_reg``. The register
-        is **512 bytes** for now; unused tail bytes are cleared.
+        Source is the **512-byte** ``post_aaq_reg`` buffer (same lane layout as
+        ``r_acc``), typically filled by ``ACTIVATE``. Each 32-bit lane is truncated
+        then clamped to INT8 and stored in the **first 128 bytes** of
+        ``post_aaq_reg``; the wide-lane tail is cleared.
 
-        In wide-vector debug mode, ``aaq`` is normally a no-op (results stay in
-        ``r_acc`` as 32-bit lanes; use ``STR_ACC_REG`` to dump them). Set
-        ``state.wide_vector_quantize_output`` to re-run INT8-style quantization
-        from wide lanes for comparison with the real path.
+        Requires INT8 mode.
+
+        In wide-vector debug mode, ``aaq`` is normally a no-op (use
+        ``STR_ACC_REG`` to dump ``r_acc``). Set ``state.wide_vector_quantize_output``
+        to quantize from ``post_aaq_reg`` wide lanes for comparison with the real path.
         """
         dtype = self.state.get_cr_dtype()
         if dtype != DType.INT8:
@@ -1165,41 +1166,46 @@ class Ipu:
         if self._wide_vector_active():
             if not self.state.wide_vector_quantize_output:
                 return
-            acc_buf = self.state.regfile.raw("r_acc")
+            src_buf = self.state.regfile.raw("post_aaq_reg")
             result = bytearray(128)
             if self.state.wide_vector_arithmetic == WideVectorArithmetic.FP32:
                 for i in range(128):
-                    val = struct.unpack_from("<f", acc_buf, i * 4)[0]
+                    val = struct.unpack_from("<f", src_buf, i * 4)[0]
                     clamped = max(-128, min(127, int(round(val))))
                     result[i] = clamped & 0xFF
             else:
                 for i in range(128):
-                    val = struct.unpack_from("<i", acc_buf, i * 4)[0]
+                    val = struct.unpack_from("<i", src_buf, i * 4)[0]
                     truncated = val >> 24
                     clamped = max(-128, min(127, truncated))
                     result[i] = clamped & 0xFF
             self.state.regfile.set_post_aaq_reg(result + bytearray(384))
             return
 
-        acc_buf = self.state.regfile.raw("r_acc")
+        src_buf = self.state.regfile.raw("post_aaq_reg")
         result = bytearray(128)
         for i in range(128):
-            val = struct.unpack_from("<i", acc_buf, i * 4)[0]
+            val = struct.unpack_from("<i", src_buf, i * 4)[0]
             truncated = val >> 24  # arithmetic right-shift: keeps top 8 bits, range [-128, 127]
             clamped = max(-128, min(127, truncated))
             result[i] = clamped & 0xFF
         self.state.regfile.set_post_aaq_reg(result + bytearray(384))
 
     def execute_activate(self, *, valid_elements: int, activation_fn: int) -> None:
-        """Apply element-wise activation to the first ``valid_elements`` lanes of ``r_acc``.
+        """Apply element-wise activation to the first ``valid_elements`` lanes.
+
+        Reads each active lane from ``r_acc`` and writes the result into the same
+        lane of ``post_aaq_reg`` (512-byte wide staging). ``r_acc`` is not modified.
+        Lanes at indices ``>=`` the active lane count in ``post_aaq_reg`` are left
+        unchanged.
 
         ``activation_fn`` is the encoded enum index (0–11) from the instruction word.
-        Lanes at indices ``>=`` the active lane count are left unchanged.
         """
         fn_id = int(activation_fn) & 0xFFFFFFFF
         active = self._agg_active_lane_count(valid_elements)
         fmt = self._acc_agg_lane_fmt()
         acc_buf = self.state.regfile.raw("r_acc")
+        post_buf = self.state.regfile.raw("post_aaq_reg")
 
         for i in range(active):
             raw = struct.unpack_from(fmt, acc_buf, i * 4)[0]
@@ -1216,23 +1222,13 @@ class Ipu:
                     yi = -2147483648
                 elif yi > 2147483647:
                     yi = 2147483647
-                struct.pack_into("<i", acc_buf, i * 4, yi)
+                struct.pack_into("<i", post_buf, i * 4, yi)
             else:
-                struct.pack_into("<f", acc_buf, i * 4, float(y))
+                struct.pack_into("<f", post_buf, i * 4, float(y))
 
     def execute_str_post_aaq_reg(self, *, offset: int, base: int) -> None:
-        """Store **POST_AAQ_REG** (512 bytes) to XMEM.
-
-        **Interim model:** ``POST_AAQ_REG`` is a **512-byte** staging register (same
-        width as ``R_ACC``) until the quantized export path is finalized. This
-        instruction writes those 512 bytes to external memory. The Python emulator
-        **refreshes** ``POST_AAQ_REG`` from ``R_ACC`` immediately before the store
-        so the buffer holds the current post-activation wide lanes (``AAQ`` still
-        writes the leading **128 bytes** with clamped INT8 when INT8 mode is on).
-        """
+        """Store **POST_AAQ_REG** (512 bytes) to XMEM."""
         addr = offset + base
-        acc = self.state.regfile.get_r_acc_bytes()
-        self.state.regfile.set_post_aaq_reg(bytearray(acc))
         self.state.xmem.write_address(addr, bytes(self.state.regfile.raw("post_aaq_reg")))
 
     # -----------------------------------------------------------------------

--- a/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
@@ -1342,7 +1342,7 @@ class Ipu:
         elif slot_type == "xmem":
             if instruction_name in {"LDR_MULT_REG", "LDR_CYCLIC_MULT_REG", "LDR_MULT_MASK_REG"}:
                 stats.xmem_reads += 1
-            elif instruction_name in {"STR_ACC_REG", "XMEM.STORE_AAQ_RESULT"}:
+            elif instruction_name in {"STR_ACC_REG", "STR_POST_AAQ_REG"}:
                 stats.xmem_writes += 1
 
         # Call handler with named arguments

--- a/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
@@ -1157,11 +1157,12 @@ class Ipu:
         self.state.regfile.set_aaq(aaq_rf_idx, self._wide_pack_aaq_bits(fmt, result_val))
 
     def execute_aaq(self) -> None:
-        """Execute AAQ: Quantize r_acc (128 × INT32) → POST_AAQ_REG (128 × INT8).
+        """Execute AAQ: Quantize r_acc (128 × INT32) → leading bytes of POST_AAQ_REG.
 
         Requires INT8 mode. Each 32-bit word is truncated (top 8 bits taken via
         arithmetic right-shift by 24) then clamped to [-128, 127] and stored as
-        a signed byte in the post_aaq_reg staging register.
+        a signed byte in the **first 128 bytes** of ``post_aaq_reg``. The register
+        is **512 bytes** for now; unused tail bytes are cleared.
 
         In wide-vector debug mode, ``aaq`` is normally a no-op (results stay in
         ``r_acc`` as 32-bit lanes; use ``STR_ACC_REG`` to dump them). Set
@@ -1188,7 +1189,7 @@ class Ipu:
                     truncated = val >> 24
                     clamped = max(-128, min(127, truncated))
                     result[i] = clamped & 0xFF
-            self.state.regfile.set_post_aaq_reg(result)
+            self.state.regfile.set_post_aaq_reg(result + bytearray(384))
             return
 
         acc_buf = self.state.regfile.raw("r_acc")
@@ -1198,7 +1199,7 @@ class Ipu:
             truncated = val >> 24  # arithmetic right-shift: keeps top 8 bits, range [-128, 127]
             clamped = max(-128, min(127, truncated))
             result[i] = clamped & 0xFF
-        self.state.regfile.set_post_aaq_reg(result)
+        self.state.regfile.set_post_aaq_reg(result + bytearray(384))
 
     def execute_activate(self, *, valid_elements: int, activation_fn: int) -> None:
         """Apply element-wise activation to the first ``valid_elements`` lanes of ``r_acc``.
@@ -1231,16 +1232,19 @@ class Ipu:
                 struct.pack_into("<f", acc_buf, i * 4, float(y))
 
     def execute_str_post_aaq_reg(self, *, offset: int, base: int) -> None:
-        """Write **512 bytes** from ``R_ACC`` to XMEM (temporary export).
+        """Store **POST_AAQ_REG** (512 bytes) to XMEM.
 
-        Intended pipeline: **activation** (32→32 per lane, in ``R_ACC``) then
-        **quantization** (32→8) into ``POST_AAQ_REG``. Until the XMEM path is switched
-        to the quantized buffer, this instruction mirrors the post-activation
-        accumulator so harnesses can snapshot full lanes.
+        **Interim model:** ``POST_AAQ_REG`` is a **512-byte** staging register (same
+        width as ``R_ACC``) until the quantized export path is finalized. This
+        instruction writes those 512 bytes to external memory. The Python emulator
+        **refreshes** ``POST_AAQ_REG`` from ``R_ACC`` immediately before the store
+        so the buffer holds the current post-activation wide lanes (``AAQ`` still
+        writes the leading **128 bytes** with clamped INT8 when INT8 mode is on).
         """
         addr = offset + base
-        data = self.state.regfile.get_r_acc_bytes()
-        self.state.xmem.write_address(addr, data)
+        acc = self.state.regfile.get_r_acc_bytes()
+        self.state.regfile.set_post_aaq_reg(bytearray(acc))
+        self.state.xmem.write_address(addr, bytes(self.state.regfile.raw("post_aaq_reg")))
 
     # -----------------------------------------------------------------------
     # COND Instruction Handlers

--- a/src/tools/ipu-emu-py/src/ipu_emu/ipu_state.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/ipu_state.py
@@ -12,6 +12,7 @@ from typing import Any
 from ipu_emu.regfile import RegFile
 from ipu_emu.stats import RunStats
 from ipu_emu.xmem import XMem
+from ipu_common import activations as _activations
 
 # Matches C: #define IPU__INST_MEM_SIZE 1024
 INST_MEM_SIZE = 1024
@@ -47,6 +48,9 @@ class IpuState:
         wide_vector_debug: bool = False,
         wide_vector_arithmetic: WideVectorArithmetic = WideVectorArithmetic.FP32,
         wide_vector_quantize_output: bool = False,
+        leaky_relu_alpha: float | None = None,
+        elu_alpha: float | None = None,
+        prelu_alpha: float | None = None,
     ) -> None:
         self.regfile = RegFile()
         self.xmem = XMem()
@@ -66,6 +70,21 @@ class IpuState:
         self._debug_mult_stage_vectors: dict[int, list[float | int]] = {}
         self._debug_mult_stage_vectors_snap: dict[int, list[float | int]] = {}
 
+        # --- Activation α (emulator-only; not mapped to CR) ----------------------
+        # Snapshot module defaults at construction unless caller overrides. Matches
+        # the ergonomics of ``set_cr_dtype`` but lives on ``IpuState`` only.
+        self.leaky_relu_alpha: float = (
+            float(leaky_relu_alpha)
+            if leaky_relu_alpha is not None
+            else float(_activations._LEAKY_ALPHA)
+        )
+        self.elu_alpha: float = (
+            float(elu_alpha) if elu_alpha is not None else float(_activations._ELU_ALPHA)
+        )
+        self.prelu_alpha: float = (
+            float(prelu_alpha) if prelu_alpha is not None else float(_activations._PRELU_ALPHA)
+        )
+
     # -- CR dtype convenience (mirrors ipu__set_cr_dtype / ipu__get_cr_dtype) --
 
     def set_cr_dtype(self, dtype: int) -> None:
@@ -75,6 +94,25 @@ class IpuState:
     def get_cr_dtype(self) -> int:
         """Read the data type register (CR[15])."""
         return self.regfile.get_cr(CR_DTYPE_REG)
+
+    def set_activation_alphas(
+        self,
+        *,
+        leaky_relu_alpha: float | None = None,
+        elu_alpha: float | None = None,
+        prelu_alpha: float | None = None,
+    ) -> None:
+        """Override α for ``leaky_relu`` / ``elu`` / ``prelu`` (emulator-only; not CR).
+
+        Only arguments that are not ``None`` are updated. Values apply to subsequent
+        ``ACTIVATE`` instructions executed on this state.
+        """
+        if leaky_relu_alpha is not None:
+            self.leaky_relu_alpha = float(leaky_relu_alpha)
+        if elu_alpha is not None:
+            self.elu_alpha = float(elu_alpha)
+        if prelu_alpha is not None:
+            self.prelu_alpha = float(prelu_alpha)
 
     # -- register file snapshot (for VLIW dispatch) -------------------------
 

--- a/src/tools/ipu-emu-py/test/test_emulator_e2e.py
+++ b/src/tools/ipu-emu-py/test/test_emulator_e2e.py
@@ -213,6 +213,23 @@ class TestRunTest:
         )
         assert len(cb_calls) > 0
 
+    def test_run_test_passes_activation_alphas_to_state(self, tmp_path: Path) -> None:
+        """``run_test`` forwards α kwargs into ``IpuState`` (emulator-only)."""
+        from ipu_as.lark_tree import assemble_to_bin_file
+
+        inst_path = tmp_path / "bkpt.bin"
+        assemble_to_bin_file("BKPT;;\n", str(inst_path))
+
+        state, _ = run_test(
+            inst_path=inst_path,
+            leaky_relu_alpha=0.07,
+            elu_alpha=1.25,
+            prelu_alpha=0.33,
+        )
+        assert state.leaky_relu_alpha == pytest.approx(0.07)
+        assert state.elu_alpha == pytest.approx(1.25)
+        assert state.prelu_alpha == pytest.approx(0.33)
+
 
 # ---------------------------------------------------------------------------
 # End-to-end: assemble → load → run → validate

--- a/src/tools/ipu-emu-py/test/test_execute.py
+++ b/src/tools/ipu-emu-py/test/test_execute.py
@@ -1855,13 +1855,12 @@ class TestActivate:
     def test_activate_relu_int32(self):
         state = _make_state(
             """\
-ACTIVATE lr0 cr2;;
+ACTIVATE lr0 1;;
 BKPT;;
 """
         )
         state.regfile.set_cr(15, DType.INT8)
         state.regfile.set_lr(0, 128)
-        state.regfile.set_cr(2, 1)  # relu
         state.regfile.set_r_acc_word(
             0, struct.unpack("<I", struct.pack("<i", -9))[0]
         )
@@ -1872,13 +1871,12 @@ BKPT;;
     def test_activate_masks_inactive_lanes(self):
         state = _make_state(
             """\
-ACTIVATE lr0 cr2;;
+ACTIVATE lr0 1;;
 BKPT;;
 """
         )
         state.regfile.set_cr(15, DType.INT8)
         state.regfile.set_lr(0, 2)
-        state.regfile.set_cr(2, 1)  # relu
         state.regfile.set_r_acc_word(
             0, struct.unpack("<I", struct.pack("<i", -5))[0]
         )
@@ -1900,16 +1898,15 @@ BKPT;;
         for i in range(2, 128):
             assert state.regfile.get_r_acc_word(i) == sentinel
 
-    def test_activate_unknown_id_is_identity(self):
+    def test_activate_reserved_id_is_identity(self):
         state = _make_state(
             """\
-ACTIVATE lr0 cr2;;
+ACTIVATE lr0 12;;
 BKPT;;
 """
         )
         state.regfile.set_cr(15, DType.INT8)
         state.regfile.set_lr(0, 1)
-        state.regfile.set_cr(2, 0x100)  # out of range → identity
         raw = struct.unpack("<I", struct.pack("<i", -42))[0]
         state.regfile.set_r_acc_word(0, raw)
         run_until_complete(state)
@@ -1918,13 +1915,12 @@ BKPT;;
     def test_activate_sigmoid_float_lane(self):
         state = _make_state(
             """\
-ACTIVATE lr0 cr2;;
+ACTIVATE lr0 4;;
 BKPT;;
 """
         )
         state.regfile.set_cr(15, DType.E4)
         state.regfile.set_lr(0, 1)
-        state.regfile.set_cr(2, 4)  # sigmoid
         state.regfile.set_r_acc_word(
             0, struct.unpack("<I", struct.pack("<f", 0.0))[0]
         )
@@ -1938,14 +1934,13 @@ BKPT;;
         x = 0.25
         for fid in range(12):
             state = _make_state(
-                """\
-ACTIVATE lr0 cr2;;
+                f"""\
+ACTIVATE lr0 {fid};;
 BKPT;;
 """
             )
             state.regfile.set_cr(15, DType.E4)
             state.regfile.set_lr(0, 1)
-            state.regfile.set_cr(2, fid)
             state.regfile.set_r_acc_word(
                 0, struct.unpack("<I", struct.pack("<f", x))[0]
             )
@@ -1959,13 +1954,12 @@ BKPT;;
     def test_activate_exp2_float(self):
         state = _make_state(
             """\
-ACTIVATE lr0 cr2;;
+ACTIVATE lr0 11;;
 BKPT;;
 """
         )
         state.regfile.set_cr(15, DType.E4)
         state.regfile.set_lr(0, 1)
-        state.regfile.set_cr(2, 11)  # exp2
         state.regfile.set_r_acc_word(
             0, struct.unpack("<I", struct.pack("<f", 3.0))[0]
         )
@@ -1978,13 +1972,12 @@ BKPT;;
     def test_activate_gelu_float(self):
         state = _make_state(
             """\
-ACTIVATE lr0 cr2;;
+ACTIVATE lr0 6;;
 BKPT;;
 """
         )
         state.regfile.set_cr(15, DType.E4)
         state.regfile.set_lr(0, 1)
-        state.regfile.set_cr(2, 6)  # gelu
         x = 1.0
         state.regfile.set_r_acc_word(
             0, struct.unpack("<I", struct.pack("<f", x))[0]
@@ -1998,13 +1991,12 @@ BKPT;;
     def test_activate_valid_elements_from_cr(self):
         state = _make_state(
             """\
-ACTIVATE cr3 cr2;;
+ACTIVATE cr3 1;;
 BKPT;;
 """
         )
         state.regfile.set_cr(15, DType.INT8)
         state.regfile.set_cr(3, 1)
-        state.regfile.set_cr(2, 1)  # relu
         state.regfile.set_r_acc_word(
             0, struct.unpack("<I", struct.pack("<i", -8))[0]
         )

--- a/src/tools/ipu-emu-py/test/test_execute.py
+++ b/src/tools/ipu-emu-py/test/test_execute.py
@@ -1845,17 +1845,15 @@ class TestAaqQuantize:
         with pytest.raises(EmulatorError, match="INT8 mode"):
             run_until_complete(state)
 
-    def test_post_aaq_reg_written_to_xmem(self):
-        """STR_POST_AAQ_REG writes exactly 128 bytes to the given address."""
+    def test_str_post_aaq_reg_writes_r_acc_512_to_xmem(self):
+        """STR_POST_AAQ_REG writes 512 bytes from R_ACC (temporary pre-quant export)."""
         state = IpuState()
         state.regfile.set_cr(15, DType.INT8)
-        # Set r_acc: each word = i << 24 so byte i = i (for i < 128)
         self._set_acc_words(state, [i << 24 for i in range(128)])
         state.regfile.set_cr(8, 0x4000)
 
         encoded = assemble(
             """\
-aaq;;
 SET lr0 cr8;;
 str_post_aaq_reg lr0 cr0;;
 BKPT;;
@@ -1867,9 +1865,8 @@ BKPT;;
         load_program(state, decoded)
         run_until_complete(state)
 
-        stored = state.xmem.read_address(0x4000, 128)
-        for i in range(128):
-            assert stored[i] == i, f"xmem byte {i}: expected {i}, got {stored[i]}"
+        stored = state.xmem.read_address(0x4000, 512)
+        assert stored == state.regfile.get_r_acc_bytes()
 
     def test_STR_ACC_REG_emits_warning(self):
         """STR_ACC_REG emits a UserWarning about being debug-only."""

--- a/src/tools/ipu-emu-py/test/test_execute.py
+++ b/src/tools/ipu-emu-py/test/test_execute.py
@@ -1709,12 +1709,12 @@ BKPT;;
             assert val == 28, f"acc word {i}: expected 28 (r1[0]=7 × cyclic[i]=4), got {val}"
 
 # ============================================================================
-# AAQ Quantization (aaq instruction + xmem.store_aaq_result)
+# AAQ Quantization (aaq instruction + str_post_aaq_reg)
 # ============================================================================
 
 
 class TestAaqQuantize:
-    """Tests for the aaq quantization instruction and xmem.store_aaq_result."""
+    """Tests for the aaq quantization instruction and STR_POST_AAQ_REG."""
 
     def _set_acc_words(self, state: IpuState, values: list[int]) -> None:
         """Write a list of 128 signed INT32 values into r_acc."""
@@ -1736,7 +1736,7 @@ class TestAaqQuantize:
         load_program(state, decoded)
         run_until_complete(state)
 
-        result = state.regfile.get_aaq_result()
+        result = state.regfile.get_post_aaq_reg()
         for i in range(128):
             expected = i if i < 128 else i - 256
             assert result[i] == (expected & 0xFF), f"byte {i}: expected {expected & 0xFF}, got {result[i]}"
@@ -1754,7 +1754,7 @@ class TestAaqQuantize:
         load_program(state, decoded)
         run_until_complete(state)
 
-        assert state.regfile.get_aaq_result() == bytearray(128)
+        assert state.regfile.get_post_aaq_reg() == bytearray(128)
 
     def test_aaq_positive_clamp(self):
         """Large positive values clamp to 127 after truncation."""
@@ -1772,7 +1772,7 @@ class TestAaqQuantize:
         load_program(state, decoded)
         run_until_complete(state)
 
-        result = state.regfile.get_aaq_result()
+        result = state.regfile.get_post_aaq_reg()
         for i in range(64):
             assert result[i] == 127, f"byte {i}: expected 127, got {result[i]}"
         for i in range(64, 128):
@@ -1792,7 +1792,7 @@ class TestAaqQuantize:
         load_program(state, decoded)
         run_until_complete(state)
 
-        result = state.regfile.get_aaq_result()
+        result = state.regfile.get_post_aaq_reg()
         for i in range(128):
             assert result[i] == 0xFF, f"byte {i}: expected 0xFF (-1), got {result[i]}"
 
@@ -1804,8 +1804,8 @@ class TestAaqQuantize:
         with pytest.raises(EmulatorError, match="INT8 mode"):
             run_until_complete(state)
 
-    def test_aaq_result_written_to_xmem(self):
-        """xmem.store_aaq_result writes exactly 128 bytes to the given address."""
+    def test_post_aaq_reg_written_to_xmem(self):
+        """STR_POST_AAQ_REG writes exactly 128 bytes to the given address."""
         state = IpuState()
         state.regfile.set_cr(15, DType.INT8)
         # Set r_acc: each word = i << 24 so byte i = i (for i < 128)
@@ -1815,7 +1815,7 @@ class TestAaqQuantize:
             """\
 aaq;;
 SET lr0 0x4000;;
-xmem.store_aaq_result lr0 cr0;;
+str_post_aaq_reg lr0 cr0;;
 BKPT;;
 """
         )

--- a/src/tools/ipu-emu-py/test/test_execute.py
+++ b/src/tools/ipu-emu-py/test/test_execute.py
@@ -26,7 +26,7 @@ from ipu_as.lark_tree import assemble, parse
 
 from ipu_as.compound_inst import CompoundInst
 
-from ipu_common.activations import apply_activation
+from ipu_common.activations import ACTIVATION_FN_NAMES, apply_activation
 
 
 # ---------------------------------------------------------------------------
@@ -1855,7 +1855,7 @@ class TestActivate:
     def test_activate_relu_int32(self):
         state = _make_state(
             """\
-ACTIVATE lr0 1;;
+ACTIVATE lr0 relu;;
 BKPT;;
 """
         )
@@ -1871,7 +1871,7 @@ BKPT;;
     def test_activate_masks_inactive_lanes(self):
         state = _make_state(
             """\
-ACTIVATE lr0 1;;
+ACTIVATE lr0 relu;;
 BKPT;;
 """
         )
@@ -1898,10 +1898,10 @@ BKPT;;
         for i in range(2, 128):
             assert state.regfile.get_r_acc_word(i) == sentinel
 
-    def test_activate_reserved_id_is_identity(self):
+    def test_activate_identity_keyword_is_noop(self):
         state = _make_state(
             """\
-ACTIVATE lr0 12;;
+ACTIVATE lr0 identity;;
 BKPT;;
 """
         )
@@ -1915,7 +1915,7 @@ BKPT;;
     def test_activate_sigmoid_float_lane(self):
         state = _make_state(
             """\
-ACTIVATE lr0 4;;
+ACTIVATE lr0 sigmoid;;
 BKPT;;
 """
         )
@@ -1932,10 +1932,10 @@ BKPT;;
 
     def test_activate_matches_reference_all_ids_float(self):
         x = 0.25
-        for fid in range(12):
+        for fid, name in enumerate(ACTIVATION_FN_NAMES):
             state = _make_state(
                 f"""\
-ACTIVATE lr0 {fid};;
+ACTIVATE lr0 {name};;
 BKPT;;
 """
             )
@@ -1954,7 +1954,7 @@ BKPT;;
     def test_activate_exp2_float(self):
         state = _make_state(
             """\
-ACTIVATE lr0 11;;
+ACTIVATE lr0 exp2;;
 BKPT;;
 """
         )
@@ -1972,7 +1972,7 @@ BKPT;;
     def test_activate_gelu_float(self):
         state = _make_state(
             """\
-ACTIVATE lr0 6;;
+ACTIVATE lr0 gelu;;
 BKPT;;
 """
         )
@@ -1988,10 +1988,45 @@ BKPT;;
         )[0]
         assert abs(out - apply_activation(6, x)) < 1e-5
 
+    def test_activate_swish_alias_matches_silu(self):
+        state = _make_state(
+            """\
+ACTIVATE lr0 swish;;
+BKPT;;
+"""
+        )
+        state.regfile.set_cr(15, DType.E4)
+        state.regfile.set_lr(0, 1)
+        x = 0.5
+        state.regfile.set_r_acc_word(
+            0, struct.unpack("<I", struct.pack("<f", x))[0]
+        )
+        run_until_complete(state)
+        out_swish = struct.unpack(
+            "<f", struct.pack("<I", state.regfile.get_r_acc_word(0))
+        )[0]
+
+        st2 = _make_state(
+            """\
+ACTIVATE lr0 silu;;
+BKPT;;
+"""
+        )
+        st2.regfile.set_cr(15, DType.E4)
+        st2.regfile.set_lr(0, 1)
+        st2.regfile.set_r_acc_word(
+            0, struct.unpack("<I", struct.pack("<f", x))[0]
+        )
+        run_until_complete(st2)
+        out_silu = struct.unpack(
+            "<f", struct.pack("<I", st2.regfile.get_r_acc_word(0))
+        )[0]
+        assert abs(out_swish - out_silu) < 1e-7
+
     def test_activate_valid_elements_from_cr(self):
         state = _make_state(
             """\
-ACTIVATE cr3 1;;
+ACTIVATE cr3 relu;;
 BKPT;;
 """
         )

--- a/src/tools/ipu-emu-py/test/test_execute.py
+++ b/src/tools/ipu-emu-py/test/test_execute.py
@@ -1788,6 +1788,7 @@ class TestAaqQuantize:
         buf = bytearray(512)
         struct.pack_into("<128i", buf, 0, *values)
         state.regfile.set_r_acc_bytes(buf)
+        state.regfile.set_post_aaq_reg(bytearray(buf))
 
     def test_aaq_basic_truncation(self):
         """Values that fit in int8 after >> 24: e.g. 1 << 24 → byte 1."""
@@ -1874,7 +1875,7 @@ class TestAaqQuantize:
             run_until_complete(state)
 
     def test_str_post_aaq_reg_writes_post_aaq_reg_512_to_xmem(self):
-        """STR_POST_AAQ_REG stores POST_AAQ_REG (512 B) to XMEM; emulator syncs from R_ACC."""
+        """STR_POST_AAQ_REG stores POST_AAQ_REG (512 B) to XMEM."""
         state = IpuState()
         state.regfile.set_cr(15, DType.INT8)
         self._set_acc_words(state, [i << 24 for i in range(128)])
@@ -1894,7 +1895,6 @@ BKPT;;
         run_until_complete(state)
 
         stored = state.xmem.read_address(0x4000, 512)
-        assert stored == state.regfile.get_r_acc_bytes()
         assert stored == state.regfile.get_post_aaq_reg()
 
     def test_STR_ACC_REG_emits_warning(self):
@@ -1913,12 +1913,24 @@ BKPT;;
 
 
 # ============================================================================
-# ACTIVATE (element-wise r_acc activations, issue #77)
+# ACTIVATE (element-wise: r_acc → POST_AAQ_REG, issue #77)
 # ============================================================================
 
 
+def _post_aaq_lane_i32(state: IpuState, lane: int) -> int:
+    buf = state.regfile.get_post_aaq_reg()
+    word = struct.unpack_from("<I", buf, lane * 4)[0]
+    return struct.unpack("<i", struct.pack("<I", word))[0]
+
+
+def _post_aaq_lane_f32(state: IpuState, lane: int) -> float:
+    buf = state.regfile.get_post_aaq_reg()
+    word = struct.unpack_from("<I", buf, lane * 4)[0]
+    return struct.unpack("<f", struct.pack("<I", word))[0]
+
+
 class TestActivate:
-    """ACTIVATE applies ipu_common.activations to the first ``valid_elements`` r_acc lanes."""
+    """ACTIVATE applies ipu_common.activations to r_acc lanes; results go to POST_AAQ_REG."""
 
     def test_activate_relu_int32(self):
         state = _make_state(
@@ -1933,8 +1945,11 @@ BKPT;;
             0, struct.unpack("<I", struct.pack("<i", -9))[0]
         )
         run_until_complete(state)
-        w0 = struct.unpack("<i", struct.pack("<I", state.regfile.get_r_acc_word(0)))[0]
-        assert w0 == 0
+        assert (
+            struct.unpack("<i", struct.pack("<I", state.regfile.get_r_acc_word(0)))[0]
+            == -9
+        )
+        assert _post_aaq_lane_i32(state, 0) == 0
 
     def test_activate_masks_inactive_lanes(self):
         state = _make_state(
@@ -1954,17 +1969,25 @@ BKPT;;
         sentinel = struct.unpack("<I", struct.pack("<i", 99_999))[0]
         for i in range(2, 128):
             state.regfile.set_r_acc_word(i, sentinel)
+        post = bytearray(512)
+        for i in range(2, 128):
+            struct.pack_into("<i", post, i * 4, 99_999)
+        state.regfile.set_post_aaq_reg(post)
         run_until_complete(state)
         assert (
             struct.unpack("<i", struct.pack("<I", state.regfile.get_r_acc_word(0)))[0]
-            == 0
+            == -5
         )
         assert (
             struct.unpack("<i", struct.pack("<I", state.regfile.get_r_acc_word(1)))[0]
-            == 0
+            == -3
         )
         for i in range(2, 128):
             assert state.regfile.get_r_acc_word(i) == sentinel
+        assert _post_aaq_lane_i32(state, 0) == 0
+        assert _post_aaq_lane_i32(state, 1) == 0
+        for i in range(2, 128):
+            assert _post_aaq_lane_i32(state, i) == 99_999
 
     def test_activate_identity_keyword_is_noop(self):
         state = _make_state(
@@ -1979,6 +2002,7 @@ BKPT;;
         state.regfile.set_r_acc_word(0, raw)
         run_until_complete(state)
         assert state.regfile.get_r_acc_word(0) == raw
+        assert _post_aaq_lane_i32(state, 0) == struct.unpack("<i", struct.pack("<I", raw))[0]
 
     def test_activate_sigmoid_float_lane(self):
         state = _make_state(
@@ -1993,9 +2017,7 @@ BKPT;;
             0, struct.unpack("<I", struct.pack("<f", 0.0))[0]
         )
         run_until_complete(state)
-        out = struct.unpack(
-            "<f", struct.pack("<I", state.regfile.get_r_acc_word(0))
-        )[0]
+        out = _post_aaq_lane_f32(state, 0)
         assert abs(out - 0.5) < 1e-6
 
     def test_activate_matches_reference_all_ids_float(self):
@@ -2013,9 +2035,7 @@ BKPT;;
                 0, struct.unpack("<I", struct.pack("<f", x))[0]
             )
             run_until_complete(state)
-            got = struct.unpack(
-                "<f", struct.pack("<I", state.regfile.get_r_acc_word(0))
-            )[0]
+            got = _post_aaq_lane_f32(state, 0)
             exp = apply_activation(fid, x)
             assert abs(got - exp) < 1e-5, f"id={fid} got={got} exp={exp}"
 
@@ -2032,9 +2052,7 @@ BKPT;;
             0, struct.unpack("<I", struct.pack("<f", 3.0))[0]
         )
         run_until_complete(state)
-        out = struct.unpack(
-            "<f", struct.pack("<I", state.regfile.get_r_acc_word(0))
-        )[0]
+        out = _post_aaq_lane_f32(state, 0)
         assert abs(out - 8.0) < 1e-5
 
     def test_activate_gelu_float(self):
@@ -2051,9 +2069,7 @@ BKPT;;
             0, struct.unpack("<I", struct.pack("<f", x))[0]
         )
         run_until_complete(state)
-        out = struct.unpack(
-            "<f", struct.pack("<I", state.regfile.get_r_acc_word(0))
-        )[0]
+        out = _post_aaq_lane_f32(state, 0)
         assert abs(out - apply_activation(6, x)) < 1e-5
 
     def test_activate_swish_alias_matches_silu(self):
@@ -2070,9 +2086,7 @@ BKPT;;
             0, struct.unpack("<I", struct.pack("<f", x))[0]
         )
         run_until_complete(state)
-        out_swish = struct.unpack(
-            "<f", struct.pack("<I", state.regfile.get_r_acc_word(0))
-        )[0]
+        out_swish = _post_aaq_lane_f32(state, 0)
 
         st2 = _make_state(
             """\
@@ -2086,9 +2100,7 @@ BKPT;;
             0, struct.unpack("<I", struct.pack("<f", x))[0]
         )
         run_until_complete(st2)
-        out_silu = struct.unpack(
-            "<f", struct.pack("<I", st2.regfile.get_r_acc_word(0))
-        )[0]
+        out_silu = _post_aaq_lane_f32(st2, 0)
         assert abs(out_swish - out_silu) < 1e-7
 
     def test_activate_leaky_relu_respects_ipu_state_alpha(self):
@@ -2108,9 +2120,7 @@ BKPT;;
             0, struct.unpack("<I", struct.pack("<f", x))[0]
         )
         run_until_complete(state)
-        out = struct.unpack(
-            "<f", struct.pack("<I", state.regfile.get_r_acc_word(0))
-        )[0]
+        out = _post_aaq_lane_f32(state, 0)
         exp = apply_activation(3, x, leaky_relu_alpha=alpha)
         assert abs(out - exp) < 1e-5
 
@@ -2130,9 +2140,7 @@ BKPT;;
             0, struct.unpack("<I", struct.pack("<f", x))[0]
         )
         run_until_complete(state)
-        out = struct.unpack(
-            "<f", struct.pack("<I", state.regfile.get_r_acc_word(0))
-        )[0]
+        out = _post_aaq_lane_f32(state, 0)
         exp = apply_activation(3, x, leaky_relu_alpha=alpha)
         assert abs(out - exp) < 1e-5
 
@@ -2153,6 +2161,8 @@ BKPT;;
         run_until_complete(state)
         assert (
             struct.unpack("<i", struct.pack("<I", state.regfile.get_r_acc_word(0)))[0]
-            == 0
+            == -8
         )
         assert state.regfile.get_r_acc_word(1) == tail
+        assert _post_aaq_lane_i32(state, 0) == 0
+        assert _post_aaq_lane_i32(state, 1) == 0

--- a/src/tools/ipu-emu-py/test/test_execute.py
+++ b/src/tools/ipu-emu-py/test/test_execute.py
@@ -34,15 +34,27 @@ from ipu_common.activations import ACTIVATION_FN_NAMES, apply_activation
 # ---------------------------------------------------------------------------
 
 
-def _make_state(asm_code: str, *, cr: dict[int, int] | None = None) -> IpuState:
+def _make_state(
+    asm_code: str,
+    *,
+    cr: dict[int, int] | None = None,
+    leaky_relu_alpha: float | None = None,
+    elu_alpha: float | None = None,
+    prelu_alpha: float | None = None,
+) -> IpuState:
     """Assemble *asm_code* and return a ready-to-run IpuState.
 
     Optional *cr* presets configuration registers before the program is loaded
-    (e.g. constants read by ``SET lr* cr*``).
+    (e.g. constants read by ``SET lr* cr*``). Optional α kwargs are forwarded to
+    :class:`IpuState` (emulator-only; not CR).
     """
     encoded = assemble(asm_code)
     decoded = [decode_instruction_word(w) for w in encoded]
-    state = IpuState()
+    state = IpuState(
+        leaky_relu_alpha=leaky_relu_alpha,
+        elu_alpha=elu_alpha,
+        prelu_alpha=prelu_alpha,
+    )
     if cr:
         for idx, val in cr.items():
             state.regfile.set_cr(idx, val)
@@ -50,10 +62,24 @@ def _make_state(asm_code: str, *, cr: dict[int, int] | None = None) -> IpuState:
     return state
 
 
-def _run(asm_code: str, *, cr: dict[int, int] | None = None, **kw) -> IpuState:
+def _run(
+    asm_code: str,
+    *,
+    cr: dict[int, int] | None = None,
+    leaky_relu_alpha: float | None = None,
+    elu_alpha: float | None = None,
+    prelu_alpha: float | None = None,
+    max_cycles: int = 100_000,
+) -> IpuState:
     """Assemble, load, run, and return the final state."""
-    state = _make_state(asm_code, cr=cr)
-    run_until_complete(state, **kw)
+    state = _make_state(
+        asm_code,
+        cr=cr,
+        leaky_relu_alpha=leaky_relu_alpha,
+        elu_alpha=elu_alpha,
+        prelu_alpha=prelu_alpha,
+    )
+    run_until_complete(state, max_cycles)
     return state
 
 
@@ -2061,6 +2087,51 @@ BKPT;;
             "<f", struct.pack("<I", st2.regfile.get_r_acc_word(0))
         )[0]
         assert abs(out_swish - out_silu) < 1e-7
+
+    def test_activate_leaky_relu_respects_ipu_state_alpha(self):
+        """``IpuState`` α overrides module defaults for ``ACTIVATE`` (not CR)."""
+        x = -1.0
+        alpha = 0.5
+        state = _make_state(
+            """\
+ACTIVATE lr0 leaky_relu;;
+BKPT;;
+""",
+            leaky_relu_alpha=alpha,
+        )
+        state.regfile.set_cr(15, DType.E4)
+        state.regfile.set_lr(0, 1)
+        state.regfile.set_r_acc_word(
+            0, struct.unpack("<I", struct.pack("<f", x))[0]
+        )
+        run_until_complete(state)
+        out = struct.unpack(
+            "<f", struct.pack("<I", state.regfile.get_r_acc_word(0))
+        )[0]
+        exp = apply_activation(3, x, leaky_relu_alpha=alpha)
+        assert abs(out - exp) < 1e-5
+
+    def test_activate_leaky_relu_after_set_activation_alphas(self):
+        x = -2.0
+        alpha = 0.125
+        state = _make_state(
+            """\
+ACTIVATE lr0 leaky_relu;;
+BKPT;;
+"""
+        )
+        state.set_activation_alphas(leaky_relu_alpha=alpha)
+        state.regfile.set_cr(15, DType.E4)
+        state.regfile.set_lr(0, 1)
+        state.regfile.set_r_acc_word(
+            0, struct.unpack("<I", struct.pack("<f", x))[0]
+        )
+        run_until_complete(state)
+        out = struct.unpack(
+            "<f", struct.pack("<I", state.regfile.get_r_acc_word(0))
+        )[0]
+        exp = apply_activation(3, x, leaky_relu_alpha=alpha)
+        assert abs(out - exp) < 1e-5
 
     def test_activate_valid_elements_from_cr(self):
         state = _make_state(

--- a/src/tools/ipu-emu-py/test/test_execute.py
+++ b/src/tools/ipu-emu-py/test/test_execute.py
@@ -26,6 +26,8 @@ from ipu_as.lark_tree import assemble, parse
 
 from ipu_as.compound_inst import CompoundInst
 
+from ipu_common.activations import apply_activation
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -1840,3 +1842,177 @@ BKPT;;
 
         with pytest.warns(UserWarning, match="DEBUG ONLY"):
             run_until_complete(state)
+
+
+# ============================================================================
+# ACTIVATE (element-wise r_acc activations, issue #77)
+# ============================================================================
+
+
+class TestActivate:
+    """ACTIVATE applies ipu_common.activations to the first ``valid_elements`` r_acc lanes."""
+
+    def test_activate_relu_int32(self):
+        state = _make_state(
+            """\
+ACTIVATE lr0 cr2;;
+BKPT;;
+"""
+        )
+        state.regfile.set_cr(15, DType.INT8)
+        state.regfile.set_lr(0, 128)
+        state.regfile.set_cr(2, 1)  # relu
+        state.regfile.set_r_acc_word(
+            0, struct.unpack("<I", struct.pack("<i", -9))[0]
+        )
+        run_until_complete(state)
+        w0 = struct.unpack("<i", struct.pack("<I", state.regfile.get_r_acc_word(0)))[0]
+        assert w0 == 0
+
+    def test_activate_masks_inactive_lanes(self):
+        state = _make_state(
+            """\
+ACTIVATE lr0 cr2;;
+BKPT;;
+"""
+        )
+        state.regfile.set_cr(15, DType.INT8)
+        state.regfile.set_lr(0, 2)
+        state.regfile.set_cr(2, 1)  # relu
+        state.regfile.set_r_acc_word(
+            0, struct.unpack("<I", struct.pack("<i", -5))[0]
+        )
+        state.regfile.set_r_acc_word(
+            1, struct.unpack("<I", struct.pack("<i", -3))[0]
+        )
+        sentinel = struct.unpack("<I", struct.pack("<i", 99_999))[0]
+        for i in range(2, 128):
+            state.regfile.set_r_acc_word(i, sentinel)
+        run_until_complete(state)
+        assert (
+            struct.unpack("<i", struct.pack("<I", state.regfile.get_r_acc_word(0)))[0]
+            == 0
+        )
+        assert (
+            struct.unpack("<i", struct.pack("<I", state.regfile.get_r_acc_word(1)))[0]
+            == 0
+        )
+        for i in range(2, 128):
+            assert state.regfile.get_r_acc_word(i) == sentinel
+
+    def test_activate_unknown_id_is_identity(self):
+        state = _make_state(
+            """\
+ACTIVATE lr0 cr2;;
+BKPT;;
+"""
+        )
+        state.regfile.set_cr(15, DType.INT8)
+        state.regfile.set_lr(0, 1)
+        state.regfile.set_cr(2, 0x100)  # out of range → identity
+        raw = struct.unpack("<I", struct.pack("<i", -42))[0]
+        state.regfile.set_r_acc_word(0, raw)
+        run_until_complete(state)
+        assert state.regfile.get_r_acc_word(0) == raw
+
+    def test_activate_sigmoid_float_lane(self):
+        state = _make_state(
+            """\
+ACTIVATE lr0 cr2;;
+BKPT;;
+"""
+        )
+        state.regfile.set_cr(15, DType.E4)
+        state.regfile.set_lr(0, 1)
+        state.regfile.set_cr(2, 4)  # sigmoid
+        state.regfile.set_r_acc_word(
+            0, struct.unpack("<I", struct.pack("<f", 0.0))[0]
+        )
+        run_until_complete(state)
+        out = struct.unpack(
+            "<f", struct.pack("<I", state.regfile.get_r_acc_word(0))
+        )[0]
+        assert abs(out - 0.5) < 1e-6
+
+    def test_activate_matches_reference_all_ids_float(self):
+        x = 0.25
+        for fid in range(12):
+            state = _make_state(
+                """\
+ACTIVATE lr0 cr2;;
+BKPT;;
+"""
+            )
+            state.regfile.set_cr(15, DType.E4)
+            state.regfile.set_lr(0, 1)
+            state.regfile.set_cr(2, fid)
+            state.regfile.set_r_acc_word(
+                0, struct.unpack("<I", struct.pack("<f", x))[0]
+            )
+            run_until_complete(state)
+            got = struct.unpack(
+                "<f", struct.pack("<I", state.regfile.get_r_acc_word(0))
+            )[0]
+            exp = apply_activation(fid, x)
+            assert abs(got - exp) < 1e-5, f"id={fid} got={got} exp={exp}"
+
+    def test_activate_exp2_float(self):
+        state = _make_state(
+            """\
+ACTIVATE lr0 cr2;;
+BKPT;;
+"""
+        )
+        state.regfile.set_cr(15, DType.E4)
+        state.regfile.set_lr(0, 1)
+        state.regfile.set_cr(2, 11)  # exp2
+        state.regfile.set_r_acc_word(
+            0, struct.unpack("<I", struct.pack("<f", 3.0))[0]
+        )
+        run_until_complete(state)
+        out = struct.unpack(
+            "<f", struct.pack("<I", state.regfile.get_r_acc_word(0))
+        )[0]
+        assert abs(out - 8.0) < 1e-5
+
+    def test_activate_gelu_float(self):
+        state = _make_state(
+            """\
+ACTIVATE lr0 cr2;;
+BKPT;;
+"""
+        )
+        state.regfile.set_cr(15, DType.E4)
+        state.regfile.set_lr(0, 1)
+        state.regfile.set_cr(2, 6)  # gelu
+        x = 1.0
+        state.regfile.set_r_acc_word(
+            0, struct.unpack("<I", struct.pack("<f", x))[0]
+        )
+        run_until_complete(state)
+        out = struct.unpack(
+            "<f", struct.pack("<I", state.regfile.get_r_acc_word(0))
+        )[0]
+        assert abs(out - apply_activation(6, x)) < 1e-5
+
+    def test_activate_valid_elements_from_cr(self):
+        state = _make_state(
+            """\
+ACTIVATE cr3 cr2;;
+BKPT;;
+"""
+        )
+        state.regfile.set_cr(15, DType.INT8)
+        state.regfile.set_cr(3, 1)
+        state.regfile.set_cr(2, 1)  # relu
+        state.regfile.set_r_acc_word(
+            0, struct.unpack("<I", struct.pack("<i", -8))[0]
+        )
+        tail = struct.unpack("<I", struct.pack("<i", 123))[0]
+        state.regfile.set_r_acc_word(1, tail)
+        run_until_complete(state)
+        assert (
+            struct.unpack("<i", struct.pack("<I", state.regfile.get_r_acc_word(0)))[0]
+            == 0
+        )
+        assert state.regfile.get_r_acc_word(1) == tail

--- a/src/tools/ipu-emu-py/test/test_execute.py
+++ b/src/tools/ipu-emu-py/test/test_execute.py
@@ -1807,6 +1807,7 @@ class TestAaqQuantize:
         for i in range(128):
             expected = i if i < 128 else i - 256
             assert result[i] == (expected & 0xFF), f"byte {i}: expected {expected & 0xFF}, got {result[i]}"
+        assert result[128:] == bytearray(384), "tail of POST_AAQ_REG should be cleared"
 
     def test_aaq_all_zeros(self):
         """All-zero accumulator quantizes to all-zero bytes."""
@@ -1821,7 +1822,7 @@ class TestAaqQuantize:
         load_program(state, decoded)
         run_until_complete(state)
 
-        assert state.regfile.get_post_aaq_reg() == bytearray(128)
+        assert state.regfile.get_post_aaq_reg() == bytearray(512)
 
     def test_aaq_positive_clamp(self):
         """Large positive values clamp to 127 after truncation."""
@@ -1844,6 +1845,7 @@ class TestAaqQuantize:
             assert result[i] == 127, f"byte {i}: expected 127, got {result[i]}"
         for i in range(64, 128):
             assert result[i] == 127, f"byte {i}: expected 127, got {result[i]}"
+        assert result[128:] == bytearray(384)
 
     def test_aaq_negative_values(self):
         """Negative accumulator values truncate correctly."""
@@ -1862,6 +1864,7 @@ class TestAaqQuantize:
         result = state.regfile.get_post_aaq_reg()
         for i in range(128):
             assert result[i] == 0xFF, f"byte {i}: expected 0xFF (-1), got {result[i]}"
+        assert result[128:] == bytearray(384)
 
     def test_aaq_requires_int8_mode(self):
         """aaq raises EmulatorError when not in INT8 mode."""
@@ -1871,8 +1874,8 @@ class TestAaqQuantize:
         with pytest.raises(EmulatorError, match="INT8 mode"):
             run_until_complete(state)
 
-    def test_str_post_aaq_reg_writes_r_acc_512_to_xmem(self):
-        """STR_POST_AAQ_REG writes 512 bytes from R_ACC (temporary pre-quant export)."""
+    def test_str_post_aaq_reg_writes_post_aaq_reg_512_to_xmem(self):
+        """STR_POST_AAQ_REG stores POST_AAQ_REG (512 B) to XMEM; emulator syncs from R_ACC."""
         state = IpuState()
         state.regfile.set_cr(15, DType.INT8)
         self._set_acc_words(state, [i << 24 for i in range(128)])
@@ -1893,6 +1896,7 @@ BKPT;;
 
         stored = state.xmem.read_address(0x4000, 512)
         assert stored == state.regfile.get_r_acc_bytes()
+        assert stored == state.regfile.get_post_aaq_reg()
 
     def test_STR_ACC_REG_emits_warning(self):
         """STR_ACC_REG emits a UserWarning about being debug-only."""

--- a/src/tools/ipu-emu-py/test/test_regfile.py
+++ b/src/tools/ipu-emu-py/test/test_regfile.py
@@ -284,6 +284,13 @@ class TestIpuState:
         state.store_r_reg_to_xmem(512, 1)
         assert state.xmem.read_address(512, 128) == data
 
+    def test_post_aaq_reg_debug_alias_aaq_result(self):
+        """Legacy debug name ``aaq_result`` resolves to ``post_aaq_reg``."""
+        state = IpuState()
+        data = bytearray(range(128))
+        state.regfile.set_post_aaq_reg(data)
+        assert state.regfile.get_register_bytes("aaq_result") == bytearray(data)
+
     def test_snapshot_regfile(self):
         state = IpuState()
         state.regfile.set_lr(3, 77)

--- a/src/tools/ipu-emu-py/test/test_regfile.py
+++ b/src/tools/ipu-emu-py/test/test_regfile.py
@@ -287,7 +287,7 @@ class TestIpuState:
     def test_post_aaq_reg_debug_alias_aaq_result(self):
         """Legacy debug name ``aaq_result`` resolves to ``post_aaq_reg``."""
         state = IpuState()
-        data = bytearray(range(128))
+        data = bytearray((i * 3) & 0xFF for i in range(512))
         state.regfile.set_post_aaq_reg(data)
         assert state.regfile.get_register_bytes("aaq_result") == bytearray(data)
 

--- a/src/tools/ipu-emu-py/test/test_wide_vector_debug.py
+++ b/src/tools/ipu-emu-py/test/test_wide_vector_debug.py
@@ -90,7 +90,7 @@ BKPT;;
 """,
             cr={6: 0x1000, 7: 0x2000, 8: 0},
         )
-        assert state.regfile.get_post_aaq_reg() == bytearray(128)
+        assert state.regfile.get_post_aaq_reg() == bytearray(512)
 
     def test_aaq_quantize_fp32_acc_for_comparison(self) -> None:
         # Use exact float product 3.0 so rounding is unambiguous (round-half-even).
@@ -123,7 +123,8 @@ BKPT;;
         load_program(state, [decode_instruction_word(w) for w in encoded])
         run_until_complete(state)
         out = state.regfile.get_post_aaq_reg()
-        assert all(b == 3 for b in out)
+        assert all(b == 3 for b in out[:128])
+        assert out[128:] == bytearray(384)
 
 
 class TestWideVectorInt32:

--- a/src/tools/ipu-emu-py/test/test_wide_vector_debug.py
+++ b/src/tools/ipu-emu-py/test/test_wide_vector_debug.py
@@ -85,10 +85,12 @@ LDR_CYCLIC_MULT_REG lr1 cr0 lr2;;
 RESET_ACC;;
 MULT.EE r0 lr2 0 lr2;;
 acc.first;;
+SET lr0 cr9;;
+ACTIVATE lr0 identity;;
 aaq;;
 BKPT;;
 """,
-            cr={6: 0x1000, 7: 0x2000, 8: 0},
+            cr={6: 0x1000, 7: 0x2000, 8: 0, 9: 128},
         )
         assert state.regfile.get_post_aaq_reg() == bytearray(512)
 
@@ -113,12 +115,15 @@ LDR_CYCLIC_MULT_REG lr1 cr0 lr2;;
 RESET_ACC;;
 MULT.EE r0 lr2 0 lr2;;
 acc.first;;
+SET lr0 cr9;;
+ACTIVATE lr0 identity;;
 aaq;;
 BKPT;;
 """
         state.regfile.set_cr(6, 0x1000)
         state.regfile.set_cr(7, 0x2000)
         state.regfile.set_cr(8, 0)
+        state.regfile.set_cr(9, 128)
         encoded = assemble(asm)
         load_program(state, [decode_instruction_word(w) for w in encoded])
         run_until_complete(state)

--- a/src/tools/ipu-emu-py/test/test_wide_vector_debug.py
+++ b/src/tools/ipu-emu-py/test/test_wide_vector_debug.py
@@ -82,7 +82,7 @@ aaq;;
 BKPT;;
 """,
         )
-        assert state.regfile.get_aaq_result() == bytearray(128)
+        assert state.regfile.get_post_aaq_reg() == bytearray(128)
 
     def test_aaq_quantize_fp32_acc_for_comparison(self) -> None:
         # Use exact float product 3.0 so rounding is unambiguous (round-half-even).
@@ -111,7 +111,7 @@ BKPT;;
         encoded = assemble(asm)
         load_program(state, [decode_instruction_word(w) for w in encoded])
         run_until_complete(state)
-        out = state.regfile.get_aaq_result()
+        out = state.regfile.get_post_aaq_reg()
         assert all(b == 3 for b in out)
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## ACTIVATE → `POST_AAQ_REG` (latest)

**Previously:** `ACTIVATE` overwrote **`R_ACC`** in place so one buffer held both “raw accumulate” and “post-activation” views—simple for a first emulator cut, but it conflates accumulation with activation staging.

**Now:**
- **`ACTIVATE`** reads each active lane from **`R_ACC`** and writes the activated **32-bit** lane into the same index in **`POST_AAQ_REG`**. **`R_ACC` is unchanged** (so **`AGG` / `AGG.FIRST`** still reduce the accumulator).
- **`AAQ`** quantizes from the **wide lanes in `POST_AAQ_REG`** (after `ACTIVATE`, or after tests copy `R_ACC` → `POST_AAQ_REG` where no activation is needed).
- **`STR_POST_AAQ_REG`** writes **`POST_AAQ_REG`** to XMEM **as-is** (no implicit refresh from `R_ACC`).

Docs (`building-applications.md`, `instruction_spec.py`, `SKILL.md`, `registers.py` comments, `activations.py`, wide-vector guide) and tests are updated accordingly. Wide-vector `AAQ` comparison test inserts **`ACTIVATE` … `identity`** (with `CR9` = 128) so `POST_AAQ_REG` holds the `R_ACC` lanes before `AAQ`.

Commit: `1e09567`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b91b0f1b-580c-43ee-8863-6d44dedb9d01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b91b0f1b-580c-43ee-8863-6d44dedb9d01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

