### PR TITLE
Add execution statistics tracking (issue #84)

### DIFF
--- a/docs/content/building-applications.md
+++ b/docs/content/building-applications.md
@@ -189,7 +189,7 @@ def main() -> None:
         max_cycles=args.max_cycles,
         debug_callback=debug_prompt,  # Interactive debug CLI
     )
-    print(f"Finished in {cycles} cycles")
+    print(state.stats.format_summary())
 
 
 if __name__ == "__main__":
@@ -275,6 +275,42 @@ Run tests:
 
 ```bash
 bazel test //src/tools/ipu-apps:test_my_app
+```
+
+## Inspecting Run Statistics
+
+Every run populates `state.stats` (a `RunStats` instance) with counters useful for spotting bottlenecks. They are updated automatically by `run_until_complete` / `run_with_debug` — no opt-in flag is required.
+
+Available fields:
+
+- `total_cycles` — VLIW cycles executed
+- `mult_active_cycles` — cycles whose MULT slot was not `MULT_NOP`
+- `acc_active_cycles` — cycles whose ACC slot was not `ACC_NOP`
+- `xmem_reads` — count of `LDR_MULT_REG`, `LDR_CYCLIC_MULT_REG`, `LDR_MULT_MASK_REG`
+- `xmem_writes` — count of `STR_ACC_REG`, `XMEM.STORE_AAQ_RESULT`
+- `xmem_accesses` — sum of reads + writes
+- `mult_utilization`, `acc_utilization` — active-cycle fraction (0.0–1.0)
+
+`state.stats.format_summary()` returns a ready-to-print multi-line block:
+
+```text
+=== Run summary ===
+Total cycles:           12847
+Mult active:            10421  (81.1%)
+Acc  active:             9876  (76.9%)
+XMEM reads:              3200
+XMEM writes:              128
+XMEM accesses:           3328
+```
+
+Typical usage from an interactive runner or a test:
+
+```python
+state, cycles = app.run(max_cycles=args.max_cycles)
+print(state.stats.format_summary())
+
+# Or pick individual fields for assertions / metrics:
+assert state.stats.mult_utilization > 0.5
 ```
 
 ## Example Application: Fully Connected Layer
@@ -476,7 +512,7 @@ def main() -> None:
         dtype=args.dtype,
     )
     state, cycles = app.run(max_cycles=args.max_cycles, debug_callback=debug_prompt)
-    print(f"Finished in {cycles} cycles")
+    print(state.stats.format_summary())
 
 
 if __name__ == "__main__":

--- a/src/tools/ipu-apps/src/ipu_apps/fully_connected/__main__.py
+++ b/src/tools/ipu-apps/src/ipu_apps/fully_connected/__main__.py
@@ -34,7 +34,7 @@ def main() -> None:
         dtype=args.dtype,
     )
     state, cycles = app.run(max_cycles=args.max_cycles, debug_callback=debug_prompt)
-    print(f"Finished in {cycles} cycles")
+    print(state.stats.format_summary())
 
 
 if __name__ == "__main__":

--- a/src/tools/ipu-emu-py/BUILD.bazel
+++ b/src/tools/ipu-emu-py/BUILD.bazel
@@ -79,3 +79,13 @@ py_pytest_test(
         requirement("pytest"),
     ],
 )
+
+py_pytest_test(
+    name = "test_stats",
+    srcs = ["test/test_stats.py"],
+    imports = ["src"],
+    deps = [
+        ":ipu_emu_lib",
+        requirement("pytest"),
+    ],
+)

--- a/src/tools/ipu-emu-py/src/ipu_emu/emulator.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/emulator.py
@@ -79,6 +79,7 @@ def run_until_complete(state: IpuState, max_cycles: int = 100_000) -> int:
             # In "run" mode, skip the break and execute the instruction anyway
             execute_instruction_skip_break(state)
         cycles += 1
+    state.stats.total_cycles = cycles
     return cycles
 
 
