### PR TITLE
feat(mult): add MULT.EE.RR multi-element execution (issue #86)

### DIFF
--- a/src/tools/ipu-common/src/ipu_common/instruction_spec.py
+++ b/src/tools/ipu-common/src/ipu_common/instruction_spec.py
@@ -356,7 +356,7 @@ INSTRUCTION_SPEC = {
     # =========================================================================
     # MULT Slot (Multiply Instructions)
     # Opcode = position: MULT.EE=0, MULT.VE.CYCLIC=1, MULT.VE.PADDED=2, MULT_NOP=3,
-    #          MULT.VE.CR=4, MULT.VE.AAQ=5
+    #          MULT.VE.CR=4, MULT.VE.AAQ=5, MULT.EE.RR=6
     # =========================================================================
     "mult": {
         "MULT.EE": {
@@ -485,6 +485,30 @@ INSTRUCTION_SPEC = {
                 example="MULT.VE.AAQ LR0, 0, LR15, AAQ1;;",
             ),
             "execute_fn": "execute_mult_ve_aaq",
+        },
+        "MULT.EE.RR": {
+            "operands": [
+                {"name": "ra", "type": "MultStageReg", "read": "live"},
+                {"name": "mask_offset", "type": "MultMaskOffsetImmediate"},
+                {"name": "mask_shift", "type": "LrIdx", "read": "live"},
+            ],
+            "doc": InstructionDoc(
+                title="Multi-Element Multiply (register by register)",
+                summary=(
+                    "Multi-element execution (MEE): multiply a mult-stage register "
+                    "element by element against itself. `ra` selects the execution "
+                    "mode — **`R0`** gives r0-by-r0, **`R1`** gives r1-by-r1."
+                ),
+                syntax="MULT.EE.RR ra, mask_offset, mask_shift",
+                operands=[
+                    "`ra`: **`R0`** | **`R1`** — selects the MEE mode; the chosen register is both multiplicand and multiplier (same cycle as `LDR_MULT_REG` into **`R0`**/**`R1`** is allowed).",
+                    "`mask_offset`: immediate mask slot **`0`**…**`7`** — selects one of eight 128-bit masks in **`r_mask`**.",
+                    "`mask_shift`: **`LR0`**…**`LR15`** — shift applied to the mask register.",
+                ],
+                operation="For each lane i: mult_res[i] = ipu_mult(ra[i], ra[i]); then apply mask and shift.",
+                example="MULT.EE.RR R0, 0, LR2;;",
+            ),
+            "execute_fn": "execute_mult_ee_rr",
         },
     },
 

--- a/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
@@ -569,6 +569,39 @@ class Ipu:
 
         self._mult_mask_and_shift(mask_offset, mask_shift)
 
+    def execute_mult_ee_rr(self, *, ra: bytearray | int,
+                           mask_offset: int, mask_shift: int) -> None:
+        """Execute MULT.EE.RR: multi-element multiply of a mult-stage register by itself.
+
+        ``ra`` selects the MEE mode: R0 → r0-by-r0, R1 → r1-by-r1. Each lane is
+        multiplied by itself (element-wise square), then masked and shifted.
+        """
+        mult_res = self.state.regfile.raw("mult_res")
+
+        if self._wide_vector_active():
+            ra_vals = self._debug_ra_lane_vals(ra)
+            if self.state.wide_vector_arithmetic == WideVectorArithmetic.FP32:
+                for i in range(R_REG_SIZE):
+                    struct.pack_into(
+                        "<f", mult_res, i * 4, float(ra_vals[i]) * float(ra_vals[i])
+                    )
+            else:
+                for i in range(R_REG_SIZE):
+                    struct.pack_into(
+                        "<i", mult_res, i * 4,
+                        self._wide_imult32(int(ra_vals[i]), int(ra_vals[i])),
+                    )
+            self._mult_mask_and_shift(mask_offset, mask_shift)
+            return
+
+        dtype = self.state.get_cr_dtype()
+
+        for i in range(R_REG_SIZE):
+            result = ipu_mult(ra[i], ra[i], dtype)
+            struct.pack_into("<i" if dtype == DType.INT8 else "<f", mult_res, i * 4, result)
+
+        self._mult_mask_and_shift(mask_offset, mask_shift)
+
     def _execute_mult_ve_variant(
         self,
         *,

--- a/src/tools/ipu-emu-py/test/test_execute.py
+++ b/src/tools/ipu-emu-py/test/test_execute.py
@@ -1660,6 +1660,93 @@ BKPT;;
             val = struct.unpack_from("<i", acc_raw, i * 4)[0]
             assert val == 28, f"acc word {i}: expected 28 (r1[0]=7 × cyclic[i]=4), got {val}"
 
+
+class TestMultEeRr:
+    """MULT.EE.RR — multi-element execution (MEE): r0-by-r0 or r1-by-r1."""
+
+    def test_mult_ee_rr_r0_by_r0(self):
+        """MEE mode R0: each lane multiplied by itself (4 × 4 = 16)."""
+        r0_data = bytes([4] * 128)
+
+        state = _make_state("""\
+SET lr0 cr8;;
+LDR_MULT_REG r0 lr0 cr0;;
+RESET_ACC;;
+SET lr5 cr9;;
+MULT.EE.RR r0 0 lr5;
+ACC;;
+BKPT;;
+""",
+            cr={8: 4096, 9: 0})
+        state.regfile.set_cr(15, DType.INT8)
+        state.xmem.write_address(0x1000, r0_data)
+        run_until_complete(state)
+
+        acc_raw = state.regfile.raw("r_acc")
+        for i in range(128):
+            val = struct.unpack_from("<i", acc_raw, i * 4)[0]
+            assert val == 16, f"acc word {i}: expected 16 (4×4), got {val}"
+
+    def test_mult_ee_rr_r1_by_r1(self):
+        """MEE mode R1 squares r1 (3 × 3 = 9); r0 holds a decoy value."""
+        r0_data = bytes([9] * 128)   # decoy — must be ignored when ra=R1
+        r1_data = bytes([3] * 128)
+
+        state = _make_state("""\
+SET lr0 cr8;;
+LDR_MULT_REG r0 lr0 cr0;;
+SET lr1 cr9;;
+LDR_MULT_REG r1 lr1 cr0;;
+RESET_ACC;;
+SET lr5 cr10;;
+MULT.EE.RR r1 0 lr5;
+ACC;;
+BKPT;;
+""",
+            cr={8: 4096, 9: 4352, 10: 0})
+        state.regfile.set_cr(15, DType.INT8)
+        state.xmem.write_address(0x1000, r0_data)
+        state.xmem.write_address(0x1100, r1_data)
+        run_until_complete(state)
+
+        acc_raw = state.regfile.raw("r_acc")
+        for i in range(128):
+            val = struct.unpack_from("<i", acc_raw, i * 4)[0]
+            assert val == 9, f"acc word {i}: expected 9 (r1 3×3, not r0), got {val}"
+
+    def test_mult_ee_rr_mask_zeroes_lanes(self):
+        """mask_offset/mask_shift still gate lanes (first 64 masked → 0)."""
+        r0_data = bytes([3] * 128)   # squared → 9
+        mask_data = bytearray(128)
+        for i in range(8):           # 64 bits set → first 64 lanes masked
+            mask_data[i] = 0xFF
+
+        state = _make_state("""\
+SET lr0 cr8;;
+LDR_MULT_REG r0 lr0 cr0;;
+SET lr3 cr9;;
+LDR_MULT_MASK_REG lr3 cr0;;
+RESET_ACC;;
+SET lr5 cr10;;
+MULT.EE.RR r0 0 lr5;
+ACC;;
+BKPT;;
+""",
+            cr={8: 4096, 9: 8192, 10: 0})
+        state.regfile.set_cr(15, DType.INT8)
+        state.xmem.write_address(0x1000, r0_data)
+        state.xmem.write_address(0x2000, bytes(mask_data))
+        run_until_complete(state)
+
+        acc_raw = state.regfile.raw("r_acc")
+        for i in range(64):
+            val = struct.unpack_from("<i", acc_raw, i * 4)[0]
+            assert val == 0, f"word {i} should be masked to 0, got {val}"
+        for i in range(64, 128):
+            val = struct.unpack_from("<i", acc_raw, i * 4)[0]
+            assert val == 9, f"word {i}: expected 9 (3×3), got {val}"
+
+
 # ============================================================================
 # AAQ Quantization (aaq instruction + xmem.store_aaq_result)
 # ============================================================================


### PR DESCRIPTION
Adds a new MULT-slot instruction enabling multi-element execution (MEE): element-by-element multiply of a mult-stage register by itself. The `ra` operand selects the mode — R0 gives r0-by-r0, R1 gives r1-by-r1 — satisfying the "interface to choose execution mode" requirement of issue #86.

- instruction_spec.py: MULT.EE.RR appended to the mult slot (opcode 6; existing opcodes 0-5 unchanged). Reuses existing mult-slot operand field types, so assembler/emulator field mapping works with no encoding changes.
- ipu.py: execute_mult_ee_rr handler mirroring execute_mult_ee (incl. wide-vector debug path and mask/shift) but squaring ra.
- test_execute.py: TestMultEeRr — r0-by-r0, r1-by-r1 (with an r0 decoy proving mode selection), and mask/shift gating.

Closes #86