### PR TITLE
Add reciprocal and rsqrt activation functions; update related specs a…

### DIFF
--- a/docs/content/specs/stage-aaq.md
+++ b/docs/content/specs/stage-aaq.md
@@ -151,6 +151,8 @@ Supported activation functions:
 | 6 | `softplus` | `f(x) = ln(1 + e^x)` | Smooth approximation of ReLU. |
 | 7 | `elu` | `f(x) = x if x ≥ 0 else α·(e^x − 1)` | Smooth negative region; reduces vanishing gradient. |
 | 8 | `exp2` | `f(x) = 2^x` | Used for dequantization, softmax and attention scaling. |
+| 9 | `reciprocal` | `f(x) = 1/x` (0 if x = 0) | Multiplicative inverse; useful for normalization. |
+| 10 | `rsqrt` | `f(x) = 1/√x` (0 if x ≤ 0) | Reciprocal square root; used in layer normalization. |
 
 ### 7.1 Aggregate (`agg`)
 

--- a/src/tools/ipu-common/src/ipu_common/activations.py
+++ b/src/tools/ipu-common/src/ipu_common/activations.py
@@ -5,7 +5,7 @@ Encodings match ``docs/content/specs/stage-aaq.md`` section 7.0. α for
 :class:`ipu_emu.ipu_state.IpuState` constructor or
 :meth:`IpuState.set_activation_alphas` (not CR-visible). Assembly uses
 ``ACTIVATE … <name>`` where ``<name>`` is one of the strings in
-``ACTIVATION_FN_NAMES`` (same order as ids **0**–**8**); the emulator writes
+``ACTIVATION_FN_NAMES`` (same order as ids **0**–**10**); the emulator writes
 activated lanes into ``POST_AAQ_REG``. See
 ``docs/content/building-applications.md#activations-emulator`` for calibration,
 ``STR_POST_AAQ_REG`` (store that register to XMEM), and pipeline notes.
@@ -24,8 +24,10 @@ ACTIVATION_GELU = 5
 ACTIVATION_SOFTPLUS = 6
 ACTIVATION_ELU = 7
 ACTIVATION_EXP2 = 8
+ACTIVATION_RECIPROCAL = 9
+ACTIVATION_RSQRT = 10
 