@@ -122,6 +123,7 @@ def run_with_debug(
 
         cycles += 1
 
+    state.stats.total_cycles = cycles
     return cycles
 
 

--- a/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
@@ -1272,6 +1272,20 @@ class Ipu:
             regfile = self.snapshot if source == "snapshot" else self.state.regfile
             kwargs[name] = self._resolve_operand(op_type, kwargs[name], regfile)
 
+        # Update run statistics
+        stats = self.state.stats
+        if slot_type == "mult":
+            if instruction_name != "MULT_NOP":
+                stats.mult_active_cycles += 1
+        elif slot_type == "acc":
+            if instruction_name != "ACC_NOP":
+                stats.acc_active_cycles += 1
+        elif slot_type == "xmem":
+            if instruction_name in {"LDR_MULT_REG", "LDR_CYCLIC_MULT_REG", "LDR_MULT_MASK_REG"}:
+                stats.xmem_reads += 1
+            elif instruction_name in {"STR_ACC_REG", "XMEM.STORE_AAQ_RESULT"}:
+                stats.xmem_writes += 1
+
         # Call handler with named arguments
         method = getattr(self, execute_fn_name)
         return method(**kwargs)

--- a/src/tools/ipu-emu-py/src/ipu_emu/ipu_state.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/ipu_state.py
@@ -10,6 +10,7 @@ from enum import Enum
 from typing import Any
 
 from ipu_emu.regfile import RegFile
+from ipu_emu.stats import RunStats
 from ipu_emu.xmem import XMem
 
 # Matches C: #define IPU__INST_MEM_SIZE 1024
@@ -50,6 +51,7 @@ class IpuState:
         self.regfile = RegFile()
         self.xmem = XMem()
         self.program_counter: int = 0
+        self.stats = RunStats()
         # Instruction memory — each entry will be a decoded instruction dict
         # (populated when loading a binary or assembling).
         self.inst_mem: list[dict[str, Any] | None] = [None] * INST_MEM_SIZE

--- a/src/tools/ipu-emu-py/src/ipu_emu/stats.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/stats.py
@@ -1,0 +1,55 @@
+"""Per-run execution statistics (issue #84).
+
+Tracks mult/accumulate stage occupancy and memory access counts over a
+single emulator run.  An instance is held on ``IpuState.stats`` and updated
+by ``Ipu.dispatch_instruction`` during execution.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class RunStats:
+    """Counters accumulated during one emulator run."""
+
+    total_cycles: int = 0
+    mult_active_cycles: int = 0
+    acc_active_cycles: int = 0
+    xmem_reads: int = 0
+    xmem_writes: int = 0
+
+    @property
+    def mult_utilization(self) -> float:
+        """Fraction of total cycles the mult stage was active (0.0–1.0)."""
+        if self.total_cycles == 0:
+            return 0.0
+        return self.mult_active_cycles / self.total_cycles
+
+    @property
+    def acc_utilization(self) -> float:
+        """Fraction of total cycles the accumulate stage was active (0.0–1.0)."""
+        if self.total_cycles == 0:
+            return 0.0
+        return self.acc_active_cycles / self.total_cycles
+
+    @property
+    def xmem_accesses(self) -> int:
+        return self.xmem_reads + self.xmem_writes
+
+    def format_summary(self) -> str:
+        """Return a multi-line human-readable summary."""
+        tc = self.total_cycles
+        mu = self.mult_utilization * 100
+        au = self.acc_utilization * 100
+        lines = [
+            "=== Run summary ===",
+            f"Total cycles:        {tc:>8}",
+            f"Mult active:         {self.mult_active_cycles:>8}  ({mu:.1f}%)",
+            f"Acc  active:         {self.acc_active_cycles:>8}  ({au:.1f}%)",
+            f"XMEM reads:          {self.xmem_reads:>8}",
+            f"XMEM writes:         {self.xmem_writes:>8}",
+            f"XMEM accesses:       {self.xmem_accesses:>8}",
+        ]
+        return "\n".join(lines)

--- a/src/tools/ipu-emu-py/test/test_stats.py
+++ b/src/tools/ipu-emu-py/test/test_stats.py
@@ -1,0 +1,178 @@
+"""Tests for RunStats counters (issue #84)."""
+
+from __future__ import annotations
+
+from ipu_emu.emulator import load_program, run_until_complete
+from ipu_emu.execute import decode_instruction_word
+from ipu_emu.ipu_state import IpuState
+from ipu_emu.stats import RunStats
+
+from ipu_as.lark_tree import assemble
+
+
+# ---------------------------------------------------------------------------
+# Helpers (mirrored from test_execute.py)
+# ---------------------------------------------------------------------------
+
+
+def _run(asm_code: str, *, cr: dict[int, int] | None = None) -> IpuState:
+    encoded = assemble(asm_code)
+    decoded = [decode_instruction_word(w) for w in encoded]
+    state = IpuState()
+    if cr:
+        for idx, val in cr.items():
+            state.regfile.set_cr(idx, val)
+    load_program(state, decoded)
+    run_until_complete(state)
+    return state
+
+
+# ---------------------------------------------------------------------------
+# RunStats unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestRunStatsProperties:
+    def test_utilization_zero_cycles(self):
+        s = RunStats()
+        assert s.mult_utilization == 0.0
+        assert s.acc_utilization == 0.0
+
+    def test_utilization_full(self):
+        s = RunStats(total_cycles=10, mult_active_cycles=10, acc_active_cycles=10)
+        assert s.mult_utilization == 1.0
+        assert s.acc_utilization == 1.0
+
+    def test_utilization_partial(self):
+        s = RunStats(total_cycles=4, mult_active_cycles=1, acc_active_cycles=2)
+        assert s.mult_utilization == 0.25
+        assert s.acc_utilization == 0.5
+
+    def test_xmem_accesses_sum(self):
+        s = RunStats(xmem_reads=3, xmem_writes=2)
+        assert s.xmem_accesses == 5
+
+    def test_format_summary_contains_key_fields(self):
+        s = RunStats(total_cycles=100, mult_active_cycles=80, acc_active_cycles=60,
+                     xmem_reads=10, xmem_writes=5)
+        text = s.format_summary()
+        assert "100" in text
+        assert "80" in text
+        assert "60" in text
+        assert "10" in text
+        assert "5" in text
+        assert "15" in text  # xmem_accesses
+
+
+# ---------------------------------------------------------------------------
+# Integration: stats are populated by run_until_complete
+# ---------------------------------------------------------------------------
+
+
+class TestStatsCountedDuringExecution:
+    def test_nop_program_has_zero_active_cycles(self):
+        # All NOPs: no mult, acc, or xmem activity
+        state = _run("BKPT;;")
+        assert state.stats.mult_active_cycles == 0
+        assert state.stats.acc_active_cycles == 0
+        assert state.stats.xmem_reads == 0
+        assert state.stats.xmem_writes == 0
+
+    def test_total_cycles_matches_instruction_count(self):
+        # BKPT halts but counts as one cycle
+        state = _run("BKPT;;")
+        assert state.stats.total_cycles == 1
+
+    def test_mult_active_counted(self):
+        # LDR_MULT_REG (1 read) + MULT.EE in one cycle, then BKPT
+        # MULT.EE syntax: ra, cyclic_offset(LR), mask_offset(imm), mask_shift(LR)
+        asm = """\
+SET lr0 cr0;;
+LDR_MULT_REG r0 lr0 cr0;MULT.EE r0 lr0 0 lr0;;
+BKPT;;
+"""
+        state = IpuState()
+        encoded = assemble(asm)
+        decoded = [decode_instruction_word(w) for w in encoded]
+        state.regfile.set_cr(0, 0)
+        state.xmem.write_address(0, bytearray(128))
+        load_program(state, decoded)
+        run_until_complete(state)
+        assert state.stats.mult_active_cycles >= 1
+
+    def test_acc_active_counted(self):
+        asm = """\
+RESET_ACC;;
+ACC;;
+BKPT;;
+"""
+        state = _run(asm)
+        assert state.stats.acc_active_cycles >= 1
+
+    def test_reset_acc_is_active(self):
+        state = _run("RESET_ACC;;BKPT;;")
+        assert state.stats.acc_active_cycles >= 1
+
+    def test_xmem_read_counted(self):
+        # LDR_MULT_REG reads from xmem
+        asm = """\
+SET lr0 cr0;;
+LDR_MULT_REG r0 lr0 cr1;;
+BKPT;;
+"""
+        state = IpuState()
+        encoded = assemble(asm)
+        decoded = [decode_instruction_word(w) for w in encoded]
+        state.regfile.set_cr(0, 0)
+        state.regfile.set_cr(1, 0x1000)
+        state.xmem.write_address(0x1000, bytearray(128))
+        load_program(state, decoded)
+        run_until_complete(state)
+        assert state.stats.xmem_reads == 1
+        assert state.stats.xmem_writes == 0
+
+    def test_xmem_write_counted(self):
+        # STR_ACC_REG writes to xmem
+        asm = """\
+RESET_ACC;;
+STR_ACC_REG lr0 cr1;;
+BKPT;;
+"""
+        state = IpuState()
+        encoded = assemble(asm)
+        decoded = [decode_instruction_word(w) for w in encoded]
+        state.regfile.set_lr(0, 0)
+        state.regfile.set_cr(1, 0x1000)
+        import warnings
+        load_program(state, decoded)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            run_until_complete(state)
+        assert state.stats.xmem_writes == 1
+        assert state.stats.xmem_reads == 0
+
+    def test_multiple_cycles_accumulate(self):
+        # 3 independent RESET_ACC cycles, then BKPT
+        asm = """\
+RESET_ACC;;
+RESET_ACC;;
+RESET_ACC;;
+BKPT;;
+"""
+        state = _run(asm)
+        assert state.stats.total_cycles == 4
+        assert state.stats.acc_active_cycles == 3
+
+    def test_nop_slots_not_counted(self):
+        # Three pure-LR instructions: no mult/acc/xmem
+        asm = """\
+SET lr0 cr0;;
+ADD lr1 lr0 1;;
+ADD lr2 lr1 1;;
+BKPT;;
+"""
+        state = _run(asm)
+        assert state.stats.mult_active_cycles == 0
+        assert state.stats.acc_active_cycles == 0
+        assert state.stats.xmem_reads == 0
+        assert state.stats.xmem_writes == 0


### PR DESCRIPTION
## Summary
Implement per-run execution statistics tracking in the IPU emulator to measure performance characteristics including multiplier/accumulator stage utilization and external memory access counts.

## Key Changes

- **New `RunStats` class** (`src/ipu_emu/stats.py`):
  - Dataclass tracking `total_cycles`, `mult_active_cycles`, `acc_active_cycles`, `xmem_reads`, and `xmem_writes`
  - Computed properties for `mult_utilization`, `acc_utilization`, and `xmem_accesses`
  - `format_summary()` method for human-readable output

- **Integration with `IpuState`** (`src/ipu_emu/ipu_state.py`):
  - Added `stats: RunStats` field to hold per-run statistics

- **Statistics collection during execution** (`src/ipu_emu/ipu.py`):
  - Updated `dispatch_instruction()` to increment counters:
    - `mult_active_cycles` for non-NOP mult slot instructions
    - `acc_active_cycles` for non-NOP acc slot instructions
    - `xmem_reads` for load instructions (`LDR_MULT_REG`, `LDR_CYCLIC_MULT_REG`, `LDR_MULT_MASK_REG`)
    - `xmem_writes` for store instructions (`STR_ACC_REG`, `XMEM.STORE_AAQ_RESULT`)

- **Cycle counting** (`src/ipu_emu/emulator.py`):
  - `run_until_complete()` now sets `state.stats.total_cycles` at completion

- **Comprehensive test suite** (`test/test_stats.py`):
  - Unit tests for utilization calculations and property aggregation
  - Integration tests verifying stats are correctly populated during execution
  - Tests for mult/acc/xmem activity detection across various instruction patterns

- **Updated application output** (`ipu_apps/fully_connected/__main__.py`):
  - Changed from simple cycle count to formatted statistics summary via `state.stats.format_summary()`

- **Build configuration** (`BUILD.bazel`):
  - Added `test_stats` pytest target

## Implementation Details

Statistics are collected at instruction dispatch time by examining the instruction slot type and name. NOP variants are explicitly excluded from active cycle counts. The design allows utilization metrics to be computed as ratios of active cycles to total cycles, providing insight into pipeline efficiency.

https://claude.ai/code/session_01NKffQFgwj1sdPqACCMwpWb