-ACTIVATION_COUNT = 9
+ACTIVATION_COUNT = 11
 
 # Assembly / encoding order (id = index); must match ACTIVATION_* constants above.
 ACTIVATION_FN_NAMES: tuple[str, ...] = (
@@ -38,6 +40,8 @@ ACTIVATION_FN_NAMES: tuple[str, ...] = (
     "softplus",
     "elu",
     "exp2",
+    "reciprocal",
+    "rsqrt",
 )
 
 # Default α value — virtual configuration outside the ISA (issue #77).
@@ -75,7 +79,7 @@ def apply_activation(
     *,
     elu_alpha: float | None = None,
 ) -> float:
-    """Apply activation ``fn_id`` (0–8) to scalar ``x``. Unknown ids → identity.
+    """Apply activation ``fn_id`` (0–10) to scalar ``x``. Unknown ids → identity.
 
     If ``elu_alpha`` is omitted, the value comes from the module
     ``DEFAULT_ELU_ALPHA`` constant (snapshotted onto
@@ -106,4 +110,8 @@ def apply_activation(
         return x if x >= 0.0 else ea * (math.exp(x) - 1.0)
     if k == ACTIVATION_EXP2:
         return math.exp(x * math.log(2.0))
+    if k == ACTIVATION_RECIPROCAL:
+        return 1.0 / x if x != 0.0 else 0.0
+    if k == ACTIVATION_RSQRT:
+        return 1.0 / math.sqrt(x) if x > 0.0 else 0.0
     return x

--- a/src/tools/ipu-common/src/ipu_common/instruction_spec.py
+++ b/src/tools/ipu-common/src/ipu_common/instruction_spec.py
@@ -792,21 +792,21 @@ INSTRUCTION_SPEC = {
                     "of ``POST_AAQ_REG`` (``r_acc`` is unchanged). The activation is "
                     "selected by keyword (see ACTIVATION_FN_NAMES). Behaviour matches the activation "
                     "table in the AAQ stage spec (section 7.0). The selector uses four bits; "
-                    "encodings outside the nine named activations behave as identity. The available "
+                    "encodings outside the eleven named activations behave as identity. The available "
                     "activation functions are: ``identity`` (0), ``relu`` (1), ``relu6`` (2), "
                     "``sigmoid`` (3), ``tanh`` (4), ``gelu`` (5), ``softplus`` (6), ``elu`` (7), "
-                    "``exp2`` (8). For Python emulator calibration (virtual α), see "
+                    "``exp2`` (8), ``reciprocal`` (9), ``rsqrt`` (10). For Python emulator calibration (virtual α), see "
                     "docs/content/building-applications.md#activations-emulator."
                 ),
                 syntax="ACTIVATE valid_elements activation_fn",
                 operands=[
                     "valid_elements: lane count from an LR or CR register (unsigned, clamped to 0–128)",
-                    "activation_fn: keyword naming the activation (one of identity, relu, relu6, sigmoid, tanh, gelu, softplus, elu, exp2; see ACTIVATION_FN_NAMES)",
+                    "activation_fn: keyword naming the activation (one of identity, relu, relu6, sigmoid, tanh, gelu, softplus, elu, exp2, reciprocal, rsqrt; see ACTIVATION_FN_NAMES)",
                 ],
                 operation=(
                     "Let n = min(valid_elements, 128) and k = encoded activation index. "
                     "For i in [0, n): POST_AAQ_REG[i] = activation_k(R_ACC[i]) (same 32-bit lane format as R_ACC). "
-                    "R_ACC is not modified. The selector uses four bits; encodings outside the nine named "
+                    "R_ACC is not modified. The selector uses four bits; encodings outside the eleven named "
                     "activations behave as identity. "
                     "α for elu is not an ISA operand; see "
                     "docs/content/building-applications.md#activations-emulator."

--- a/src/tools/ipu-emu-py/test/test_execute.py
+++ b/src/tools/ipu-emu-py/test/test_execute.py
@@ -2125,3 +2125,69 @@ BKPT;;
         assert state.regfile.get_r_acc_word(1) == tail
         assert _post_aaq_lane_i32(state, 0) == 0
         assert _post_aaq_lane_i32(state, 1) == 0
+
+    def test_activate_reciprocal_float(self):
+        state = _make_state(
+            """\
+ACTIVATE lr0 reciprocal;;
+BKPT;;
+"""
+        )
+        state.regfile.set_cr(15, DType.E4)
+        state.regfile.set_lr(0, 1)
+        x = 4.0
+        state.regfile.set_r_acc_word(
+            0, struct.unpack("<I", struct.pack("<f", x))[0]
+        )
+        run_until_complete(state)
+        out = _post_aaq_lane_f32(state, 0)
+        assert abs(out - 0.25) < 1e-6
+
+    def test_activate_reciprocal_zero_input(self):
+        state = _make_state(
+            """\
+ACTIVATE lr0 reciprocal;;
+BKPT;;
+"""
+        )
+        state.regfile.set_cr(15, DType.E4)
+        state.regfile.set_lr(0, 1)
+        state.regfile.set_r_acc_word(
+            0, struct.unpack("<I", struct.pack("<f", 0.0))[0]
+        )
+        run_until_complete(state)
+        out = _post_aaq_lane_f32(state, 0)
+        assert out == 0.0
+
+    def test_activate_rsqrt_float(self):
+        state = _make_state(
+            """\
+ACTIVATE lr0 rsqrt;;
+BKPT;;
+"""
+        )
+        state.regfile.set_cr(15, DType.E4)
+        state.regfile.set_lr(0, 1)
+        x = 4.0
+        state.regfile.set_r_acc_word(
+            0, struct.unpack("<I", struct.pack("<f", x))[0]
+        )
+        run_until_complete(state)
+        out = _post_aaq_lane_f32(state, 0)
+        assert abs(out - 0.5) < 1e-6
+
+    def test_activate_rsqrt_nonpositive_input(self):
+        state = _make_state(
+            """\
+ACTIVATE lr0 rsqrt;;
+BKPT;;
+"""
+        )
+        state.regfile.set_cr(15, DType.E4)
+        state.regfile.set_lr(0, 1)
+        state.regfile.set_r_acc_word(
+            0, struct.unpack("<I", struct.pack("<f", 0.0))[0]
+        )
+        run_until_complete(state)
+        out = _post_aaq_lane_f32(state, 0)
+        assert out == 0.0


### PR DESCRIPTION
Summary:

Added two new element-wise activation functions to the ACTIVATE instruction:
reciprocal (encoding 9): f(x) = 1/x, returns 0 for x = 0
rsqrt (encoding 10): f(x) = 1/√x, returns 0 for x ≤ 0
Files changed:

activations.py — new constants, updated ACTIVATION_FN_NAMES tuple and apply_activation() math
instruction_spec.py — updated description and operand docs to list the new functions
stage-aaq.md — added encodings 9 and 10 to the activation function table (§7.0)
test_execute.py — 4 new tests covering normal inputs and edge cases (x=0 / x≤0) for both functions
Test plan:

bazel test //... — all 250 tests pass
