### PR TITLE
Add FullXmemRow support to instruction set and documentation

### DIFF
--- a/docs/content/assembly-syntax.md
+++ b/docs/content/assembly-syntax.md
@@ -1,0 +1,107 @@
+# Assembly Language Syntax
+
+The IPU assembler is a Python-based tool that turns assembly source into binary VLIW instructions for the emulator. Instruction names, operands, and encoding are driven by `instruction_spec.py` in `ipu_common`; the [Instruction reference](instructions.md) and [Operand types](operand-types.md) are generated from that same toolchain.
+
+## Features
+
+- **Jinja2 preprocessing** — templates and macros for generated assembly
+- **Label resolution** — forward and backward references
+- **VLIW compounds** — multiple pipeline slots per cycle (`XMEM`, `MULT`, `ACC`, `AAQ`, `LR`×3, `COND`, `BREAK`)
+- **Syntax validation** — Lark-based parser with detailed errors
+
+## Basic Syntax
+
+Assembly is line-oriented. One **compound instruction** may contain several **slot** instructions separated by `;`, terminated by `;;`.
+
+```asm
+# Comments start with # or //
+label:                          # Labels end with a colon
+    LDR_MULT_REG r0 lr0 cr0;     # XMEM: load into mult stage r0
+    MULT.EE r0 lr1 0 lr3;        # MULT: element-wise multiply
+    ACC;                         # ACC: accumulate
+    ADD lr0 lr0 1;               # LR: bump address (increment via ADD)
+    BNE lr0 lr1 next;            # COND: branch
+    ;;
+```
+
+By convention, **instruction mnemonics are written in upper case** in documentation and examples (e.g. `MULT.EE`, `LDR_MULT_REG`). **Operand tokens** use **lower case** (`lr0`, `r0`, `cr0`). The assembler accepts **any case** for mnemonics and register tokens.
+
+## Compound instructions
+
+A full IPU instruction is one **compound** word: several slots execute in parallel in a single cycle.
+
+**Pattern:**
+
+```asm
+xmem_inst; mult_inst; acc_inst; aaq_inst; lr_inst_a; lr_inst_b; lr_inst_c; cond_inst; break_inst;;
+```
+
+**Rules:**
+
+- Each slot appears a fixed number of times (see `SLOT_COUNT` in `instruction_spec.py`); unused slots are filled with that slot’s **NOP** by the assembler.
+- Slot order in the binary word is defined by the toolchain (`break`, `xmem`, `mult`, `acc`, `aaq`, then three `lr` sub-slots, then `cond`).
+- The emulator runs **BREAK** first (may halt), then resolves **LR** sub-instructions, then **XMEM**, **MULT**, **ACC**, **AAQ**, **COND** in one cycle (see `execute_vliw_cycle` in `ipu.py`).
+
+**Example (parallel slots):**
+
+```asm
+LDR_MULT_REG r0 lr0 cr0; MULT.EE r0 lr1 0 lr3; ACC; ADD lr0 lr0 1; BNE lr0 lr1 loop;;
+```
+
+## Register names
+
+The mult-stage and scalar register **tokens** below are derived from `REGISTER_DEFINITIONS` in `ipu_common.registers` (same source as the assembler).
+
+| Kind | Assembler tokens | Notes |
+|------|------------------|--------|
+| Mult stage | `r0`, `r1` | 128-byte vectors; 2-bit mult-stage field (`2` reserved). See [MultStageReg](operand-types.md#multstagereg). |
+| Cyclic / mask | *(architectural)* | Cyclic (**RC**) and mask (**RM**) register files are documented per instruction in the reference; operands pass **byte offsets** via `LR` values. |
+| Loop / scalar | `lr0`–`lr15` | General-purpose; **read/write**. See [LrIdx](operand-types.md#lridx). |
+| Constant | `cr0`–`cr15` | **Read-only** in assembly; initialized by the harness. **`cr0`** / **`cr1`** are often 0 and 1. See [CrIdx](operand-types.md#cridx). |
+| AAQ | `aaq0`, `aaq1`, `aaq2`, `aaq3` | Activation / quantization registers. See [AaqRegIdx](operand-types.md#aaqregidx). |
+
+The **`mem_bypass`** vector may still exist in the **emulator regfile** for debugging, but it is **not** a valid mult-stage assembly operand.
+
+**LR slot:** **`SET`** copies from a **`cr`** register (see [CrIdx](operand-types.md#cridx)); **`ADD`**/**`SUB`** accept a small unsigned immediate on **`src_b`** only; **`INCR_MOD_POW2`** uses a dedicated **k** immediate (see [LrModPow2KImmediate](operand-types.md#lrmodpow2kimmediate)).
+
+## Labels and branches
+
+```asm
+start:
+    SET lr0 cr0;;
+loop:
+    ADD lr0 lr0 1;;
+    BNE lr0 lr1 loop;;
+    BKPT;;
+```
+
+Relative labels such as `B +5` / `B -2` are supported where the grammar accepts a **label** token (see cond-slot instructions in the reference).
+
+## Jinja2 preprocessing
+
+The assembler runs Jinja2 on the source when `{{`, `{%`, and `{#` appear.
+
+```jinja2
+{% set off_reg = 6 %}
+SET lr0 cr{{ off_reg }};;
+LDR_MULT_REG r0 lr0 cr0;;
+```
+
+The harness must initialize **`cr6`** (here: the memory offset) before this program runs.
+
+## Running the assembler
+
+**Command line (Bazel):**
+
+```bash
+bazel run //src/tools/ipu-as-py:ipu-as -- assemble --input prog.asm --output prog.bin
+```
+
+**In Bazel build rules:** use the project’s `ipu_asm` rule (see [Building Applications](building-applications.md)).
+
+## Further reading
+
+- [Operand types](operand-types.md) — field types used in `instruction_spec`
+- [Instruction reference](instructions.md) — per-opcode documentation
+- [Adding instructions](adding-instruction.md)
+- [Building applications](building-applications.md)

--- a/docs/content/instructions.md
+++ b/docs/content/instructions.md
@@ -1,0 +1,1257 @@
+# IPU Assembly Instruction Reference
+
+Per-opcode documentation is generated from `InstructionDoc` entries in `instruction_spec.py`. Operand **types** link to the shared [operand type reference](operand-types.md).
+
+## Compound Instruction Layout
+
+<svg width="888" height="641" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <style>
+      .inst-title { font-size: 14px; font-weight: bold; font-family: Arial; }
+      .inst-label { font-size: 8px; font-weight: bold; font-family: Arial; }
+      .field-label { font-size: 7px; font-family: Arial; }
+      .bit-range { font-size: 8px; font-family: Arial; }
+    </style>
+  </defs>
+  <rect x="0" y="0" width="888" height="641" fill="white" stroke="none"/>
+  <text x="444.0" y="34" text-anchor="middle" class="inst-title">CompoundInst Layout - 156 total bits</text>
+  <rect x="80" y="55.0" width="768" height="80" fill="white" stroke="black" stroke-width="2"/>
+  <text x="50" y="99.0" text-anchor="end" class="bit-range">[155:128]</text>
+  <text x="188.0" y="67.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">155</text>
+  <text x="212.0" y="67.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">154</text>
+  <text x="236.0" y="67.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">153</text>
+  <text x="260.0" y="67.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">152</text>
+  <text x="284.0" y="67.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">151</text>
+  <text x="308.0" y="67.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">150</text>
+  <text x="332.0" y="67.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">149</text>
+  <text x="356.0" y="67.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">148</text>
+  <text x="380.0" y="67.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">147</text>
+  <text x="404.0" y="67.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">146</text>
+  <text x="428.0" y="67.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">145</text>
+  <text x="452.0" y="67.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">144</text>
+  <text x="476.0" y="67.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">143</text>
+  <text x="500.0" y="67.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">142</text>
+  <text x="524.0" y="67.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">141</text>
+  <text x="548.0" y="67.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">140</text>
+  <text x="572.0" y="67.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">139</text>
+  <text x="596.0" y="67.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">138</text>
+  <text x="620.0" y="67.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">137</text>
+  <text x="644.0" y="67.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">136</text>
+  <text x="668.0" y="67.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">135</text>
+  <text x="692.0" y="67.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">134</text>
+  <text x="716.0" y="67.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">133</text>
+  <text x="740.0" y="67.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">132</text>
+  <text x="764.0" y="67.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">131</text>
+  <text x="788.0" y="67.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">130</text>
+  <text x="812.0" y="67.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">129</text>
+  <text x="836.0" y="67.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">128</text>
+  <rect x="776" y="55.0" width="72" height="80" fill="#FF6B6B" stroke="black" stroke-width="1" opacity="0.85"/>
+  <text x="812.0" y="84.0" text-anchor="middle" class="field-label">cr</text>
+  <text x="812.0" y="95.0" text-anchor="middle" class="field-label">reg</text>
+  <text x="812.0" y="109.0" text-anchor="middle" class="field-label" style="font-weight: bold;">[130:127]</text>
+  <rect x="704" y="55.0" width="72" height="80" fill="#FF6B6B" stroke="black" stroke-width="1" opacity="0.85"/>
+  <text x="740.0" y="78.5" text-anchor="middle" class="field-label">xmem</text>
+  <text x="740.0" y="89.5" text-anchor="middle" class="field-label">inst</text>
+  <text x="740.0" y="100.5" text-anchor="middle" class="field-label">opcode</text>
+  <text x="740.0" y="114.5" text-anchor="middle" class="field-label" style="font-weight: bold;">[133:131]</text>
+  <rect x="608" y="55.0" width="96" height="80" fill="#FFD93D" stroke="black" stroke-width="1" opacity="0.85"/>
+  <text x="656.0" y="84.0" text-anchor="middle" class="field-label">lr</text>
+  <text x="656.0" y="95.0" text-anchor="middle" class="field-label">reg</text>
+  <text x="656.0" y="109.0" text-anchor="middle" class="field-label" style="font-weight: bold;">[137:134]</text>
+  <rect x="224" y="55.0" width="384" height="80" fill="#FFD93D" stroke="black" stroke-width="1" opacity="0.85"/>
+  <text x="416.0" y="84.0" text-anchor="middle" class="field-label">break</text>
+  <text x="416.0" y="95.0" text-anchor="middle" class="field-label">immediate</text>
+  <text x="416.0" y="109.0" text-anchor="middle" class="field-label" style="font-weight: bold;">[153:138]</text>
+  <rect x="176" y="55.0" width="48" height="80" fill="#FFD93D" stroke="black" stroke-width="1" opacity="0.85"/>
+  <text x="200.0" y="78.5" text-anchor="middle" class="field-label">break</text>
+  <text x="200.0" y="89.5" text-anchor="middle" class="field-label">inst</text>
+  <text x="200.0" y="100.5" text-anchor="middle" class="field-label">opcode</text>
+  <text x="200.0" y="114.5" text-anchor="middle" class="field-label" style="font-weight: bold;">[155:154]</text>
+  <rect x="80" y="135.0" width="768" height="80" fill="white" stroke="black" stroke-width="2"/>
+  <text x="50" y="179.0" text-anchor="end" class="bit-range">[127:96]</text>
+  <text x="92.0" y="147.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">127</text>
+  <text x="116.0" y="147.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">126</text>
+  <text x="140.0" y="147.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">125</text>
+  <text x="164.0" y="147.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">124</text>
+  <text x="188.0" y="147.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">123</text>
+  <text x="212.0" y="147.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">122</text>
+  <text x="236.0" y="147.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">121</text>
+  <text x="260.0" y="147.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">120</text>
+  <text x="284.0" y="147.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">119</text>
+  <text x="308.0" y="147.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">118</text>
+  <text x="332.0" y="147.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">117</text>
+  <text x="356.0" y="147.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">116</text>
+  <text x="380.0" y="147.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">115</text>
+  <text x="404.0" y="147.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">114</text>
+  <text x="428.0" y="147.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">113</text>
+  <text x="452.0" y="147.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">112</text>
+  <text x="476.0" y="147.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">111</text>
+  <text x="500.0" y="147.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">110</text>
+  <text x="524.0" y="147.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">109</text>
+  <text x="548.0" y="147.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">108</text>
+  <text x="572.0" y="147.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">107</text>
+  <text x="596.0" y="147.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">106</text>
+  <text x="620.0" y="147.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">105</text>
+  <text x="644.0" y="147.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">104</text>
+  <text x="668.0" y="147.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">103</text>
+  <text x="692.0" y="147.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">102</text>
+  <text x="716.0" y="147.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">101</text>
+  <text x="740.0" y="147.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">100</text>
+  <text x="764.0" y="147.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">99</text>
+  <text x="788.0" y="147.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">98</text>
+  <text x="812.0" y="147.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">97</text>
+  <text x="836.0" y="147.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">96</text>
+  <rect x="824" y="135.0" width="24" height="80" fill="#45B7D1" stroke="black" stroke-width="1" opacity="0.85"/>
+  <text x="836.0" y="164.0" text-anchor="middle" class="field-label">aaq</text>
+  <text x="836.0" y="175.0" text-anchor="middle" class="field-label">reg</text>
+  <text x="836.0" y="189.0" text-anchor="middle" class="field-label" style="font-weight: bold;">[96:95]</text>
+  <rect x="728" y="135.0" width="96" height="80" fill="#45B7D1" stroke="black" stroke-width="1" opacity="0.85"/>
+  <text x="776.0" y="158.5" text-anchor="middle" class="field-label">acc</text>
+  <text x="776.0" y="169.5" text-anchor="middle" class="field-label">inst</text>
+  <text x="776.0" y="180.5" text-anchor="middle" class="field-label">opcode</text>
+  <text x="776.0" y="194.5" text-anchor="middle" class="field-label" style="font-weight: bold;">[100:97]</text>
+  <rect x="656" y="135.0" width="72" height="80" fill="#4ECDC4" stroke="black" stroke-width="1" opacity="0.85"/>
+  <text x="692.0" y="153.0" text-anchor="middle" class="field-label">mult</text>
+  <text x="692.0" y="164.0" text-anchor="middle" class="field-label">mask</text>
+  <text x="692.0" y="175.0" text-anchor="middle" class="field-label">offset</text>
+  <text x="692.0" y="186.0" text-anchor="middle" class="field-label">immediate</text>
+  <text x="692.0" y="200.0" text-anchor="middle" class="field-label" style="font-weight: bold;">[103:101]</text>
+  <rect x="560" y="135.0" width="96" height="80" fill="#4ECDC4" stroke="black" stroke-width="1" opacity="0.85"/>
+  <text x="608.0" y="164.0" text-anchor="middle" class="field-label">lr</text>
+  <text x="608.0" y="175.0" text-anchor="middle" class="field-label">reg</text>
+  <text x="608.0" y="189.0" text-anchor="middle" class="field-label" style="font-weight: bold;">[107:104]</text>
+  <rect x="464" y="135.0" width="96" height="80" fill="#4ECDC4" stroke="black" stroke-width="1" opacity="0.85"/>
+  <text x="512.0" y="164.0" text-anchor="middle" class="field-label">lr</text>
+  <text x="512.0" y="175.0" text-anchor="middle" class="field-label">reg</text>
+  <text x="512.0" y="189.0" text-anchor="middle" class="field-label" style="font-weight: bold;">[111:108]</text>
+  <rect x="368" y="135.0" width="96" height="80" fill="#4ECDC4" stroke="black" stroke-width="1" opacity="0.85"/>
+  <text x="416.0" y="164.0" text-anchor="middle" class="field-label">cr</text>
+  <text x="416.0" y="175.0" text-anchor="middle" class="field-label">reg</text>
+  <text x="416.0" y="189.0" text-anchor="middle" class="field-label" style="font-weight: bold;">[115:112]</text>
+  <rect x="296" y="135.0" width="72" height="80" fill="#4ECDC4" stroke="black" stroke-width="1" opacity="0.85"/>
+  <text x="332.0" y="158.5" text-anchor="middle" class="field-label">mult</text>
+  <text x="332.0" y="169.5" text-anchor="middle" class="field-label">inst</text>
+  <text x="332.0" y="180.5" text-anchor="middle" class="field-label">opcode</text>
+  <text x="332.0" y="194.5" text-anchor="middle" class="field-label" style="font-weight: bold;">[118:116]</text>
+  <rect x="200" y="135.0" width="96" height="80" fill="#FF6B6B" stroke="black" stroke-width="1" opacity="0.85"/>
+  <text x="248.0" y="164.0" text-anchor="middle" class="field-label">lr</text>
+  <text x="248.0" y="175.0" text-anchor="middle" class="field-label">reg</text>
+  <text x="248.0" y="189.0" text-anchor="middle" class="field-label" style="font-weight: bold;">[122:119]</text>
+  <rect x="104" y="135.0" width="96" height="80" fill="#FF6B6B" stroke="black" stroke-width="1" opacity="0.85"/>
+  <text x="152.0" y="164.0" text-anchor="middle" class="field-label">lr</text>
+  <text x="152.0" y="175.0" text-anchor="middle" class="field-label">reg</text>
+  <text x="152.0" y="189.0" text-anchor="middle" class="field-label" style="font-weight: bold;">[126:123]</text>
+  <rect x="80" y="135.0" width="24" height="80" fill="#FF6B6B" stroke="black" stroke-width="1" opacity="0.85"/>
+  <text x="92.0" y="164.0" text-anchor="middle" class="field-label">cr</text>
+  <text x="92.0" y="175.0" text-anchor="middle" class="field-label">reg</text>
+  <text x="92.0" y="189.0" text-anchor="middle" class="field-label" style="font-weight: bold;">[130:127]</text>
+  <rect x="80" y="215.0" width="768" height="80" fill="white" stroke="black" stroke-width="2"/>
+  <text x="50" y="259.0" text-anchor="end" class="bit-range">[95:64]</text>
+  <text x="92.0" y="227.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">95</text>
+  <text x="116.0" y="227.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">94</text>
+  <text x="140.0" y="227.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">93</text>
+  <text x="164.0" y="227.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">92</text>
+  <text x="188.0" y="227.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">91</text>
+  <text x="212.0" y="227.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">90</text>
+  <text x="236.0" y="227.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">89</text>
+  <text x="260.0" y="227.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">88</text>
+  <text x="284.0" y="227.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">87</text>
+  <text x="308.0" y="227.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">86</text>
+  <text x="332.0" y="227.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">85</text>
+  <text x="356.0" y="227.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">84</text>
+  <text x="380.0" y="227.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">83</text>
+  <text x="404.0" y="227.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">82</text>
+  <text x="428.0" y="227.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">81</text>
+  <text x="452.0" y="227.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">80</text>
+  <text x="476.0" y="227.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">79</text>
+  <text x="500.0" y="227.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">78</text>
+  <text x="524.0" y="227.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">77</text>
+  <text x="548.0" y="227.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">76</text>
+  <text x="572.0" y="227.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">75</text>
+  <text x="596.0" y="227.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">74</text>
+  <text x="620.0" y="227.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">73</text>
+  <text x="644.0" y="227.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">72</text>
+  <text x="668.0" y="227.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">71</text>
+  <text x="692.0" y="227.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">70</text>
+  <text x="716.0" y="227.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">69</text>
+  <text x="740.0" y="227.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">68</text>
+  <text x="764.0" y="227.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">67</text>
+  <text x="788.0" y="227.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">66</text>
+  <text x="812.0" y="227.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">65</text>
+  <text x="836.0" y="227.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">64</text>
+  <rect x="728" y="215.0" width="120" height="80" fill="#FFA07A" stroke="black" stroke-width="1" opacity="0.85"/>
+  <text x="788.0" y="233.0" text-anchor="middle" class="field-label">add</text>
+  <text x="788.0" y="244.0" text-anchor="middle" class="field-label">sub</text>
+  <text x="788.0" y="255.0" text-anchor="middle" class="field-label">src</text>
+  <text x="788.0" y="266.0" text-anchor="middle" class="field-label">b</text>
+  <text x="788.0" y="280.0" text-anchor="middle" class="field-label" style="font-weight: bold;">[68:63]</text>
+  <rect x="680" y="215.0" width="48" height="80" fill="#FFA07A" stroke="black" stroke-width="1" opacity="0.85"/>
+  <text x="704.0" y="238.5" text-anchor="middle" class="field-label">lr</text>
+  <text x="704.0" y="249.5" text-anchor="middle" class="field-label">inst</text>
+  <text x="704.0" y="260.5" text-anchor="middle" class="field-label">opcode</text>
+  <text x="704.0" y="274.5" text-anchor="middle" class="field-label" style="font-weight: bold;">[70:69]</text>
+  <rect x="632" y="215.0" width="48" height="80" fill="#9B59B6" stroke="black" stroke-width="1" opacity="0.85"/>
+  <text x="656.0" y="244.0" text-anchor="middle" class="field-label">post</text>
+  <text x="656.0" y="255.0" text-anchor="middle" class="field-label">fn</text>
+  <text x="656.0" y="269.0" text-anchor="middle" class="field-label" style="font-weight: bold;">[72:71]</text>
+  <rect x="608" y="215.0" width="24" height="80" fill="#9B59B6" stroke="black" stroke-width="1" opacity="0.85"/>
+  <text x="620.0" y="238.5" text-anchor="middle" class="field-label">full</text>
+  <text x="620.0" y="249.5" text-anchor="middle" class="field-label">xmem</text>
+  <text x="620.0" y="260.5" text-anchor="middle" class="field-label">row</text>
+  <text x="620.0" y="274.5" text-anchor="middle" class="field-label" style="font-weight: bold;">[73:73]</text>
+  <rect x="512" y="215.0" width="96" height="80" fill="#9B59B6" stroke="black" stroke-width="1" opacity="0.85"/>
+  <text x="560.0" y="244.0" text-anchor="middle" class="field-label">cr</text>
+  <text x="560.0" y="255.0" text-anchor="middle" class="field-label">reg</text>
+  <text x="560.0" y="269.0" text-anchor="middle" class="field-label" style="font-weight: bold;">[77:74]</text>
+  <rect x="488" y="215.0" width="24" height="80" fill="#9B59B6" stroke="black" stroke-width="1" opacity="0.85"/>
+  <text x="500.0" y="244.0" text-anchor="middle" class="field-label">agg</text>
+  <text x="500.0" y="255.0" text-anchor="middle" class="field-label">mode</text>
+  <text x="500.0" y="269.0" text-anchor="middle" class="field-label" style="font-weight: bold;">[78:78]</text>
+  <rect x="392" y="215.0" width="96" height="80" fill="#9B59B6" stroke="black" stroke-width="1" opacity="0.85"/>
+  <text x="440.0" y="244.0" text-anchor="middle" class="field-label">activation</text>
+  <text x="440.0" y="255.0" text-anchor="middle" class="field-label">fn</text>
+  <text x="440.0" y="269.0" text-anchor="middle" class="field-label" style="font-weight: bold;">[82:79]</text>
+  <rect x="320" y="215.0" width="72" height="80" fill="#9B59B6" stroke="black" stroke-width="1" opacity="0.85"/>
+  <text x="356.0" y="238.5" text-anchor="middle" class="field-label">aaq</text>
+  <text x="356.0" y="249.5" text-anchor="middle" class="field-label">inst</text>
+  <text x="356.0" y="260.5" text-anchor="middle" class="field-label">opcode</text>
+  <text x="356.0" y="274.5" text-anchor="middle" class="field-label" style="font-weight: bold;">[85:83]</text>
+  <rect x="272" y="215.0" width="48" height="80" fill="#45B7D1" stroke="black" stroke-width="1" opacity="0.85"/>
+  <text x="296.0" y="244.0" text-anchor="middle" class="field-label">vertical</text>
+  <text x="296.0" y="255.0" text-anchor="middle" class="field-label">stride</text>
+  <text x="296.0" y="269.0" text-anchor="middle" class="field-label" style="font-weight: bold;">[87:86]</text>
+  <rect x="176" y="215.0" width="96" height="80" fill="#45B7D1" stroke="black" stroke-width="1" opacity="0.85"/>
+  <text x="224.0" y="244.0" text-anchor="middle" class="field-label">lr</text>
+  <text x="224.0" y="255.0" text-anchor="middle" class="field-label">reg</text>
+  <text x="224.0" y="269.0" text-anchor="middle" class="field-label" style="font-weight: bold;">[91:88]</text>
+  <rect x="104" y="215.0" width="72" height="80" fill="#45B7D1" stroke="black" stroke-width="1" opacity="0.85"/>
+  <text x="140.0" y="244.0" text-anchor="middle" class="field-label">horizontal</text>
+  <text x="140.0" y="255.0" text-anchor="middle" class="field-label">stride</text>
+  <text x="140.0" y="269.0" text-anchor="middle" class="field-label" style="font-weight: bold;">[94:92]</text>
+  <rect x="80" y="215.0" width="24" height="80" fill="#45B7D1" stroke="black" stroke-width="1" opacity="0.85"/>
+  <text x="92.0" y="244.0" text-anchor="middle" class="field-label">aaq</text>
+  <text x="92.0" y="255.0" text-anchor="middle" class="field-label">reg</text>
+  <text x="92.0" y="269.0" text-anchor="middle" class="field-label" style="font-weight: bold;">[96:95]</text>
+  <rect x="80" y="295.0" width="768" height="80" fill="white" stroke="black" stroke-width="2"/>
+  <text x="50" y="339.0" text-anchor="end" class="bit-range">[63:32]</text>
+  <text x="92.0" y="307.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">63</text>
+  <text x="116.0" y="307.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">62</text>
+  <text x="140.0" y="307.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">61</text>
+  <text x="164.0" y="307.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">60</text>
+  <text x="188.0" y="307.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">59</text>
+  <text x="212.0" y="307.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">58</text>
+  <text x="236.0" y="307.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">57</text>
+  <text x="260.0" y="307.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">56</text>
+  <text x="284.0" y="307.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">55</text>
+  <text x="308.0" y="307.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">54</text>
+  <text x="332.0" y="307.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">53</text>
+  <text x="356.0" y="307.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">52</text>
+  <text x="380.0" y="307.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">51</text>
+  <text x="404.0" y="307.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">50</text>
+  <text x="428.0" y="307.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">49</text>
+  <text x="452.0" y="307.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">48</text>
+  <text x="476.0" y="307.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">47</text>
+  <text x="500.0" y="307.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">46</text>
+  <text x="524.0" y="307.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">45</text>
+  <text x="548.0" y="307.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">44</text>
+  <text x="572.0" y="307.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">43</text>
+  <text x="596.0" y="307.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">42</text>
+  <text x="620.0" y="307.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">41</text>
+  <text x="644.0" y="307.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">40</text>
+  <text x="668.0" y="307.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">39</text>
+  <text x="692.0" y="307.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">38</text>
+  <text x="716.0" y="307.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">37</text>
+  <text x="740.0" y="307.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">36</text>
+  <text x="764.0" y="307.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">35</text>
+  <text x="788.0" y="307.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">34</text>
+  <text x="812.0" y="307.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">33</text>
+  <text x="836.0" y="307.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">32</text>
+  <rect x="728" y="295.0" width="120" height="80" fill="#FFA07A" stroke="black" stroke-width="1" opacity="0.85"/>
+  <text x="788.0" y="313.0" text-anchor="middle" class="field-label">add</text>
+  <text x="788.0" y="324.0" text-anchor="middle" class="field-label">sub</text>
+  <text x="788.0" y="335.0" text-anchor="middle" class="field-label">src</text>
+  <text x="788.0" y="346.0" text-anchor="middle" class="field-label">b</text>
+  <text x="788.0" y="360.0" text-anchor="middle" class="field-label" style="font-weight: bold;">[36:31]</text>
+  <rect x="680" y="295.0" width="48" height="80" fill="#FFA07A" stroke="black" stroke-width="1" opacity="0.85"/>
+  <text x="704.0" y="318.5" text-anchor="middle" class="field-label">lr</text>
+  <text x="704.0" y="329.5" text-anchor="middle" class="field-label">inst</text>
+  <text x="704.0" y="340.5" text-anchor="middle" class="field-label">opcode</text>
+  <text x="704.0" y="354.5" text-anchor="middle" class="field-label" style="font-weight: bold;">[38:37]</text>
+  <rect x="584" y="295.0" width="96" height="80" fill="#FFA07A" stroke="black" stroke-width="1" opacity="0.85"/>
+  <text x="632.0" y="324.0" text-anchor="middle" class="field-label">lr</text>
+  <text x="632.0" y="335.0" text-anchor="middle" class="field-label">reg</text>
+  <text x="632.0" y="349.0" text-anchor="middle" class="field-label" style="font-weight: bold;">[42:39]</text>
+  <rect x="488" y="295.0" width="96" height="80" fill="#FFA07A" stroke="black" stroke-width="1" opacity="0.85"/>
+  <text x="536.0" y="324.0" text-anchor="middle" class="field-label">lr</text>
+  <text x="536.0" y="335.0" text-anchor="middle" class="field-label">reg</text>
+  <text x="536.0" y="349.0" text-anchor="middle" class="field-label" style="font-weight: bold;">[46:43]</text>
+  <rect x="344" y="295.0" width="144" height="80" fill="#FFA07A" stroke="black" stroke-width="1" opacity="0.85"/>
+  <text x="416.0" y="313.0" text-anchor="middle" class="field-label">add</text>
+  <text x="416.0" y="324.0" text-anchor="middle" class="field-label">sub</text>
+  <text x="416.0" y="335.0" text-anchor="middle" class="field-label">src</text>
+  <text x="416.0" y="346.0" text-anchor="middle" class="field-label">b</text>
+  <text x="416.0" y="360.0" text-anchor="middle" class="field-label" style="font-weight: bold;">[52:47]</text>
+  <rect x="296" y="295.0" width="48" height="80" fill="#FFA07A" stroke="black" stroke-width="1" opacity="0.85"/>
+  <text x="320.0" y="318.5" text-anchor="middle" class="field-label">lr</text>
+  <text x="320.0" y="329.5" text-anchor="middle" class="field-label">inst</text>
+  <text x="320.0" y="340.5" text-anchor="middle" class="field-label">opcode</text>
+  <text x="320.0" y="354.5" text-anchor="middle" class="field-label" style="font-weight: bold;">[54:53]</text>
+  <rect x="200" y="295.0" width="96" height="80" fill="#FFA07A" stroke="black" stroke-width="1" opacity="0.85"/>
+  <text x="248.0" y="324.0" text-anchor="middle" class="field-label">lr</text>
+  <text x="248.0" y="335.0" text-anchor="middle" class="field-label">reg</text>
+  <text x="248.0" y="349.0" text-anchor="middle" class="field-label" style="font-weight: bold;">[58:55]</text>
+  <rect x="104" y="295.0" width="96" height="80" fill="#FFA07A" stroke="black" stroke-width="1" opacity="0.85"/>
+  <text x="152.0" y="324.0" text-anchor="middle" class="field-label">lr</text>
+  <text x="152.0" y="335.0" text-anchor="middle" class="field-label">reg</text>
+  <text x="152.0" y="349.0" text-anchor="middle" class="field-label" style="font-weight: bold;">[62:59]</text>
+  <rect x="80" y="295.0" width="24" height="80" fill="#FFA07A" stroke="black" stroke-width="1" opacity="0.85"/>
+  <text x="92.0" y="313.0" text-anchor="middle" class="field-label">add</text>
+  <text x="92.0" y="324.0" text-anchor="middle" class="field-label">sub</text>
+  <text x="92.0" y="335.0" text-anchor="middle" class="field-label">src</text>
+  <text x="92.0" y="346.0" text-anchor="middle" class="field-label">b</text>
+  <text x="92.0" y="360.0" text-anchor="middle" class="field-label" style="font-weight: bold;">[68:63]</text>
+  <rect x="80" y="375.0" width="768" height="80" fill="white" stroke="black" stroke-width="2"/>
+  <text x="50" y="419.0" text-anchor="end" class="bit-range">[31:0]</text>
+  <text x="92.0" y="387.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">31</text>
+  <text x="116.0" y="387.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">30</text>
+  <text x="140.0" y="387.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">29</text>
+  <text x="164.0" y="387.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">28</text>
+  <text x="188.0" y="387.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">27</text>
+  <text x="212.0" y="387.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">26</text>
+  <text x="236.0" y="387.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">25</text>
+  <text x="260.0" y="387.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">24</text>
+  <text x="284.0" y="387.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">23</text>
+  <text x="308.0" y="387.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">22</text>
+  <text x="332.0" y="387.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">21</text>
+  <text x="356.0" y="387.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">20</text>
+  <text x="380.0" y="387.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">19</text>
+  <text x="404.0" y="387.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">18</text>
+  <text x="428.0" y="387.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">17</text>
+  <text x="452.0" y="387.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">16</text>
+  <text x="476.0" y="387.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">15</text>
+  <text x="500.0" y="387.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">14</text>
+  <text x="524.0" y="387.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">13</text>
+  <text x="548.0" y="387.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">12</text>
+  <text x="572.0" y="387.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">11</text>
+  <text x="596.0" y="387.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">10</text>
+  <text x="620.0" y="387.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">9</text>
+  <text x="644.0" y="387.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">8</text>
+  <text x="668.0" y="387.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">7</text>
+  <text x="692.0" y="387.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">6</text>
+  <text x="716.0" y="387.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">5</text>
+  <text x="740.0" y="387.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">4</text>
+  <text x="764.0" y="387.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">3</text>
+  <text x="788.0" y="387.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">2</text>
+  <text x="812.0" y="387.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">1</text>
+  <text x="836.0" y="387.0" text-anchor="middle" class="field-label" style="font-size: 6px; fill: #000000; font-weight: bold;">0</text>
+  <rect x="728" y="375.0" width="120" height="80" fill="#98D8C8" stroke="black" stroke-width="1" opacity="0.85"/>
+  <text x="788.0" y="404.0" text-anchor="middle" class="field-label">lcr</text>
+  <text x="788.0" y="415.0" text-anchor="middle" class="field-label">reg</text>
+  <text x="788.0" y="429.0" text-anchor="middle" class="field-label" style="font-weight: bold;">[4:0]</text>
+  <rect x="608" y="375.0" width="120" height="80" fill="#98D8C8" stroke="black" stroke-width="1" opacity="0.85"/>
+  <text x="668.0" y="404.0" text-anchor="middle" class="field-label">lcr</text>
+  <text x="668.0" y="415.0" text-anchor="middle" class="field-label">reg</text>
+  <text x="668.0" y="429.0" text-anchor="middle" class="field-label" style="font-weight: bold;">[9:5]</text>
+  <rect x="368" y="375.0" width="240" height="80" fill="#98D8C8" stroke="black" stroke-width="1" opacity="0.85"/>
+  <text x="488.0" y="404.0" text-anchor="middle" class="field-label">label</text>
+  <text x="488.0" y="415.0" text-anchor="middle" class="field-label">token</text>
+  <text x="488.0" y="429.0" text-anchor="middle" class="field-label" style="font-weight: bold;">[19:10]</text>
+  <rect x="296" y="375.0" width="72" height="80" fill="#98D8C8" stroke="black" stroke-width="1" opacity="0.85"/>
+  <text x="332.0" y="398.5" text-anchor="middle" class="field-label">cond</text>
+  <text x="332.0" y="409.5" text-anchor="middle" class="field-label">inst</text>
+  <text x="332.0" y="420.5" text-anchor="middle" class="field-label">opcode</text>
+  <text x="332.0" y="434.5" text-anchor="middle" class="field-label" style="font-weight: bold;">[22:20]</text>
+  <rect x="200" y="375.0" width="96" height="80" fill="#FFA07A" stroke="black" stroke-width="1" opacity="0.85"/>
+  <text x="248.0" y="404.0" text-anchor="middle" class="field-label">lr</text>
+  <text x="248.0" y="415.0" text-anchor="middle" class="field-label">reg</text>
+  <text x="248.0" y="429.0" text-anchor="middle" class="field-label" style="font-weight: bold;">[26:23]</text>
+  <rect x="104" y="375.0" width="96" height="80" fill="#FFA07A" stroke="black" stroke-width="1" opacity="0.85"/>
+  <text x="152.0" y="404.0" text-anchor="middle" class="field-label">lr</text>
+  <text x="152.0" y="415.0" text-anchor="middle" class="field-label">reg</text>
+  <text x="152.0" y="429.0" text-anchor="middle" class="field-label" style="font-weight: bold;">[30:27]</text>
+  <rect x="80" y="375.0" width="24" height="80" fill="#FFA07A" stroke="black" stroke-width="1" opacity="0.85"/>
+  <text x="92.0" y="393.0" text-anchor="middle" class="field-label">add</text>
+  <text x="92.0" y="404.0" text-anchor="middle" class="field-label">sub</text>
+  <text x="92.0" y="415.0" text-anchor="middle" class="field-label">src</text>
+  <text x="92.0" y="426.0" text-anchor="middle" class="field-label">b</text>
+  <text x="92.0" y="440.0" text-anchor="middle" class="field-label" style="font-weight: bold;">[36:31]</text>
+  <text x="80" y="475.0" class="inst-label" style="font-weight: bold;">Instruction Type Colors:</text>
+  <rect x="80" y="480.0" width="12" height="12" fill="#FFD93D" stroke="black" stroke-width="1" opacity="0.85"/>
+  <text x="100" y="492.0" class="field-label" style="font-size: 9px;">BreakInst (Break / Debug)</text>
+  <rect x="80" y="495.0" width="12" height="12" fill="#FF6B6B" stroke="black" stroke-width="1" opacity="0.85"/>
+  <text x="100" y="507.0" class="field-label" style="font-size: 9px;">XmemInst (Extended Memory)</text>
+  <rect x="80" y="510.0" width="12" height="12" fill="#4ECDC4" stroke="black" stroke-width="1" opacity="0.85"/>
+  <text x="100" y="522.0" class="field-label" style="font-size: 9px;">MultInst (Multiply)</text>
+  <rect x="80" y="525.0" width="12" height="12" fill="#45B7D1" stroke="black" stroke-width="1" opacity="0.85"/>
+  <text x="100" y="537.0" class="field-label" style="font-size: 9px;">AccInst (Accumulator)</text>
+  <rect x="80" y="540.0" width="12" height="12" fill="#9B59B6" stroke="black" stroke-width="1" opacity="0.85"/>
+  <text x="100" y="552.0" class="field-label" style="font-size: 9px;">AaqInst (Activation and Quantization)</text>
+  <rect x="80" y="555.0" width="12" height="12" fill="#FFA07A" stroke="black" stroke-width="1" opacity="0.85"/>
+  <text x="100" y="567.0" class="field-label" style="font-size: 9px;">LrInst (Link Register)</text>
+  <rect x="80" y="570.0" width="12" height="12" fill="#98D8C8" stroke="black" stroke-width="1" opacity="0.85"/>
+  <text x="100" y="582.0" class="field-label" style="font-size: 9px;">CondInst (Conditional)</text>
+</svg>
+
+---
+
+
+## XMEM Instructions
+
+Memory access instructions for loading and storing data between registers and memory.
+
+### `STR_ACC_REG` — Store Accumulator
+
+**Syntax:** `STR_ACC_REG offset, base`
+
+**Operands:** *(the **Type** column links to the [operand type reference](operand-types.md))*
+
+| Name | Type | Details |
+|------|------|---------|
+| `offset` | [`LrIdx`](operand-types.md#lridx) | offset: Offset register (LR0–LR15) |
+| `base` | [`CrIdx`](operand-types.md#cridx) | base: Base address register (CR0–CR14) |
+
+**General description:**
+Store accumulator to memory.
+
+**Pseudo code:**
+`Memory[offset + base] = R_ACC`
+
+**Example of usage:**
+```asm
+STR_ACC_REG CR0, CR1;;
+```
+
+### `LDR_MULT_REG` — Load Register
+
+**Syntax:** `LDR_MULT_REG dest, offset, base`
+
+**Operands:** *(the **Type** column links to the [operand type reference](operand-types.md))*
+
+| Name | Type | Details |
+|------|------|---------|
+| `dest` | [`MultStageReg`](operand-types.md#multstagereg) | `dest`: **`R0`** \| **`R1`** — mult-stage register to load (2-bit field; only these encodings are valid). |
+| `offset` | [`LrIdx`](operand-types.md#lridx) | `offset`: **`LR0`**…**`LR15`** — offset register. |
+| `base` | [`CrIdx`](operand-types.md#cridx) | `base`: **`CR0`**…**`CR15`** — base address register. |
+
+**General description:**
+Load data from memory into a multiplication stage register.
+
+**Pseudo code:**
+`dest = Memory[offset + base]  # 128 elements (512 in wide-vector debug mode)`
+
+**Example of usage:**
+```asm
+SET LR0, CR1;;
+LDR_MULT_REG R0, LR0, CR0;;
+```
+
+### `LDR_CYCLIC_MULT_REG` — Load Cyclic Register
+
+**Syntax:** `LDR_CYCLIC_MULT_REG offset, base, index`
+
+**Operands:** *(the **Type** column links to the [operand type reference](operand-types.md))*
+
+| Name | Type | Details |
+|------|------|---------|
+| `offset` | [`LrIdx`](operand-types.md#lridx) | offset: Offset register (LR0–LR15) |
+| `base` | [`CrIdx`](operand-types.md#cridx) | base: Base address register (CR0–CR14) |
+| `index` | [`LrIdx`](operand-types.md#lridx) | index: Index inside cyclic register (LR0–LR15) |
+
+**General description:**
+Load with cyclic addressing into R_CYCLIC.
+
+**Pseudo code:**
+`R_CYCLIC[index % 512:128] = Memory[offset + base]`
+
+
+### `LDR_MULT_MASK_REG` — Load Mask Register
+
+**Syntax:** `LDR_MULT_MASK_REG offset, base, mask_idx`
+
+**Operands:** *(the **Type** column links to the [operand type reference](operand-types.md))*
+
+| Name | Type | Details |
+|------|------|---------|
+| `offset` | [`LrIdx`](operand-types.md#lridx) | offset: Offset register (LR0–LR15) |
+| `base` | [`CrIdx`](operand-types.md#cridx) | base: Base address register (CR0–CR14) |
+
+**General description:**
+Load mask data from memory.
+
+**Pseudo code:**
+`R_MASK = Memory[offset + base]`
+
+
+### `XMEM_NOP` — No Operation (XMEM)
+
+**Syntax:** `XMEM_NOP`
+
+**General description:**
+No operation for xmem slot.
+
+
+### `STR_POST_AAQ_REG` — Store Post-AAQ register
+
+**Syntax:** `STR_POST_AAQ_REG offset, base`
+
+**Operands:** *(the **Type** column links to the [operand type reference](operand-types.md))*
+
+| Name | Type | Details |
+|------|------|---------|
+| `offset` | [`LrIdx`](operand-types.md#lridx) | offset: Offset register (LR0–LR15) |
+| `base` | [`CrIdx`](operand-types.md#cridx) | base: Base address register (CR0–CR14) |
+
+**General description:**
+Write **512 bytes** of **`POST_AAQ_REG`** to external memory. **Interim:** the buffer is **512 bytes** (128×32-bit lanes) until quantization export is finalized.
+
+**Pseudo code:**
+`Memory[offset + base] = POST_AAQ_REG (512 bytes); interim staging register`
+
+**Example of usage:**
+```asm
+STR_POST_AAQ_REG LR0, CR0;;
+```
+
+---
+
+## MULT Instructions
+
+Multiplication instructions for element-wise and element-vector operations.
+The multiplication result (`mult_result`) is forwarded to the ACC stage in the CPU and not stored in any register in the way.
+
+### `MULT.EE` — Element-wise Multiply
+
+**Syntax:** `MULT.EE ra, cyclic_offset, mask_offset, mask_shift`
+
+**Operands:** *(the **Type** column links to the [operand type reference](operand-types.md))*
+
+| Name | Type | Details |
+|------|------|---------|
+| `ra` | [`MultStageReg`](operand-types.md#multstagereg) | `ra`: **`R0`** \| **`R1`** — multiplicand mult-stage register (same cycle as `LDR_MULT_REG` into **`R0`**/**`R1`** is allowed). |
+| `cyclic_offset` | [`LrIdx`](operand-types.md#lridx) | `cyclic_offset`: **`LR0`**…**`LR15`** — base byte offset into **`R_CYCLIC`**. |
+| `mask_offset` | [`MultMaskOffsetImmediate`](operand-types.md#multmaskoffsetimmediate) | `mask_offset`: immediate mask slot **`0`**…**`7`** — selects one of eight 128-bit masks in **`R_MASK`**. |
+| `mask_shift` | [`LrIdx`](operand-types.md#lridx) | `mask_shift`: **`LR0`**…**`LR15`** — shift applied to the mask register. |
+
+**General description:**
+Multiply elements of two registers element by element.
+
+**Pseudo code:**
+`For each lane i: MULT_RES[i] = ipu_mult(ra[i], R_CYCLIC[cyclic_offset + i]); then apply mask and shift.`
+
+**Example of usage:**
+```asm
+MULT.EE R0, LR0, 0, LR2;;
+```
+
+### `MULT.VE.CYCLIC` — Vector-Element Multiply (cyclic RC)
+
+**Syntax:** `MULT.VE.CYCLIC cyclic_offset, mask_offset, mask_shift, fixed_idx`
+
+**Operands:** *(the **Type** column links to the [operand type reference](operand-types.md))*
+
+| Name | Type | Details |
+|------|------|---------|
+| `cyclic_offset` | [`LrIdx`](operand-types.md#lridx) | `cyclic_offset`: **`LR0`**…**`LR15`** — base byte offset into **`R_CYCLIC`** (reduced mod 512). |
+| `mask_offset` | [`MultMaskOffsetImmediate`](operand-types.md#multmaskoffsetimmediate) | `mask_offset`: immediate mask slot **`0`**…**`7`** — selects one of eight 128-bit masks in **`R_MASK`**. |
+| `mask_shift` | [`LrIdx`](operand-types.md#lridx) | `mask_shift`: **`LR0`**…**`LR15`** — shift applied to the mask register. |
+| `fixed_idx` | [`LrIdx`](operand-types.md#lridx) | `fixed_idx`: **`LR0`**…**`LR15`** (value read live) — scalar index into **`R0`**/**`R1`**. |
+
+**General description:**
+Multiply a fixed element from R0 or R1 against R_CYCLIC[cyclic_offset:cyclic_offset+128]. `fixed_idx` 0..127 selects `R0[fixed_idx]`, 128..255 selects `R1[fixed_idx - 128]`. R_CYCLIC is addressed cyclically modulo 512 elements (no padding with 1 past the boundary).
+
+**Pseudo code:**
+`For i in [0, 128): rb = R_CYCLIC[(cyclic_offset + i) % 512]; scalar from R0/R1 via fixed_idx; MULT_RES[i] = scalar * rb (then mask/shift).`
+
+**Example of usage:**
+```asm
+MULT.VE.CYCLIC LR0, 0, LR2, LR3;;
+```
+
+### `MULT.VE.PADDED` — Vector-Element Multiply (padded RC)
+
+**Syntax:** `MULT.VE.PADDED cyclic_offset, mask_offset, mask_shift, fixed_idx`
+
+**Operands:** *(the **Type** column links to the [operand type reference](operand-types.md))*
+
+| Name | Type | Details |
+|------|------|---------|
+| `cyclic_offset` | [`LrIdx`](operand-types.md#lridx) | `cyclic_offset`: **`LR0`**…**`LR15`** — base byte offset into `R_CYCLIC`; out-of-range lanes use dtype 1. |
+| `mask_offset` | [`MultMaskOffsetImmediate`](operand-types.md#multmaskoffsetimmediate) | `mask_offset`: immediate mask slot **`0`**…**`7`** — selects one of eight 128-bit masks in `R_MASK`. |
+| `mask_shift` | [`LrIdx`](operand-types.md#lridx) | `mask_shift`: **`LR0`**…**`LR15`** — shift applied to the mask register. |
+| `fixed_idx` | [`LrIdx`](operand-types.md#lridx) | `fixed_idx`: **`LR0`**…**`LR15`** (value read live) — scalar index into **`R0`**/**`R1`**. |
+
+**General description:**
+Same scalar × RC row as `MULT.VE.CYCLIC`, but indices at or past the 512-byte RC boundary within the 128-element window use a dtype-specific 1 instead of wrapping.
+
+**Pseudo code:**
+`For i in [0, 128): rb = R_CYCLIC[cyclic_offset + i] if in bounds else dtype_one; scalar from R0/R1; MULT_RES[i] = scalar * rb (then mask/shift).`
+
+**Example of usage:**
+```asm
+MULT.VE.PADDED LR0, 0, LR2, LR3;;
+```
+
+### `MULT_NOP` — No Operation (MULT)
+
+**Syntax:** `MULT_NOP`
+
+**General description:**
+No operation for multiply slot.
+
+
+### `MULT.VE.CR` — Vector-Element Multiply (CR scalar)
+
+**Syntax:** `MULT.VE.CR cyclic_offset, mask_offset, mask_shift, cr_idx`
+
+**Operands:** *(the **Type** column links to the [operand type reference](operand-types.md))*
+
+| Name | Type | Details |
+|------|------|---------|
+| `cyclic_offset` | [`LrIdx`](operand-types.md#lridx) | cyclic_offset: Base offset into RC (cyclic register); non-cyclic — out-of-bounds elements are padded with 1 |
+| `mask_offset` | [`MultMaskOffsetImmediate`](operand-types.md#multmaskoffsetimmediate) | mask_offset: Immediate mask slot 0–7 (128-bit slice of R_MASK) |
+| `mask_shift` | [`LrIdx`](operand-types.md#lridx) | mask_shift: Shift applied to the mask (from LR) |
+| `cr_idx` | [`CrIdx`](operand-types.md#cridx) | cr_idx: CR register whose low byte supplies the fixed scalar multiplier (CR0–CR14) |
+
+**General description:**
+Multiply each element of RC[cyclic_offset:cyclic_offset+128] by a scalar from a CR register. Elements beyond RC boundary are treated as 1 (dtype-specific).
+
+**Pseudo code:**
+`For i in [0,128): rb = RC[cyclic_offset+i] if in bounds else dtype_one; MULT_RES[i] = CR[cr_idx][0] * rb`
+
+**Example of usage:**
+```asm
+MULT.VE.CR LR0, 0, LR15, CR3;;
+```
+
+### `MULT.VE.AAQ` — Vector-Element Multiply (AAQ scalar)
+
+**Syntax:** `MULT.VE.AAQ cyclic_offset, mask_offset, mask_shift, aaq_rf_idx`
+
+**Operands:** *(the **Type** column links to the [operand type reference](operand-types.md))*
+
+| Name | Type | Details |
+|------|------|---------|
+| `cyclic_offset` | [`LrIdx`](operand-types.md#lridx) | cyclic_offset: Base offset into RC (cyclic register); non-cyclic — out-of-bounds elements are padded with 1 |
+| `mask_offset` | [`MultMaskOffsetImmediate`](operand-types.md#multmaskoffsetimmediate) | mask_offset: Immediate mask slot 0–7 (128-bit slice of R_MASK) |
+| `mask_shift` | [`LrIdx`](operand-types.md#lridx) | mask_shift: Shift applied to the mask (from LR) |
+| `aaq_rf_idx` | [`AaqRegIdx`](operand-types.md#aaqregidx) | aaq_rf_idx: AAQ register whose low byte supplies the fixed scalar multiplier (AAQ0–AAQ3) |
+
+**General description:**
+Multiply each element of RC[cyclic_offset:cyclic_offset+128] by a scalar from an AAQ register. Elements beyond RC boundary are treated as 1 (dtype-specific).
+
+**Pseudo code:**
+`For i in [0,128): rb = RC[cyclic_offset+i] if in bounds else dtype_one; MULT_RES[i] = AAQ[aaq_rf_idx][0] * rb`
+
+**Example of usage:**
+```asm
+MULT.VE.AAQ LR0, 0, LR15, AAQ1;;
+```
+
+### `MULT.EE.RR` — Multi-Element Multiply (register by register)
+
+**Syntax:** `MULT.EE.RR ra, mask_offset, mask_shift`
+
+**Operands:** *(the **Type** column links to the [operand type reference](operand-types.md))*
+
+| Name | Type | Details |
+|------|------|---------|
+| `ra` | [`MultStageReg`](operand-types.md#multstagereg) | `ra`: **`R0`** \| **`R1`** — selects the MEE mode; the chosen register is both multiplicand and multiplier (same cycle as `LDR_MULT_REG` into **`R0`**/**`R1`** is allowed). |
+| `mask_offset` | [`MultMaskOffsetImmediate`](operand-types.md#multmaskoffsetimmediate) | `mask_offset`: immediate mask slot **`0`**…**`7`** — selects one of eight 128-bit masks in **`r_mask`**. |
+| `mask_shift` | [`LrIdx`](operand-types.md#lridx) | `mask_shift`: **`LR0`**…**`LR15`** — shift applied to the mask register. |
+
+**General description:**
+Multi-element execution (MEE): multiply a mult-stage register element by element against itself. `ra` selects the execution mode — **`R0`** gives r0-by-r0, **`R1`** gives r1-by-r1.
+
+**Pseudo code:**
+`For each lane i: mult_res[i] = ipu_mult(ra[i], ra[i]); then apply mask and shift.`
+
+**Example of usage:**
+```asm
+MULT.EE.RR R0, 0, LR2;;
+```
+
+---
+
+## ACC Instructions
+
+Accumulation instructions for combining values with optional masking and shifting.
+
+### `ACC` — Accumulate
+
+**Syntax:** `ACC`
+
+**General description:**
+Accumulate multiply result.
+
+**Pseudo code:**
+`R_ACC += multiply_result`
+
+
+### `ACC.FIRST` — Accumulate First
+
+**Syntax:** `ACC.FIRST`
+
+**General description:**
+Set accumulator to multiply result (do not ADD to previous R_ACC).
+
+**Pseudo code:**
+`R_ACC = multiply_result`
+
+**Example of usage:**
+```asm
+ACC.FIRST;;
+```
+
+### `RESET_ACC` — Reset Accumulator
+
+**Syntax:** `RESET_ACC`
+
+**General description:**
+Reset accumulator to zero.
+
+**Pseudo code:**
+`R_ACC = 0`
+
+
+### `ACC_NOP` — No Operation (ACC)
+
+**Syntax:** `ACC_NOP`
+
+**General description:**
+No operation for accumulator slot.
+
+
+### `ACC.ADD_AAQ` — Accumulate and Add AAQ
+
+**Syntax:** `ACC.ADD_AAQ aaq_rf_idx`
+
+**Operands:** *(the **Type** column links to the [operand type reference](operand-types.md))*
+
+| Name | Type | Details |
+|------|------|---------|
+| `aaq_rf_idx` | [`AaqRegIdx`](operand-types.md#aaqregidx) | aaq_rf_idx: AAQ register index (AAQ0–AAQ3) |
+
+**General description:**
+Accumulate multiply result, then ADD the selected AAQ register (32-bit) to each of the 128 accumulator words.
+
+**Pseudo code:**
+`R_ACC += multiply_result;
+for i in [0, 128): R_ACC[i] += AAQ_REGS[aaq_rf_idx]`
+
+**Example of usage:**
+```asm
+ACC.ADD_AAQ AAQ0;;
+```
+
+### `ACC.ADD_AAQ.FIRST` — Accumulate and Add AAQ (First)
+
+**Syntax:** `ACC.ADD_AAQ.FIRST aaq_rf_idx`
+
+**Operands:** *(the **Type** column links to the [operand type reference](operand-types.md))*
+
+| Name | Type | Details |
+|------|------|---------|
+| `aaq_rf_idx` | [`AaqRegIdx`](operand-types.md#aaqregidx) | aaq_rf_idx: AAQ register index (AAQ0–AAQ3) |
+
+**General description:**
+Set accumulator to multiply result plus selected AAQ register (do not ADD to previous R_ACC).
+
+**Pseudo code:**
+`R_ACC = multiply_result;
+for i in [0, 128): R_ACC[i] += AAQ_REGS[aaq_rf_idx]`
+
+**Example of usage:**
+```asm
+ACC.ADD_AAQ.FIRST AAQ0;;
+```
+
+### `ACC.MAX` — Accumulator Max
+
+**Syntax:** `ACC.MAX aaq_rf_idx`
+
+**Operands:** *(the **Type** column links to the [operand type reference](operand-types.md))*
+
+| Name | Type | Details |
+|------|------|---------|
+| `aaq_rf_idx` | [`AaqRegIdx`](operand-types.md#aaqregidx) | aaq_rf_idx: AAQ register index (AAQ0–AAQ3) |
+
+**General description:**
+For each element, SET R_ACC[i] = max(R_ACC[i], MULT_RES[i], AAQ_REGS[aaq_rf_idx]).
+
+**Pseudo code:**
+`for i in [0, 128): R_ACC[i] = max(R_ACC[i], MULT_RES[i], AAQ_REGS[aaq_rf_idx])`
+
+**Example of usage:**
+```asm
+ACC.MAX AAQ0;;
+```
+
+### `ACC.MAX.FIRST` — Accumulator Max (First)
+
+**Syntax:** `ACC.MAX.FIRST aaq_rf_idx`
+
+**Operands:** *(the **Type** column links to the [operand type reference](operand-types.md))*
+
+| Name | Type | Details |
+|------|------|---------|
+| `aaq_rf_idx` | [`AaqRegIdx`](operand-types.md#aaqregidx) | aaq_rf_idx: AAQ register index (AAQ0–AAQ3) |
+
+**General description:**
+For each element, SET R_ACC[i] = max(MULT_RES[i], AAQ_REGS[aaq_rf_idx]). Previous R_ACC is ignored (treated as 0).
+
+**Pseudo code:**
+`for i in [0, 128): R_ACC[i] = max(MULT_RES[i], AAQ_REGS[aaq_rf_idx])`
+
+**Example of usage:**
+```asm
+ACC.MAX.FIRST AAQ0;;
+```
+
+### `ACC.STRIDE` — Accumulator Stride
+
+**Syntax:** `ACC.STRIDE elements_in_row, horizontal_stride, vertical_stride, offset`
+
+**Operands:** *(the **Type** column links to the [operand type reference](operand-types.md))*
+
+| Name | Type | Details |
+|------|------|---------|
+| `elements_in_row` | [`ElementsInRow`](operand-types.md#elementsinrow) | elements_in_row: Elements per row (8, 16, 32, or 64) |
+| `horizontal_stride` | [`HorizontalStride`](operand-types.md#horizontalstride) | horizontal_stride: Horizontal stride mode (enabled, inverted, expand) |
+| `vertical_stride` | [`VerticalStride`](operand-types.md#verticalstride) | vertical_stride: Vertical stride mode (enabled, inverted) |
+| `offset` | [`LrIdx`](operand-types.md#lridx) | offset: LR register; value % 4 gives start index in RACC (0, 32, 64, or 96) |
+
+**General description:**
+Reorder the multiplication result into R_ACC using horizontal/vertical stride decimation. Only updates the RACC indexes written; leaves the rest unchanged.
+
+**Pseudo code:**
+`Decimate MULT_RES as rows×cols; apply horizontal stride (take every 2nd column, optional expand); then vertical stride (take every 2nd row). Write result into R_ACC[start:start+N] where start = (offset%4)*32, N = 32|64|128.`
+
+**Example of usage:**
+```asm
+ACC.STRIDE 8, off, off, LR0;;
+```
+
+---
+
+## AAQ Instructions
+
+Activation and quantization: aggregate r_acc into AAQ registers; ACTIVATE writes activated lanes from r_acc into POST_AAQ_REG; AAQ quantizes POST_AAQ_REG.
+
+### `AAQ_NOP` — No Operation (AAQ)
+
+**Syntax:** `AAQ_NOP`
+
+**General description:**
+No operation for AAQ slot.
+
+
+### `AGG` — Accumulator Aggregate
+
+**Syntax:** `AGG agg_mode, post_fn, cr_idx, aaq_rf_idx, full_xmem_row`
+
+**Operands:** *(the **Type** column links to the [operand type reference](operand-types.md))*
+
+| Name | Type | Details |
+|------|------|---------|
+| `agg_mode` | [`AggMode`](operand-types.md#aggmode) | agg_mode: sum or max |
+| `post_fn` | [`PostFn`](operand-types.md#postfn) | post_fn: value, value_cr, inv, or inv_sqrt |
+| `cr_idx` | [`CrIdx`](operand-types.md#cridx) | cr_idx: CR register for value_cr post function (CR0–CR14) |
+| `aaq_rf_idx` | [`AaqRegIdx`](operand-types.md#aaqregidx) | aaq_rf_idx: AAQ register to store result (AAQ0–AAQ3) |
+| `full_xmem_row` | [`FullXmemRow`](operand-types.md#fullxmemrow) | full_xmem_row: 1 = always 128 lanes; 0 = use CR15.valid_elements (default 0) |
+
+**General description:**
+Collapse R_ACC lanes into one value (SUM or MAX); apply post function; store to selected AAQ register. ``full_xmem_row=1`` always uses 128 lanes; ``full_xmem_row=0`` uses CR15.valid_elements.
+
+**Pseudo code:**
+`Let n = 128 if full_xmem_row else min(CR15.valid_elements, 128). If sum: v = sum(R_ACC[0..n-1]). If max: v = max(R_ACC[0..n-1], AAQ[aaq_rf_idx]). Apply post_fn(v): value→v, value_cr→v*cr[cr_idx], inv→1/v, inv_sqrt→1/sqrt(v). AAQ[aaq_rf_idx] = result.`
+
+**Example of usage:**
+```asm
+AGG sum, value, CR0, AAQ0, 0;;
+```
+
+### `AGG.FIRST` — Accumulator Aggregate First
+
+**Syntax:** `AGG.FIRST agg_mode, post_fn, cr_idx, aaq_rf_idx, full_xmem_row`
+
+**Operands:** *(the **Type** column links to the [operand type reference](operand-types.md))*
+
+| Name | Type | Details |
+|------|------|---------|
+| `agg_mode` | [`AggMode`](operand-types.md#aggmode) | agg_mode: sum or max |
+| `post_fn` | [`PostFn`](operand-types.md#postfn) | post_fn: value, value_cr, inv, or inv_sqrt |
+| `cr_idx` | [`CrIdx`](operand-types.md#cridx) | cr_idx: CR register for value_cr post function (CR0–CR14) |
+| `aaq_rf_idx` | [`AaqRegIdx`](operand-types.md#aaqregidx) | aaq_rf_idx: AAQ register to store result (AAQ0–AAQ3) |
+| `full_xmem_row` | [`FullXmemRow`](operand-types.md#fullxmemrow) | full_xmem_row: 1 = always 128 lanes; 0 = use CR15.valid_elements (default 0) |
+
+**General description:**
+Like AGG, but for MAX mode ignores the previous AAQ register value, avoiding contamination from uninitialized data. ``full_xmem_row=1`` always uses 128 lanes; ``full_xmem_row=0`` uses CR15.valid_elements.
+
+**Pseudo code:**
+`Let n = 128 if full_xmem_row else min(CR15.valid_elements, 128). If sum: v = sum(R_ACC[0..n-1]). If max: v = max(R_ACC[0..n-1]) (previous AAQ value is NOT included). Apply post_fn(v): value→v, value_cr→v*cr[cr_idx], inv→1/v, inv_sqrt→1/sqrt(v). AAQ[aaq_rf_idx] = result.`
+
+**Example of usage:**
+```asm
+AGG.FIRST max, value, CR0, AAQ0, 0;;
+```
+
+### `AAQ` — AAQ Quantize
+
+**Syntax:** `AAQ full_xmem_row`
+
+**Operands:** *(the **Type** column links to the [operand type reference](operand-types.md))*
+
+| Name | Type | Details |
+|------|------|---------|
+| `full_xmem_row` | [`FullXmemRow`](operand-types.md#fullxmemrow) | full_xmem_row: 1 = always 128 lanes (full XMEM row); 0 = use CR15.valid_elements lane count |
+
+**General description:**
+Quantize wide lanes in **`POST_AAQ_REG`** (INT32 per lane in INT8 mode) to INT8, storing clamped bytes in the **leading 128 bytes** of **`POST_AAQ_REG`** and clearing the rest of the register. Wide lanes are normally produced by **`ACTIVATE`** (from ``r_acc``). Requires INT8 mode. ``full_xmem_row=1`` always processes all 128 lanes; ``full_xmem_row=0`` uses ``CR15.valid_elements`` as the active lane count.
+
+**Pseudo code:**
+`Requires INT8 mode (IpuState.dtype == DType.INT8 in the Python emulator). Let n = 128 if full_xmem_row else min(CR15.valid_elements, 128). For i in [0, n): POST_AAQ_REG[i] = clamp(trunc(POST_AAQ_REG wide lane i), -128, 127). POST_AAQ_REG[n..511] = 0.`
+
+**Example of usage:**
+```asm
+AAQ 1;;
+```
+
+### `ACTIVATE` — Accumulator Activation
+
+**Syntax:** `ACTIVATE activation_fn, full_xmem_row`
+
+**Operands:** *(the **Type** column links to the [operand type reference](operand-types.md))*
+
+| Name | Type | Details |
+|------|------|---------|
+| `activation_fn` | [`ActivationFn`](operand-types.md#activationfn) | activation_fn: keyword naming the activation (one of identity, relu, relu6, sigmoid, tanh, gelu, softplus, elu, exp2; see ACTIVATION_FN_NAMES) |
+| `full_xmem_row` | [`FullXmemRow`](operand-types.md#fullxmemrow) | full_xmem_row: 1 = always 128 lanes; 0 = use CR15.valid_elements (default 0) |
+
+**General description:**
+Read active lanes from ``r_acc``, apply the selected element-wise activation, and write results into the same lane indices of ``POST_AAQ_REG`` (``r_acc`` is unchanged). ``full_xmem_row=1`` always activates all 128 lanes; ``full_xmem_row=0`` uses CR15.valid_elements. The activation is selected by keyword (see ACTIVATION_FN_NAMES). The available activation functions are: ``identity`` (0), ``relu`` (1), ``relu6`` (2), ``sigmoid`` (3), ``tanh`` (4), ``gelu`` (5), ``softplus`` (6), ``elu`` (7), ``exp2`` (8), ``reciprocal`` (9), ``rsqrt`` (10). For Python emulator calibration (virtual α), see docs/content/building-applications.md#activations-emulator.
+
+**Pseudo code:**
+`Let n = 128 if full_xmem_row else min(CR15.valid_elements, 128) and k = encoded activation index. For i in [0, n): POST_AAQ_REG[i] = activation_k(R_ACC[i]) (same 32-bit lane format as R_ACC). R_ACC is not modified. The selector uses four bits; encodings outside the eleven named activations behave as identity. α for elu is not an ISA operand; see docs/content/building-applications.md#activations-emulator.`
+
+**Example of usage:**
+```asm
+ACTIVATE relu, 0;;
+```
+
+---
+
+## LR Instructions
+
+Loop register manipulation instructions for controlling loop counters and addresses.
+
+### `SET` — Set Loop Register
+
+**Syntax:** `SET reg, src`
+
+**Operands:** *(the **Type** column links to the [operand type reference](operand-types.md))*
+
+| Name | Type | Details |
+|------|------|---------|
+| `reg` | [`LrIdx`](operand-types.md#lridx) | reg: Loop register (LR0–LR15) |
+| `src` | [`CrIdx`](operand-types.md#cridx) | src: Source configuration register (CR0–CR14) |
+
+**General description:**
+Copy a 32-bit value from a configuration register into a loop register.
+
+**Pseudo code:**
+`reg = cr[src]`
+
+**Example of usage:**
+```asm
+SET LR0, CR1;;
+```
+
+### `ADD` — Add
+
+**Syntax:** `ADD dest, src_a, src_b`
+
+**Operands:** *(the **Type** column links to the [operand type reference](operand-types.md))*
+
+| Name | Type | Details |
+|------|------|---------|
+| `dest` | [`LrIdx`](operand-types.md#lridx) | dest: Destination local register (LR0–LR15) |
+| `src_a` | [`LrIdx`](operand-types.md#lridx) | src_a: First source local register (LR0–LR15) |
+| `src_b` | [`AddSubSrcB`](operand-types.md#addsubsrcb) | src_b: Second source — LR0–LR15, CR0–CR14, or unsigned immediate 0–31 |
+
+**General description:**
+Add two sources (second source may be an LR, CR, or 5-bit unsigned immediate) and store the result in the destination LR.
+
+**Pseudo code:**
+`dest = src_a + src_b`
+
+**Example of usage:**
+```asm
+ADD LR0, LR1, LR2;;
+ADD LR3, LR1, CR5;;
+ADD LR4, LR1, 7;;
+```
+
+### `SUB` — Subtract
+
+**Syntax:** `SUB dest, src_a, src_b`
+
+**Operands:** *(the **Type** column links to the [operand type reference](operand-types.md))*
+
+| Name | Type | Details |
+|------|------|---------|
+| `dest` | [`LrIdx`](operand-types.md#lridx) | dest: Destination local register (LR0–LR15) |
+| `src_a` | [`LrIdx`](operand-types.md#lridx) | src_a: First source local register (LR0–LR15) |
+| `src_b` | [`AddSubSrcB`](operand-types.md#addsubsrcb) | src_b: Second source — LR0–LR15, CR0–CR14, or unsigned immediate 0–31 |
+
+**General description:**
+Subtract the second source from the first (second source may be an LR, CR, or 5-bit unsigned immediate) and store the result in the destination LR.
+
+**Pseudo code:**
+`dest = src_a - src_b`
+
+**Example of usage:**
+```asm
+SUB LR0, LR1, LR2;;
+SUB LR3, LR1, CR5;;
+SUB LR4, LR1, 7;;
+```
+
+### `INCR_MOD_POW2` — Increment Loop Register Modulo Power of Two
+
+**Syntax:** `INCR_MOD_POW2 dst, step, k`
+
+**Operands:** *(the **Type** column links to the [operand type reference](operand-types.md))*
+
+| Name | Type | Details |
+|------|------|---------|
+| `dest` | [`LrIdx`](operand-types.md#lridx) | dst: Destination loop register (LR0–LR15); read and written |
+| `step` | [`LcrIdx`](operand-types.md#lcridx) | step: Signed 32-bit increment from LR0–LR15 or CR0–CR14 |
+| `k` | [`LrModPow2KImmediate`](operand-types.md#lrmodpow2kimmediate) | k: Immediate in [1, 9]; encoded in 4 bits as (k − 1); mask = (1 << k) - 1 |
+
+**General description:**
+Add a loop or configuration register into the destination loop register, then mask to k low bits (mod 2^k).
+
+**Pseudo code:**
+`dst <- (dst + step) & ((1 << k) - 1)`
+
+**Example of usage:**
+```asm
+INCR_MOD_POW2 LR2, LR3, 4;;
+```
+
+---
+
+## Conditional Branch Instructions
+
+Control flow instructions for branching based on conditions or unconditionally.
+
+### `BEQ` — Branch if Equal
+
+**Syntax:** `BEQ reg1, reg2, label`
+
+**Operands:** *(the **Type** column links to the [operand type reference](operand-types.md))*
+
+| Name | Type | Details |
+|------|------|---------|
+| `reg1` | [`LcrIdx`](operand-types.md#lcridx) | reg1: First register to compare (LR0–LR15 or CR0–CR14) |
+| `reg2` | [`LcrIdx`](operand-types.md#lcridx) | reg2: Second register to compare (LR0–LR15 or CR0–CR14) |
+| `label` | [`Label`](operand-types.md#label) | label: Branch target label |
+
+**General description:**
+Branch if two registers are equal.
+
+**Pseudo code:**
+`if (reg1 == reg2) PC = label`
+
+**Example of usage:**
+```asm
+BEQ LR0, LR1, end;;
+```
+
+### `BNE` — Branch if Not Equal
+
+**Syntax:** `BNE reg1, reg2, label`
+
+**Operands:** *(the **Type** column links to the [operand type reference](operand-types.md))*
+
+| Name | Type | Details |
+|------|------|---------|
+| `reg1` | [`LcrIdx`](operand-types.md#lcridx) | reg1: First register to compare (LR0–LR15 or CR0–CR14) |
+| `reg2` | [`LcrIdx`](operand-types.md#lcridx) | reg2: Second register to compare (LR0–LR15 or CR0–CR14) |
+| `label` | [`Label`](operand-types.md#label) | label: Branch target label |
+
+**General description:**
+Branch if two registers are not equal.
+
+**Pseudo code:**
+`if (reg1 != reg2) PC = label`
+
+**Example of usage:**
+```asm
+BNE LR0, CR0, loop;;
+```
+
+### `BLT` — Branch if Less Than
+
+**Syntax:** `BLT reg1, reg2, label`
+
+**Operands:** *(the **Type** column links to the [operand type reference](operand-types.md))*
+
+| Name | Type | Details |
+|------|------|---------|
+| `reg1` | [`LcrIdx`](operand-types.md#lcridx) | reg1: First register to compare (LR0–LR15 or CR0–CR14) |
+| `reg2` | [`LcrIdx`](operand-types.md#lcridx) | reg2: Second register to compare (LR0–LR15 or CR0–CR14) |
+| `label` | [`Label`](operand-types.md#label) | label: Branch target label |
+
+**General description:**
+Branch if first register is less than second.
+
+**Pseudo code:**
+`if (reg1 < reg2) PC = label`
+
+**Example of usage:**
+```asm
+BLT LR0, CR1, smaller;;
+```
+
+### `BNZ` — Branch if Not Zero
+
+**Syntax:** `BNZ test_reg, base_reg, label`
+
+**Operands:** *(the **Type** column links to the [operand type reference](operand-types.md))*
+
+| Name | Type | Details |
+|------|------|---------|
+| `test_reg` | [`LcrIdx`](operand-types.md#lcridx) | test_reg: Register to test (LR0–LR15 or CR0–CR14) |
+| `base_reg` | [`LcrIdx`](operand-types.md#lcridx) | base_reg: Base comparison register (LR0–LR15 or CR0–CR14) |
+| `label` | [`Label`](operand-types.md#label) | label: Branch target label |
+
+**General description:**
+Branch if test register not equal to base register.
+
+**Pseudo code:**
+`if (test_reg != base_reg) PC = label`
+
+**Example of usage:**
+```asm
+BNZ LR3, LR0, loop;;
+```
+
+### `BZ` — Branch if Zero
+
+**Syntax:** `BZ test_reg, base_reg, label`
+
+**Operands:** *(the **Type** column links to the [operand type reference](operand-types.md))*
+
+| Name | Type | Details |
+|------|------|---------|
+| `test_reg` | [`LcrIdx`](operand-types.md#lcridx) | test_reg: Register to test (LR0–LR15 or CR0–CR14) |
+| `base_reg` | [`LcrIdx`](operand-types.md#lcridx) | base_reg: Base comparison register (LR0–LR15 or CR0–CR14) |
+| `label` | [`Label`](operand-types.md#label) | label: Branch target label |
+
+**General description:**
+Branch if test register equals base register.
+
+**Pseudo code:**
+`if (test_reg == base_reg) PC = label`
+
+**Example of usage:**
+```asm
+BZ LR0, LR1, zero;;
+```
+
+### `B` — Unconditional Branch
+
+**Syntax:** `B label`
+
+**Operands:** *(the **Type** column links to the [operand type reference](operand-types.md))*
+
+| Name | Type | Details |
+|------|------|---------|
+| `label` | [`Label`](operand-types.md#label) | label: Branch target label |
+
+**General description:**
+Always branch to label.
+
+**Pseudo code:**
+`PC = label`
+
+**Example of usage:**
+```asm
+B start;;
+```
+
+### `BR` — Branch Register
+
+**Syntax:** `BR reg`
+
+**Operands:** *(the **Type** column links to the [operand type reference](operand-types.md))*
+
+| Name | Type | Details |
+|------|------|---------|
+| `reg` | [`LcrIdx`](operand-types.md#lcridx) | reg: Register containing target address (LR0–LR15 or CR0–CR14) |
+
+**General description:**
+Branch to address in register.
+
+**Pseudo code:**
+`PC = reg`
+
+
+### `BKPT` — Breakpoint
+
+**Syntax:** `BKPT`
+
+**General description:**
+Conditional breakpoint.
+
+**Pseudo code:**
+`Halt execution (debugging)`
+
+---
+
+## Break Instructions
+
+Debug break instructions for halting execution and entering debug mode.
+
+### `BREAK` — Break
+
+**Syntax:** `BREAK`
+
+**General description:**
+Unconditional break.
+
+**Pseudo code:**
+`Halt execution`
+
+
+### `BREAK.IFEQ` — Break if Equal
+
+**Syntax:** `BREAK.IFEQ reg, value`
+
+**Operands:** *(the **Type** column links to the [operand type reference](operand-types.md))*
+
+| Name | Type | Details |
+|------|------|---------|
+| `reg` | [`LrIdx`](operand-types.md#lridx) | reg: Register to test (LR0–LR15) |
+| `value` | [`BreakImmediate`](operand-types.md#breakimmediate) | value: Immediate value to compare against |
+
+**General description:**
+Break execution if register equals value.
+
+**Pseudo code:**
+`if (reg == value) BREAK`
+
+**Example of usage:**
+```asm
+BREAK.IFEQ LR0, 10;;
+```
+
+### `BREAK_NOP` — No Operation (BREAK)
+
+**Syntax:** `BREAK_NOP`
+
+**General description:**
+No operation for BREAK slot.
+
+---

--- a/docs/content/operand-types.md
+++ b/docs/content/operand-types.md
@@ -1,0 +1,71 @@
+# Operand types
+
+This page is **generated** by `ipu_as.gen_docs` from `VALID_OPERAND_TYPES` in `instruction_spec.py` and the descriptions below. For encodings per instruction, see the [Instruction reference](instructions.md).
+
+## `AaqRegIdx` {: #aaqregidx }
+
+AAQ register selector: **`aaq0`** … **`aaq3`**.
+
+## `ActivationFn` {: #activationfn }
+
+AAQ-slot keyword on **`ACTIVATE`**: one of **identity**, **relu**, **relu6**, **sigmoid**, **tanh**, **gelu**, **softplus**, **elu**, **exp2** (see ``ACTIVATION_FN_NAMES`` in ``ipu_common.activations``). Emulator-only calibration (including α) and how **`POST_AAQ_REG`** (interim **512 B**) and **`STR_POST_AAQ_REG`** (store to XMEM) are described in **Building Applications** (`docs/content/building-applications.md#activations-emulator`).
+
+## `AddSubSrcB` {: #addsubsrcb }
+
+Second source for **`ADD`** / **`SUB`** in the LR slot: **`lr0`–`lr15`**, **`cr0`–`cr14`**, or an **unsigned 5-bit immediate** (`0`–`31`). Encoded in **6 bits**: **`0`–`31`** use the same ordering as **`LcrIdx`**; **`32`–`63`** encode immediates as **`32 + imm`**. `cr15` is reserved and is not a valid operand.
+
+## `AggMode` {: #aggmode }
+
+AAQ-slot immediate: aggregation mode for the `AGG` / `AGG.FIRST` instructions (sum / max family); see `acc_agg_enums`.
+
+## `BreakImmediate` {: #breakimmediate }
+
+16-bit value for **`BREAK`** / breakpoint slot conditions.
+
+## `CrIdx` {: #cridx }
+
+Constant-register index: **`cr0`** … **`cr14`**. CRs are **read-only** in assembly; the harness initializes them (e.g. base pointers, strides). `cr15` is reserved for dstructure configuration and is not a valid ISA operand. **`SET`** in the LR slot copies the full **32-bit** CR value into an LR.
+
+## `ElementsInRow` {: #elementsinrow }
+
+ACC-slot immediate: encoded **elements-per-row** selector (see `acc_stride_enums` in `ipu_common`).
+
+## `FullXmemRow` {: #fullxmemrow }
+
+1-bit control flag on **`AAQ`**: **`1`** = always process all **128 lanes** (full XMEM row, ignores ``CR15.valid_elements``); **`0`** = process only the first ``CR15.valid_elements`` lanes (clamped to 128) and zero the rest. Defaults to **`1`** for backward compatibility.
+
+## `HorizontalStride` {: #horizontalstride }
+
+ACC-slot immediate: **horizontal stride** bit pattern for `ACC.STRIDE` (see `acc_stride_enums`).
+
+## `Label` {: #label }
+
+Branch target: a symbolic **`label`** or a relative offset accepted by the cond slot (e.g. `loop`, `+3`).
+
+## `LcrIdx` {: #lcridx }
+
+LR **or** CR index in one field: lower indices map to **`lr0`–`lr15`**, higher indices to `**cr0`–`cr14`** in the usual combined ordering used by the assembler. `cr15` is reserved and is not a valid operand.
+
+## `LrIdx` {: #lridx }
+
+Loop register index: resolves to **`lr0`** … **`lr15`**. Often used for addresses, strides, and control values. When marked `read: live` in the spec, the emulator reads the **current** LR value after earlier slots in the same cycle.
+
+## `LrModPow2KImmediate` {: #lrmodpow2kimmediate }
+
+Four-bit immediate for **`INCR_MOD_POW2`**: encodes exponent **k** with semantic **k ∈ [1, 9]** as **(k − 1)** in the word.
+
+## `MultMaskOffsetImmediate` {: #multmaskoffsetimmediate }
+
+Unsigned **3-bit** immediate on multiply instructions: **`mask_offset`** selects slot **`0`**–**`7`**, each a **128-bit** region of **`R_MASK`** (eight mask slots total). **`mask_shift`** remains an **`LrIdx`**.
+
+## `MultStageReg` {: #multstagereg }
+
+Multiply-stage field in the VLIW encoding. Assembly accepts **`r0`** and **`r1`** only; the field is **two bits** wide (encoding `2` is reserved). Used as the destination of `LDR_MULT_REG` and as the **`ra`** operand of `MULT.EE`.
+
+## `PostFn` {: #postfn }
+
+AAQ-slot immediate: post-aggregation function selector (identity, inverse sqrt, etc.); see `acc_agg_enums`.
+
+## `VerticalStride` {: #verticalstride }
+
+ACC-slot immediate: **vertical stride** bit pattern for `ACC.STRIDE` (see `acc_stride_enums`).

--- a/docs/content/release-log.md
+++ b/docs/content/release-log.md
@@ -1,0 +1,65 @@
+# Release Log
+
+This page lists every pull request that has been merged into `master`, newest
+first.  It is regenerated automatically as part of the docs build on every
+merge.
+
+| # | Title | Merged at (UTC) |
+|---|-------|----------------|
+| [#101](https://github.com/rechefe/ipu-emulator/pull/101) | Update documentation and code to restrict usage of CR15 as an ISA ope… | 2026-05-29 16:28 |
+| [#100](https://github.com/rechefe/ipu-emulator/pull/100) | Changes in IPU configuration registers (Issue #98) | 2026-05-29 14:13 |
+| [#97](https://github.com/rechefe/ipu-emulator/pull/97) | Add reciprocal and rsqrt activation functions; update related specs a… | 2026-05-29 07:05 |
+| [#94](https://github.com/rechefe/ipu-emulator/pull/94) | Remove Spec and AAQ Support for leaky_relu, prelu, silu/swish Activations | 2026-05-26 19:01 |
+| [#79](https://github.com/rechefe/ipu-emulator/pull/79) | Issue #77: Configure activation α on IpuState (no CR) | 2026-05-23 18:52 |
+| [#92](https://github.com/rechefe/ipu-emulator/pull/92) | feat(isa): union layout solver for bitfield sharing across opcodes | 2026-05-23 16:31 |
+| [#90](https://github.com/rechefe/ipu-emulator/pull/90) | docs: enhance Control Stage documentation with detailed descriptions … | 2026-05-23 14:03 |
+| [#89](https://github.com/rechefe/ipu-emulator/pull/89) | feat(mult): add MULT.EE.RR multi-element execution (issue #86) | 2026-05-17 17:43 |
+| [#88](https://github.com/rechefe/ipu-emulator/pull/88) | docs: update ISA section with detailed instruction references for AAQ… | 2026-05-16 15:02 |
+| [#81](https://github.com/rechefe/ipu-emulator/pull/81) | Control stage spec | 2026-05-15 15:11 |
+| [#85](https://github.com/rechefe/ipu-emulator/pull/85) | Add execution statistics tracking (issue #84) | 2026-05-14 10:45 |
+| [#83](https://github.com/rechefe/ipu-emulator/pull/83) | LR SET: copy from CR register; remove 16-bit immediate (#82) | 2026-05-14 08:50 |
+| [#80](https://github.com/rechefe/ipu-emulator/pull/80) | Standardize instruction syntax and register naming conventions | 2026-05-12 20:27 |
+| [#78](https://github.com/rechefe/ipu-emulator/pull/78) | Fix LR conflict detection for INCR_MOD_POW2 instructions | 2026-05-12 20:14 |
+| [#72](https://github.com/rechefe/ipu-emulator/pull/72) | Standardize upper-case instruction mnemonics and lower-case operand names | 2026-05-09 19:12 |
+| [#71](https://github.com/rechefe/ipu-emulator/pull/71) | Issue #51: valid_elements operand for agg / agg.first | 2026-05-09 17:32 |
+| [#67](https://github.com/rechefe/ipu-emulator/pull/67) | Fix #46: immediate multiply mask slot (0–7); shift stays LR | 2026-05-09 17:22 |
+| [#70](https://github.com/rechefe/ipu-emulator/pull/70) | Fix mult.ve cyclic RC access and add 128-element padding flag (closes #44) | 2026-05-09 17:15 |
+| [#68](https://github.com/rechefe/ipu-emulator/pull/68) | Fix #64: add/sub ISA — LR src_a, LR\|CR\|IMM5 src_b | 2026-05-09 17:05 |
+| [#69](https://github.com/rechefe/ipu-emulator/pull/69) | Close #52, #65, #66: ISA cleanup (remove mult.ev, mult.ee R0/R1 only) and docs | 2026-05-09 16:05 |
+| [#62](https://github.com/rechefe/ipu-emulator/pull/62) | AAQ spec: rename Post-Function “Edge case” column to “Corner case” | 2026-05-08 13:21 |
+| [#60](https://github.com/rechefe/ipu-emulator/pull/60) | MkDocs: git revision dates, history links, giscus (issue #59) | 2026-05-06 20:38 |
+| [#58](https://github.com/rechefe/ipu-emulator/pull/58) | Rename "IPU Specification" to "AAQ Stage Specification" in mkdocs nav | 2026-05-06 20:04 |
+| [#56](https://github.com/rechefe/ipu-emulator/pull/56) | Fix MkDocs build: nested docs paths, stage spec filename, Mermaid fences | 2026-05-06 19:50 |
+| [#54](https://github.com/rechefe/ipu-emulator/pull/54) | Specs added for cache unit and AAQ stage | 2026-05-06 19:25 |
+| [#50](https://github.com/rechefe/ipu-emulator/pull/50) | Encode incr_mod_pow2 k in 4 bits (k − 1) | 2026-05-05 20:29 |
+| [#49](https://github.com/rechefe/ipu-emulator/pull/49) | Add incr_mod_pow2 LR instruction (Issue #47) | 2026-05-05 20:06 |
+| [#48](https://github.com/rechefe/ipu-emulator/pull/48) | Allow three LR sub-instructions per VLIW word (issue #45) | 2026-05-04 19:52 |
+| [#43](https://github.com/rechefe/ipu-emulator/pull/43) | Wide-vector debug mode (32-bit lanes, issue #33) | 2026-05-03 20:11 |
+| [#42](https://github.com/rechefe/ipu-emulator/pull/42) | Add agg.first instruction to fix RF register noise (fixes #32) | 2026-05-03 17:31 |
+| [#41](https://github.com/rechefe/ipu-emulator/pull/41) | Implements shared fixed_idx (0–255) for mult.ve | 2026-05-02 18:45 |
+| [#40](https://github.com/rechefe/ipu-emulator/pull/40) | Support CR registers as operands in conditional branch and br instructions | 2026-05-02 16:12 |
+| [#37](https://github.com/rechefe/ipu-emulator/pull/37) | fix: mult.ve boundary padding parity with mult.ve.cr / mult.ve.aaq | 2026-04-27 19:20 |
+| [#35](https://github.com/rechefe/ipu-emulator/pull/35) | Add auto-updating Release Log documentation page | 2026-04-26 18:36 |
+| [#30](https://github.com/rechefe/ipu-emulator/pull/30) | Replace bitwise stride decoding with lookup tables | 2026-04-03 08:07 |
+| [#28](https://github.com/rechefe/ipu-emulator/pull/28) | Generalize FP8 support to all e(x)m(8-x) format - closes #19 | 2026-03-27 13:29 |
+| [#26](https://github.com/rechefe/ipu-emulator/pull/26) | Fix duplicated legend in SVG generator | 2026-03-24 20:34 |
+| [#27](https://github.com/rechefe/ipu-emulator/pull/27) | Add aaq quantization instruction and xmem.store_aaq_result (closes #24) | 2026-03-24 20:31 |
+| [#23](https://github.com/rechefe/ipu-emulator/pull/23) | Add mult.ve.cr and mult.ve.aaq instructions (closes #17) | 2026-03-23 20:30 |
+| [#22](https://github.com/rechefe/ipu-emulator/pull/22) | [skill] Add AI Assistant Skill Reference for IPU Emulator & Assembler | 2026-03-23 19:50 |
+| [#16](https://github.com/rechefe/ipu-emulator/pull/16) | Refactor new instructions | 2026-03-07 16:05 |
+| [#15](https://github.com/rechefe/ipu-emulator/pull/15) | [doc] Update docs - detailed example of fully connected layer impleme… | 2026-03-02 18:18 |
+| [#14](https://github.com/rechefe/ipu-emulator/pull/14) | Python refactor | 2026-02-16 16:51 |
+| [#13](https://github.com/rechefe/ipu-emulator/pull/13) | Feature/debug | 2026-01-30 15:40 |
+| [#12](https://github.com/rechefe/ipu-emulator/pull/12) | [emulator] Implemented add and sub instructions for LR and CR registe… | 2026-01-30 10:57 |
+| [#11](https://github.com/rechefe/ipu-emulator/pull/11) | [emulator] Fixed multiplier instruction ev and ve | 2026-01-30 10:32 |
+| [#10](https://github.com/rechefe/ipu-emulator/pull/10) | Doc/adding mult acc | 2026-01-26 19:49 |
+| [#8](https://github.com/rechefe/ipu-emulator/pull/8) | [docs] Add new documentat regarding how to add new instructions to as… | 2026-01-12 15:05 |
+| [#5](https://github.com/rechefe/ipu-emulator/pull/5) | [data_formats] WIP - start adding new data formats | 2026-01-09 14:47 |
+| [#7](https://github.com/rechefe/ipu-emulator/pull/7) | Reset command | 2026-01-09 14:47 |
+| [#6](https://github.com/rechefe/ipu-emulator/pull/6) | Add zero_rq instruction and update opcode handling | 2025-12-30 19:35 |
+| [#4](https://github.com/rechefe/ipu-emulator/pull/4) | Docs | 2025-12-22 20:55 |
+| [#3](https://github.com/rechefe/ipu-emulator/pull/3) | Docs | 2025-12-22 20:12 |
+| [#2](https://github.com/rechefe/ipu-emulator/pull/2) | [preprocessor] Add preprocessing capabilities to assembly syntax | 2025-12-22 16:29 |
+| [#1](https://github.com/rechefe/ipu-emulator/pull/1) | Dockerfile | 2025-12-22 16:01 |
+
+*Last updated: 2026-05-29 18:54 UTC*

--- a/docs/content/specs/stage-aaq.md
+++ b/docs/content/specs/stage-aaq.md
@@ -70,6 +70,7 @@ flowchart LR
        aaq_rf_idx  ─────>│                                      │
           dtype  ─────>│                                      │
    valid_elements  ─────>│                                      │
+    full_xmem_row  ─────>│                                      │
                          └──────────────────────────────────────┘
 ```
 
@@ -88,7 +89,8 @@ flowchart LR
 | `act_cr_idx` | `input logic [3:0]` | CR register index whose value selects the activation function (see §7.0). |
 | `aaq_rf_idx` | `input logic [1:0]` | AAQ register index (0–3). |
 | `dtype` | `input logic [2:0]` | Global data type forwarded from outside configuration; governs lane interpretation for all AAQ operations. Must be `DType.INT8` (0) for `aaq`. |
-| `valid_elements` | `input logic [7:0]` | Active lane count. Always sourced from `CR15.valid_elements` (bits [7:0] of the CR15 dstructure register). |
+| `valid_elements` | `input logic [7:0]` | Active lane count. Sourced from `CR15.valid_elements` (bits [7:0] of the CR15 dstructure register). Ignored when `full_xmem_row` = 1. |
+| `full_xmem_row` | `input logic [0:0]` | Lane-count override. 1 = always use all 128 lanes (ignore `valid_elements`); 0 = use `valid_elements`. Applies to `AGG`, `AGG.FIRST`, `AAQ`, and `ACTIVATE`. |
 
 ### 3.2 Outputs
 
@@ -135,7 +137,8 @@ The function is selected at runtime by reading the CR register indexed by `act_c
 ```text
 // Applied to all valid lanes before aggregation or quantization
 activation_fn = cr[act_cr_idx]
-activated[i]  = activation_fn(r_acc[i])   for i in 0..valid_elements-1
+n             = 128 if full_xmem_row else min(valid_elements, 128)
+activated[i]  = activation_fn(r_acc[i])   for i in 0..n-1
 ```
 
 Supported activation functions:
@@ -156,13 +159,14 @@ Supported activation functions:
 
 ### 7.1 Aggregate (`agg`)
 
-**Assembly syntax:** `AGG agg_mode, post_fn, cr_idx, aaq_rf_idx`
+**Assembly syntax:** `AGG agg_mode, post_fn, cr_idx, aaq_rf_idx, full_xmem_row`
 
-The active lane count (`valid_elements`) is always read implicitly from `CR15.valid_elements` (bits [7:0] of the CR15 dstructure register) — it is not an assembly operand.
+The active lane count is controlled by `full_xmem_row`: when `1`, all 128 lanes are used; when `0`, the count is read implicitly from `CR15.valid_elements` (bits [7:0] of the CR15 dstructure register).
 
 ```text
-// r_acc lanes are always FP32; only the first valid_elements lanes are used
-values = [activation(r_acc[i]) for i in 0..valid_elements-1]
+// r_acc lanes are always FP32
+n      = 128 if full_xmem_row else min(valid_elements, 128)
+values = [activation(r_acc[i]) for i in 0..n-1]
 
 // Adder tree / max tree (feedback from RF included in max mode)
 if agg_mode == sum:
@@ -175,7 +179,7 @@ aaq[aaq_rf_idx] = pack32(out)                  // stored as float32
 ```
 
 Notes:
-- Only lanes `0..valid_elements-1` are fed into the adder/max tree; lanes beyond that index are ignored.
+- Only lanes `0..n-1` are fed into the adder/max tree (where `n = 128` if `full_xmem_row=1`, else `min(CR15.valid_elements, 128)`); lanes beyond that index are ignored.
 - The activation function applied is the one selected for the current operation (see §7.0).
 - In `max` mode the current value of the target AAQ register is fed back from RF into
   the adder/max tree. Use `agg.first` to avoid contamination from an uninitialised register.
@@ -220,15 +224,16 @@ flowchart TD
 
 #### 7.1.1 Aggregate First (`agg.first`)
 
-**Assembly syntax:** `AGG.FIRST agg_mode, post_fn, cr_idx, aaq_rf_idx`
+**Assembly syntax:** `AGG.FIRST agg_mode, post_fn, cr_idx, aaq_rf_idx, full_xmem_row`
 
-Same lane-count masking rules as `AGG` — `valid_elements` is read implicitly from `CR15.valid_elements`.
+Same lane-count rules as `AGG` — `full_xmem_row=1` uses all 128 lanes; `full_xmem_row=0` reads `valid_elements` from `CR15.valid_elements`.
 
 Identical to `agg` except that `max` mode ignores the RF feedback value:
 
 ```text
-// r_acc lanes are always FP32; only the first valid_elements lanes are used
-values = [activation(r_acc[i]) for i in 0..valid_elements-1]
+// r_acc lanes are always FP32
+n      = 128 if full_xmem_row else min(valid_elements, 128)
+values = [activation(r_acc[i]) for i in 0..n-1]
 
 if agg_mode == sum:
     raw = sum(values)       // FP32 scalar; input to post_fn
@@ -251,9 +256,11 @@ lanes as FP32, quantizes to INT8, clamps, and writes the 128-byte result to
 
 ```text
 // dtype must be DType.INT8; r_acc lanes are FP32
-for i in 0..127:
+n = 128 if full_xmem_row else min(CR15.valid_elements, 128)
+for i in 0..n-1:
     val            = r_acc[i]        // FP32
     aaq_result[i]  = clamp(round(val), -128, 127)
+aaq_result[n..127] = 0
 ```
 
 Notes:
@@ -281,8 +288,8 @@ duplicated here.
 
 The AAQ slot is resolved by CTRL and forwarded down the dispatch chain;
 the stage does not read the CR/LR register files itself (see the
-Control Stage spec, §5). The `valid_elements` lane count is taken from
-the register **value** at cycle start — see §7.1 for the masking rule.
+Control Stage spec, §5). The active lane count is determined by `full_xmem_row`:
+`1` = always 128, `0` = `CR15.valid_elements` at cycle start — see §7.1 for the masking rule.
 
 ### 8.1 `AAQ_NOP` — No Operation
 
@@ -294,16 +301,17 @@ the register **value** at cycle start — see §7.1 for the masking rule.
 
 ### 8.2 `AGG` — Accumulator Aggregate
 
-- **Summary:** Collapse the first `CR15.valid_elements` lanes of `r_acc` into one FP32 scalar (`sum` or `max`), apply the post function, and store the result to the selected AAQ register.
-- **Syntax:** `AGG agg_mode, post_fn, cr_idx, aaq_rf_idx`
+- **Summary:** Collapse `r_acc` lanes into one FP32 scalar (`sum` or `max`), apply the post function, and store the result to the selected AAQ register. `full_xmem_row` controls whether all 128 lanes or only `CR15.valid_elements` lanes participate.
+- **Syntax:** `AGG agg_mode, post_fn, cr_idx, aaq_rf_idx, full_xmem_row`
 - **Operands:**
   - `agg_mode` — aggregation mode: `sum` (0) or `max` (1).
   - `post_fn` — post function applied to the aggregated scalar: `value` (0), `value_cr` (1), `inv` (2), `inv_sqrt` (3). See §7.1 *Post-Function Details*.
   - `cr_idx` — `CR0`–`CR14`; the CR value used by the `value_cr` post function.
   - `aaq_rf_idx` — destination AAQ register, `AAQ0`–`AAQ3`.
+  - `full_xmem_row` — `1` = always use 128 lanes; `0` = use `CR15.valid_elements` (default `0`).
 - **Operation:**
   ```text
-  n = min(CR15.valid_elements, 128)
+  n = 128 if full_xmem_row else min(CR15.valid_elements, 128)
   values = [activation(r_acc[i]) for i in 0..n-1]      // activation per §7.0
   if agg_mode == sum:
       raw = sum(values)
@@ -312,18 +320,19 @@ the register **value** at cycle start — see §7.1 for the masking rule.
   AAQ[aaq_rf_idx] = pack32(post_fn(raw, CR[cr_idx]))    // stored as float32
   ```
 - **Examples:**
-  - `AGG sum, value, CR0, AAQ0;;` — sum the first `CR15.valid_elements` lanes into `AAQ0`.
-  - `AGG max, value_cr, CR5, AAQ1;;` — max of the first `CR15.valid_elements` lanes (with `AAQ1` fed back), scaled by `CR5`.
+  - `AGG sum, value, CR0, AAQ0, 0;;` — sum the first `CR15.valid_elements` lanes into `AAQ0`.
+  - `AGG sum, value, CR0, AAQ0, 1;;` — sum all 128 lanes into `AAQ0` regardless of `CR15`.
+  - `AGG max, value_cr, CR5, AAQ1, 0;;` — max of `CR15.valid_elements` lanes (with `AAQ1` fed back), scaled by `CR5`.
 - **Notes:** In `max` mode the current value of `AAQ[aaq_rf_idx]` is fed back into the max tree; use `AGG.FIRST` to avoid contamination from an uninitialised register.
 
 ### 8.3 `AGG.FIRST` — Accumulator Aggregate First
 
-- **Summary:** Identical to `AGG` except that `max` mode does **not** fold in the previous AAQ register value (no RF feedback).
-- **Syntax:** `AGG.FIRST agg_mode, post_fn, cr_idx, aaq_rf_idx`
-- **Operands:** identical to `AGG`.
+- **Summary:** Identical to `AGG` except that `max` mode does **not** fold in the previous AAQ register value (no RF feedback). `full_xmem_row` controls the active lane count as in `AGG`.
+- **Syntax:** `AGG.FIRST agg_mode, post_fn, cr_idx, aaq_rf_idx, full_xmem_row`
+- **Operands:** identical to `AGG` (including `full_xmem_row`).
 - **Operation:**
   ```text
-  n = min(CR15.valid_elements, 128)
+  n = 128 if full_xmem_row else min(CR15.valid_elements, 128)
   values = [activation(r_acc[i]) for i in 0..n-1]
   if agg_mode == sum:
       raw = sum(values)
@@ -331,22 +340,25 @@ the register **value** at cycle start — see §7.1 for the masking rule.
       raw = max(values)
   AAQ[aaq_rf_idx] = pack32(post_fn(raw, CR[cr_idx]))
   ```
-- **Example:** `AGG.FIRST max, value, CR0, AAQ0;;`.
+- **Example:** `AGG.FIRST max, value, CR0, AAQ0, 0;;`.
 - **Notes:** Use at the start of a new accumulation sequence so a stale/uninitialised `AAQ[aaq_rf_idx]` cannot contaminate the `max`.
 
 ### 8.4 `AAQ` — Quantize Accumulator
 
-- **Summary:** Quantize the 128-lane accumulator to 8-bit and write the 128-byte `aaq_result` register. Requires INT8 mode.
-- **Syntax:** `AAQ`
-- **Operands:** none.
+- **Summary:** Quantize wide lanes in `POST_AAQ_REG` to 8-bit and write the 128-byte `aaq_result` register. Requires INT8 mode. The `full_xmem_row` flag controls how many lanes are active.
+- **Syntax:** `AAQ full_xmem_row`
+- **Operands:**
+  - `full_xmem_row`: `1` = always process all 128 lanes (full XMEM row, ignores `CR15.valid_elements`); `0` = process only the first `CR15.valid_elements` lanes (clamped to 128) and zero the rest. Defaults to `0`.
 - **Operation:**
   ```text
-  // requires dtype == DType.INT8; r_acc lanes are FP32
-  for i in 0..127:
-      aaq_result[i] = clamp(trunc(r_acc[i]), -128, 127)
+  // requires dtype == DType.INT8
+  n = 128 if full_xmem_row else min(CR15.valid_elements, 128)
+  for i in 0..n-1:
+      aaq_result[i] = clamp(trunc(POST_AAQ_REG[i]), -128, 127)
+  aaq_result[n..127] = 0
   ```
   The Quantization block appends 12 bits of metadata to the 1024-bit payload (see §5 / §7.2).
-- **Example:** `AAQ;;`.
+- **Example:** `AAQ 1;;` (full row), `AAQ 0;;` (use `CR15.valid_elements`).
 - **Notes:** `aaq_result` must be flushed with `XMEM.STORE_AAQ_RESULT offset base` before the next `AAQ` overwrites it (see §7.2).
 
 ### 8.5 Summary Table
@@ -354,6 +366,7 @@ the register **value** at cycle start — see §7.1 for the masking rule.
 | Slot | Mnemonic | Operands | One-line Effect |
 |------|----------|----------|-----------------|
 | AAQ | `AAQ_NOP`   | —                                                      | no state change |
-| AAQ | `AGG`       | `agg_mode, post_fn, cr_idx, aaq_rf_idx` | `AAQ[idx] = post_fn(agg(r_acc[0..n-1], AAQ[idx]))`, n from `CR15.valid_elements` |
-| AAQ | `AGG.FIRST` | `agg_mode, post_fn, cr_idx, aaq_rf_idx` | `AAQ[idx] = post_fn(agg(r_acc[0..n-1]))` (no RF feedback), n from `CR15.valid_elements` |
-| AAQ | `AAQ`       | —                                                      | `aaq_result[i] = clamp(trunc(r_acc[i]), -128, 127)` |
+| AAQ | `AGG`       | `agg_mode, post_fn, cr_idx, aaq_rf_idx, full_xmem_row` | `AAQ[idx] = post_fn(agg(r_acc[0..n-1], AAQ[idx]))`, n = 128 if full_xmem_row else CR15.valid_elements |
+| AAQ | `AGG.FIRST` | `agg_mode, post_fn, cr_idx, aaq_rf_idx, full_xmem_row` | `AAQ[idx] = post_fn(agg(r_acc[0..n-1]))` (no RF feedback), n = 128 if full_xmem_row else CR15.valid_elements |
+| AAQ | `AAQ`       | `full_xmem_row`                                        | `aaq_result[0..n-1] = clamp(trunc(POST_AAQ_REG[i]), -128, 127)`, n = 128 if full_xmem_row else CR15.valid_elements |
+| AAQ | `ACTIVATE`  | `activation_fn, full_xmem_row`                         | `POST_AAQ_REG[0..n-1] = activation_fn(r_acc[i])`, n = 128 if full_xmem_row else CR15.valid_elements |

--- a/src/tools/ipu-as-py/src/ipu_as/gen_docs.py
+++ b/src/tools/ipu-as-py/src/ipu_as/gen_docs.py
@@ -77,6 +77,11 @@ OPERAND_TYPE_DETAILS: dict[str, str] = {
         "**`mask_shift`** remains an **`LrIdx`**."
     ),
     "BreakImmediate": "16-bit value for **`BREAK`** / breakpoint slot conditions.",
+    "FullXmemRow": (
+        "1-bit control flag on **`AAQ`**: **`1`** = always process all **128 lanes** (full XMEM row, "
+        "ignores ``CR15.valid_elements``); **`0`** = process only the first ``CR15.valid_elements`` "
+        "lanes (clamped to 128) and zero the rest. Defaults to **`1`** for backward compatibility."
+    ),
     "Label": (
         "Branch target: a symbolic **`label`** or a relative offset accepted by the cond slot "
         "(e.g. `loop`, `+3`)."

--- a/src/tools/ipu-as-py/src/ipu_as/immediate.py
+++ b/src/tools/ipu-as-py/src/ipu_as/immediate.py
@@ -202,3 +202,31 @@ class PostFnField(ipu_token.EnumToken):
     @classmethod
     def enum_array(cls) -> list[str]:
         return list(POST_FN_NAMES)
+
+
+class FullXmemRowField(ipu_token.IpuToken):
+    """1-bit flag on AAQ: 1=always 128 elements (full row), 0=use CR15.valid_elements."""
+
+    @classmethod
+    def bits(cls) -> int:
+        return 1
+
+    @classmethod
+    def default(cls) -> "ipu_token.IpuToken":
+        return cls(ipu_token.AnnotatedToken(lark.Token("NUMBER", "0"), 0))
+
+    def __init__(self, token: ipu_token.AnnotatedToken):
+        super().__init__(token)
+        try:
+            self.int = int(token.token.value, 0)
+        except ValueError:
+            self._raise_error(f"Value {self.token.value} is not a valid integer")
+        if self.int not in (0, 1):
+            self._raise_error("full_xmem_row must be 0 or 1")
+
+    def encode(self) -> int:
+        return self.int
+
+    @classmethod
+    def decode(cls, value: int) -> str:
+        return str(value & 1)

--- a/src/tools/ipu-as-py/src/ipu_as/inst.py
+++ b/src/tools/ipu-as-py/src/ipu_as/inst.py
@@ -40,6 +40,7 @@ OPERAND_TYPE_MAP: dict[str, type[ipu_token.IpuToken]] = {
     "MultMaskOffsetImmediate": immediate.MultMaskOffsetImmediate,
     "ActivationFn": immediate.ActivationFnField,
     "BreakImmediate": immediate.BreakImmediateType,
+    "FullXmemRow": immediate.FullXmemRowField,
     "Label": ipu_token.LabelToken,
 }
 

--- a/src/tools/ipu-common/src/ipu_common/instruction_spec.py
+++ b/src/tools/ipu-common/src/ipu_common/instruction_spec.py
@@ -687,28 +687,31 @@ INSTRUCTION_SPEC = {
                 {"name": "post_fn", "type": "PostFn"},
                 {"name": "cr_idx", "type": "CrIdx"},
                 {"name": "aaq_rf_idx", "type": "AaqRegIdx"},
+                {"name": "full_xmem_row", "type": "FullXmemRow"},
             ],
             "doc": InstructionDoc(
                 title="Accumulator Aggregate",
                 summary=(
-                    "Collapse R_ACC lanes into one value (SUM or MAX), using CR15.valid_elements "
-                    "lanes; apply post function; store to selected AAQ register."
+                    "Collapse R_ACC lanes into one value (SUM or MAX); apply post function; "
+                    "store to selected AAQ register. "
+                    "``full_xmem_row=1`` always uses 128 lanes; ``full_xmem_row=0`` uses CR15.valid_elements."
                 ),
-                syntax="AGG agg_mode, post_fn, cr_idx, aaq_rf_idx",
+                syntax="AGG agg_mode, post_fn, cr_idx, aaq_rf_idx, full_xmem_row",
                 operands=[
                     "agg_mode: sum or max",
                     "post_fn: value, value_cr, inv, or inv_sqrt",
                     "cr_idx: CR register for value_cr post function (CR0–CR14)",
                     "aaq_rf_idx: AAQ register to store result (AAQ0–AAQ3)",
+                    "full_xmem_row: 1 = always 128 lanes; 0 = use CR15.valid_elements (default 0)",
                 ],
                 operation=(
-                    "Let n = min(CR15.valid_elements, 128), where CR15 is decoded as the dstructure register. "
+                    "Let n = 128 if full_xmem_row else min(CR15.valid_elements, 128). "
                     "If sum: v = sum(R_ACC[0..n-1]). "
                     "If max: v = max(R_ACC[0..n-1], AAQ[aaq_rf_idx]). "
                     "Apply post_fn(v): value→v, value_cr→v*cr[cr_idx], inv→1/v, inv_sqrt→1/sqrt(v). "
                     "AAQ[aaq_rf_idx] = result."
                 ),
-                example="AGG sum, value, CR0, AAQ0;;",
+                example="AGG sum, value, CR0, AAQ0, 0;;",
             ),
             "execute_fn": "execute_agg",
         },
@@ -718,73 +721,86 @@ INSTRUCTION_SPEC = {
                 {"name": "post_fn", "type": "PostFn"},
                 {"name": "cr_idx", "type": "CrIdx"},
                 {"name": "aaq_rf_idx", "type": "AaqRegIdx"},
+                {"name": "full_xmem_row", "type": "FullXmemRow"},
             ],
             "doc": InstructionDoc(
                 title="Accumulator Aggregate First",
-                summary="Like AGG, but for MAX mode ignores the previous AAQ register value, avoiding contamination from uninitialized data.",
-                syntax="AGG.FIRST agg_mode, post_fn, cr_idx, aaq_rf_idx",
+                summary=(
+                    "Like AGG, but for MAX mode ignores the previous AAQ register value, "
+                    "avoiding contamination from uninitialized data. "
+                    "``full_xmem_row=1`` always uses 128 lanes; ``full_xmem_row=0`` uses CR15.valid_elements."
+                ),
+                syntax="AGG.FIRST agg_mode, post_fn, cr_idx, aaq_rf_idx, full_xmem_row",
                 operands=[
                     "agg_mode: sum or max",
                     "post_fn: value, value_cr, inv, or inv_sqrt",
                     "cr_idx: CR register for value_cr post function (CR0–CR14)",
                     "aaq_rf_idx: AAQ register to store result (AAQ0–AAQ3)",
+                    "full_xmem_row: 1 = always 128 lanes; 0 = use CR15.valid_elements (default 0)",
                 ],
                 operation=(
-                    "Let n = min(CR15.valid_elements, 128), where CR15 is decoded as the dstructure register. "
+                    "Let n = 128 if full_xmem_row else min(CR15.valid_elements, 128). "
                     "If sum: v = sum(R_ACC[0..n-1]). "
                     "If max: v = max(R_ACC[0..n-1]) (previous AAQ value is NOT included). "
                     "Apply post_fn(v): value→v, value_cr→v*cr[cr_idx], inv→1/v, inv_sqrt→1/sqrt(v). "
                     "AAQ[aaq_rf_idx] = result."
                 ),
-                example="AGG.FIRST max, value, CR0, AAQ0;;",
+                example="AGG.FIRST max, value, CR0, AAQ0, 0;;",
             ),
             "execute_fn": "execute_agg_first",
         },
         "AAQ": {
-            "operands": [],
+            "operands": [
+                {"name": "full_xmem_row", "type": "FullXmemRow"},
+            ],
             "doc": InstructionDoc(
                 title="AAQ Quantize",
                 summary=(
-                    "Quantize the 128 wide lanes in **`POST_AAQ_REG`** (INT32 per lane in INT8 mode) "
+                    "Quantize wide lanes in **`POST_AAQ_REG`** (INT32 per lane in INT8 mode) "
                     "to INT8, storing clamped bytes in the **leading 128 bytes** of **`POST_AAQ_REG`** "
                     "and clearing the rest of the register. Wide lanes are normally produced by "
-                    "**`ACTIVATE`** (from ``r_acc``). Requires INT8 mode."
+                    "**`ACTIVATE`** (from ``r_acc``). Requires INT8 mode. "
+                    "``full_xmem_row=1`` always processes all 128 lanes; "
+                    "``full_xmem_row=0`` uses ``CR15.valid_elements`` as the active lane count."
                 ),
-                syntax="AAQ",
-                operands=[],
+                syntax="AAQ full_xmem_row",
+                operands=[
+                    "full_xmem_row: 1 = always 128 lanes (full XMEM row); 0 = use CR15.valid_elements lane count",
+                ],
                 operation=(
                     "Requires INT8 mode (IpuState.dtype == DType.INT8 in the Python emulator). "
-                    "For i in [0, 128): POST_AAQ_REG[i] = clamp(trunc(POST_AAQ_REG wide lane i), -128, 127); "
-                    "POST_AAQ_REG[128..511] = 0"
+                    "Let n = 128 if full_xmem_row else min(CR15.valid_elements, 128). "
+                    "For i in [0, n): POST_AAQ_REG[i] = clamp(trunc(POST_AAQ_REG wide lane i), -128, 127). "
+                    "POST_AAQ_REG[n..511] = 0."
                 ),
-                example="AAQ;;",
+                example="AAQ 1;;",
             ),
             "execute_fn": "execute_aaq",
         },
         "ACTIVATE": {
             "operands": [
                 {"name": "activation_fn", "type": "ActivationFn"},
+                {"name": "full_xmem_row", "type": "FullXmemRow"},
             ],
             "doc": InstructionDoc(
                 title="Accumulator Activation",
                 summary=(
-                    "Read each of the first ``CR15.valid_elements`` lanes from ``r_acc``, apply the "
-                    "selected element-wise activation, and write results into the same lane indices "
-                    "of ``POST_AAQ_REG`` (``r_acc`` is unchanged). The activation is "
-                    "selected by keyword (see ACTIVATION_FN_NAMES). Behaviour matches the activation "
-                    "table in the AAQ stage spec (section 7.0). The selector uses four bits; "
-                    "encodings outside the eleven named activations behave as identity. The available "
+                    "Read active lanes from ``r_acc``, apply the selected element-wise activation, "
+                    "and write results into the same lane indices of ``POST_AAQ_REG`` (``r_acc`` is unchanged). "
+                    "``full_xmem_row=1`` always activates all 128 lanes; ``full_xmem_row=0`` uses CR15.valid_elements. "
+                    "The activation is selected by keyword (see ACTIVATION_FN_NAMES). The available "
                     "activation functions are: ``identity`` (0), ``relu`` (1), ``relu6`` (2), "
                     "``sigmoid`` (3), ``tanh`` (4), ``gelu`` (5), ``softplus`` (6), ``elu`` (7), "
                     "``exp2`` (8), ``reciprocal`` (9), ``rsqrt`` (10). For Python emulator calibration (virtual α), see "
                     "docs/content/building-applications.md#activations-emulator."
                 ),
-                syntax="ACTIVATE activation_fn",
+                syntax="ACTIVATE activation_fn, full_xmem_row",
                 operands=[
                     "activation_fn: keyword naming the activation (one of identity, relu, relu6, sigmoid, tanh, gelu, softplus, elu, exp2; see ACTIVATION_FN_NAMES)",
+                    "full_xmem_row: 1 = always 128 lanes; 0 = use CR15.valid_elements (default 0)",
                 ],
                 operation=(
-                    "Let n = min(CR15.valid_elements, 128) (valid_elements from the dstructure register) "
+                    "Let n = 128 if full_xmem_row else min(CR15.valid_elements, 128) "
                     "and k = encoded activation index. "
                     "For i in [0, n): POST_AAQ_REG[i] = activation_k(R_ACC[i]) (same 32-bit lane format as R_ACC). "
                     "R_ACC is not modified. The selector uses four bits; encodings outside the eleven named "
@@ -792,7 +808,7 @@ INSTRUCTION_SPEC = {
                     "α for elu is not an ISA operand; see "
                     "docs/content/building-applications.md#activations-emulator."
                 ),
-                example="ACTIVATE relu;;",
+                example="ACTIVATE relu, 0;;",
             ),
             "execute_fn": "execute_activate",
         },
@@ -1214,6 +1230,7 @@ VALID_OPERAND_TYPES: frozenset[str] = frozenset(
         "BreakImmediate",
         "Label",
         "AddSubSrcB",
+        "FullXmemRow",
     }
 )
 

--- a/src/tools/ipu-common/src/ipu_common/union_layout.py
+++ b/src/tools/ipu-common/src/ipu_common/union_layout.py
@@ -62,6 +62,7 @@ def get_operand_type_bits() -> dict[str, int]:
         "AggMode": _enum_bits(AGG_MODE_NAMES),
         "PostFn": _enum_bits(POST_FN_NAMES),
         "ActivationFn": _enum_bits(ACTIVATION_FN_NAMES),
+        "FullXmemRow": 1,
     }
 
 

--- a/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
@@ -101,6 +101,7 @@ _TYPE_FIELD_SUFFIX = {
     "ActivationFn": "activation_fn_field",
     "BreakImmediate": "break_immediate_type",
     "Label": "label_token",
+    "FullXmemRow": "full_xmem_row_field",
 }
 
 # Field prefix for each slot type (matches compound_inst naming)
@@ -1010,13 +1011,14 @@ class Ipu:
         post_fn: int,
         cr_idx: int,
         aaq_rf_idx: int,
+        full_xmem_row: int,
     ) -> None:
         """Execute AGG: Collapse r_acc words to one value (SUM or MAX), apply post function, store to AAQ.
 
         For MAX, the current value of the target AAQ register is included in the max (no update if already max).
-        Lane count is taken from the CR15 dstructure register.
+        full_xmem_row=1: always use 128 lanes. full_xmem_row=0: lane count from CR15.valid_elements.
         """
-        valid_elements = self.state.get_config_valid_elements()
+        valid_elements = 128 if full_xmem_row else self.state.get_config_valid_elements()
         dtype = self.state.dtype
         fmt = self._acc_agg_lane_fmt()
         acc_buf = self.state.regfile.raw("r_acc")
@@ -1085,12 +1087,13 @@ class Ipu:
         post_fn: int,
         cr_idx: int,
         aaq_rf_idx: int,
+        full_xmem_row: int,
     ) -> None:
         """Execute AGG.FIRST: like AGG but for MAX mode ignores previous AAQ value.
 
-        Lane count is taken from the CR15 dstructure register.
+        full_xmem_row=1: always use 128 lanes. full_xmem_row=0: lane count from CR15.valid_elements.
         """
-        valid_elements = self.state.get_config_valid_elements()
+        valid_elements = 128 if full_xmem_row else self.state.get_config_valid_elements()
         dtype = self.state.dtype
         fmt = self._acc_agg_lane_fmt()
         acc_buf = self.state.regfile.raw("r_acc")
@@ -1149,13 +1152,16 @@ class Ipu:
 
         self.state.regfile.set_aaq(aaq_rf_idx, self._wide_pack_aaq_bits(fmt, result_val))
 
-    def execute_aaq(self) -> None:
+    def execute_aaq(self, *, full_xmem_row: int) -> None:
         """Execute AAQ: Quantize wide lanes in ``POST_AAQ_REG`` (128 × 32-bit) → leading bytes.
 
         Source is the **512-byte** ``post_aaq_reg`` buffer (same lane layout as
-        ``r_acc``), typically filled by ``ACTIVATE``. Each 32-bit lane is truncated
-        then clamped to INT8 and stored in the **first 128 bytes** of
-        ``post_aaq_reg``; the wide-lane tail is cleared.
+        ``r_acc``), typically filled by ``ACTIVATE``. Each active 32-bit lane is
+        truncated then clamped to INT8 and stored in the leading bytes of
+        ``post_aaq_reg``; the remainder is zeroed.
+
+        ``full_xmem_row=1``: always process all 128 lanes.
+        ``full_xmem_row=0``: process only ``CR15.valid_elements`` lanes (clamped to 128).
 
         Requires INT8 mode.
 
@@ -1167,18 +1173,22 @@ class Ipu:
         if dtype != DType.INT8:
             raise EmulatorError("AAQ instruction requires INT8 mode")
 
+        active = 128 if full_xmem_row else self._agg_active_lane_count(
+            self.state.get_config_valid_elements()
+        )
+
         if self._wide_vector_active():
             if not self.state.wide_vector_quantize_output:
                 return
             src_buf = self.state.regfile.raw("post_aaq_reg")
             result = bytearray(128)
             if self.state.wide_vector_arithmetic == WideVectorArithmetic.FP32:
-                for i in range(128):
+                for i in range(active):
                     val = struct.unpack_from("<f", src_buf, i * 4)[0]
                     clamped = max(-128, min(127, int(round(val))))
                     result[i] = clamped & 0xFF
             else:
-                for i in range(128):
+                for i in range(active):
                     val = struct.unpack_from("<i", src_buf, i * 4)[0]
                     truncated = val >> 24
                     clamped = max(-128, min(127, truncated))
@@ -1188,15 +1198,15 @@ class Ipu:
 
         src_buf = self.state.regfile.raw("post_aaq_reg")
         result = bytearray(128)
-        for i in range(128):
+        for i in range(active):
             val = struct.unpack_from("<i", src_buf, i * 4)[0]
             truncated = val >> 24  # arithmetic right-shift: keeps top 8 bits, range [-128, 127]
             clamped = max(-128, min(127, truncated))
             result[i] = clamped & 0xFF
         self.state.regfile.set_post_aaq_reg(result + bytearray(384))
 
-    def execute_activate(self, *, activation_fn: int) -> None:
-        """Apply element-wise activation to CR15.valid_elements lanes.
+    def execute_activate(self, *, activation_fn: int, full_xmem_row: int) -> None:
+        """Apply element-wise activation to active lanes.
 
         Reads each active lane from ``r_acc`` and writes the result into the same
         lane of ``post_aaq_reg`` (512-byte wide staging). ``r_acc`` is not modified.
@@ -1204,10 +1214,10 @@ class Ipu:
         unchanged.
 
         ``activation_fn`` is the encoded enum index (0–8) from the instruction word.
-        Active lane count is taken from the CR15 dstructure register.
+        full_xmem_row=1: always use 128 lanes. full_xmem_row=0: lane count from CR15.valid_elements.
         """
         fn_id = int(activation_fn) & REGISTER_WORD_VALUE_MASK
-        valid_elements = self.state.get_config_valid_elements()
+        valid_elements = 128 if full_xmem_row else self.state.get_config_valid_elements()
         active = self._agg_active_lane_count(valid_elements)
         fmt = self._acc_agg_lane_fmt()
         acc_buf = self.state.regfile.raw("r_acc")

--- a/src/tools/ipu-emu-py/test/test_execute.py
+++ b/src/tools/ipu-emu-py/test/test_execute.py
@@ -909,7 +909,7 @@ BKPT;;
 
         state = _make_state(
             """\
-agg sum value cr0 aaq0;;
+agg sum value cr0 aaq0 0;;
 BKPT;;
 """
         )
@@ -930,7 +930,7 @@ BKPT;;
 
         state = _make_state(
             """\
-agg max value cr0 aaq1;;
+agg max value cr0 aaq1 0;;
 BKPT;;
 """
         )
@@ -950,7 +950,7 @@ BKPT;;
 
         state = _make_state(
             """\
-agg max value cr0 aaq0;;
+agg max value cr0 aaq0 0;;
 BKPT;;
 """
         )
@@ -970,7 +970,7 @@ BKPT;;
 
         state = _make_state(
             """\
-agg sum value_cr cr2 aaq2;;
+agg sum value_cr cr2 aaq2 0;;
 BKPT;;
 """
         )
@@ -991,7 +991,7 @@ BKPT;;
 
         state = _make_state(
             """\
-agg.first max value cr0 aaq0;;
+agg.first max value cr0 aaq0 0;;
 BKPT;;
 """
         )
@@ -1012,7 +1012,7 @@ BKPT;;
 
         state = _make_state(
             """\
-agg.first max value cr0 aaq1;;
+agg.first max value cr0 aaq1 0;;
 BKPT;;
 """
         )
@@ -1032,7 +1032,7 @@ BKPT;;
 
         state = _make_state(
             """\
-agg.first sum value cr0 aaq2;;
+agg.first sum value cr0 aaq2 0;;
 BKPT;;
 """
         )
@@ -1052,7 +1052,7 @@ BKPT;;
 
         state = _make_state(
             """\
-agg sum value cr0 aaq0;;
+agg sum value cr0 aaq0 0;;
 BKPT;;
 """
         )
@@ -1071,7 +1071,7 @@ BKPT;;
 
         state = _make_state(
             """\
-agg sum value cr0 aaq0;;
+agg sum value cr0 aaq0 0;;
 BKPT;;
 """
         )
@@ -1090,7 +1090,7 @@ BKPT;;
 
         state = _make_state(
             """\
-agg max value cr0 aaq0;;
+agg max value cr0 aaq0 0;;
 BKPT;;
 """
         )
@@ -1109,7 +1109,7 @@ BKPT;;
 
         state = _make_state(
             """\
-agg.first max value cr0 aaq0;;
+agg.first max value cr0 aaq0 0;;
 BKPT;;
 """
         )
@@ -1121,6 +1121,78 @@ BKPT;;
         state.regfile.set_aaq(0, struct.unpack("<I", struct.pack("<i", 0))[0])
         run_until_complete(state)
         assert state.regfile.get_aaq(0) == struct.unpack("<I", struct.pack("<i", 3))[0]
+
+    def test_agg_full_xmem_row_1_ignores_valid_elements(self):
+        """agg full_xmem_row=1: uses all 128 lanes even when CR15.valid_elements < 128."""
+        import struct
+
+        state = _make_state(
+            """\
+agg sum value cr0 aaq0 1;;
+BKPT;;
+"""
+        )
+        state.dtype = DType.INT8
+        state.set_cr_dstructure(valid_elements=4)
+        for i in range(128):
+            state.regfile.set_r_acc_word(i, struct.unpack("<I", struct.pack("<i", 1))[0])
+        run_until_complete(state)
+        result = struct.unpack("<i", struct.pack("<I", state.regfile.get_aaq(0)))[0]
+        assert result == 128, f"expected sum of all 128 lanes = 128, got {result}"
+
+    def test_agg_full_xmem_row_0_uses_valid_elements(self):
+        """agg full_xmem_row=0: uses only CR15.valid_elements lanes."""
+        import struct
+
+        state = _make_state(
+            """\
+agg sum value cr0 aaq0 0;;
+BKPT;;
+"""
+        )
+        state.dtype = DType.INT8
+        state.set_cr_dstructure(valid_elements=4)
+        for i in range(128):
+            state.regfile.set_r_acc_word(i, struct.unpack("<I", struct.pack("<i", 1))[0])
+        run_until_complete(state)
+        result = struct.unpack("<i", struct.pack("<I", state.regfile.get_aaq(0)))[0]
+        assert result == 4, f"expected sum of 4 lanes = 4, got {result}"
+
+    def test_agg_first_full_xmem_row_1_ignores_valid_elements(self):
+        """agg.first full_xmem_row=1: uses all 128 lanes even when CR15.valid_elements < 128."""
+        import struct
+
+        state = _make_state(
+            """\
+agg.first sum value cr0 aaq1 1;;
+BKPT;;
+"""
+        )
+        state.dtype = DType.INT8
+        state.set_cr_dstructure(valid_elements=4)
+        for i in range(128):
+            state.regfile.set_r_acc_word(i, struct.unpack("<I", struct.pack("<i", 1))[0])
+        run_until_complete(state)
+        result = struct.unpack("<i", struct.pack("<I", state.regfile.get_aaq(1)))[0]
+        assert result == 128, f"expected sum of all 128 lanes = 128, got {result}"
+
+    def test_agg_first_full_xmem_row_0_uses_valid_elements(self):
+        """agg.first full_xmem_row=0: uses only CR15.valid_elements lanes."""
+        import struct
+
+        state = _make_state(
+            """\
+agg.first sum value cr0 aaq1 0;;
+BKPT;;
+"""
+        )
+        state.dtype = DType.INT8
+        state.set_cr_dstructure(valid_elements=4)
+        for i in range(128):
+            state.regfile.set_r_acc_word(i, struct.unpack("<I", struct.pack("<i", 1))[0])
+        run_until_complete(state)
+        result = struct.unpack("<i", struct.pack("<I", state.regfile.get_aaq(1)))[0]
+        assert result == 4, f"expected sum of 4 lanes = 4, got {result}"
 
 
 # ============================================================================
@@ -1785,7 +1857,7 @@ class TestAaqQuantize:
         state.dtype = DType.INT8
         self._set_acc_words(state, [i << 24 for i in range(128)])
 
-        encoded = assemble("aaq;;\nBKPT;;")
+        encoded = assemble("aaq 0;;\nBKPT;;")
         from ipu_emu.execute import decode_instruction_word
         from ipu_emu.emulator import load_program, run_until_complete
         decoded = [decode_instruction_word(w) for w in encoded]
@@ -1804,7 +1876,7 @@ class TestAaqQuantize:
         state.dtype = DType.INT8
         self._set_acc_words(state, [0] * 128)
 
-        encoded = assemble("aaq;;\nBKPT;;")
+        encoded = assemble("aaq 0;;\nBKPT;;")
         from ipu_emu.execute import decode_instruction_word
         from ipu_emu.emulator import load_program, run_until_complete
         decoded = [decode_instruction_word(w) for w in encoded]
@@ -1822,7 +1894,7 @@ class TestAaqQuantize:
         values = [0x7F000000] * 64 + [0x7FFFFFFF] * 64
         self._set_acc_words(state, values)
 
-        encoded = assemble("aaq;;\nBKPT;;")
+        encoded = assemble("aaq 0;;\nBKPT;;")
         from ipu_emu.execute import decode_instruction_word
         from ipu_emu.emulator import load_program, run_until_complete
         decoded = [decode_instruction_word(w) for w in encoded]
@@ -1843,7 +1915,7 @@ class TestAaqQuantize:
         state.dtype = DType.INT8
         self._set_acc_words(state, [(-1) << 24] * 128)
 
-        encoded = assemble("aaq;;\nBKPT;;")
+        encoded = assemble("aaq 0;;\nBKPT;;")
         from ipu_emu.execute import decode_instruction_word
         from ipu_emu.emulator import load_program, run_until_complete
         decoded = [decode_instruction_word(w) for w in encoded]
@@ -1858,10 +1930,46 @@ class TestAaqQuantize:
     def test_aaq_requires_int8_mode(self):
         """aaq raises EmulatorError when not in INT8 mode."""
         from ipu_emu.ipu import EmulatorError
-        state = _make_state("aaq;;\nBKPT;;")
+        state = _make_state("aaq 0;;\nBKPT;;")
         state.dtype = DType.E4
         with pytest.raises(EmulatorError, match="INT8 mode"):
             run_until_complete(state)
+
+    def test_aaq_full_xmem_row_1_ignores_valid_elements(self):
+        """full_xmem_row=1 always quantizes all 128 lanes even if CR15.valid_elements < 128."""
+        state = IpuState()
+        state.dtype = DType.INT8
+        state.set_cr_dstructure(valid_elements=64)
+        self._set_acc_words(state, [1 << 24] * 128)
+
+        encoded = assemble("aaq 1;;\nBKPT;;")
+        from ipu_emu.execute import decode_instruction_word
+        from ipu_emu.emulator import load_program, run_until_complete
+        decoded = [decode_instruction_word(w) for w in encoded]
+        load_program(state, decoded)
+        run_until_complete(state)
+
+        result = state.regfile.get_post_aaq_reg()
+        assert result[:128] == bytearray([1] * 128), "all 128 lanes should be quantized"
+        assert result[128:] == bytearray(384)
+
+    def test_aaq_full_xmem_row_0_uses_valid_elements(self):
+        """full_xmem_row=0 quantizes only CR15.valid_elements lanes; rest are zeroed."""
+        state = IpuState()
+        state.dtype = DType.INT8
+        state.set_cr_dstructure(valid_elements=48)
+        self._set_acc_words(state, [1 << 24] * 128)
+
+        encoded = assemble("aaq 0;;\nBKPT;;")
+        from ipu_emu.execute import decode_instruction_word
+        from ipu_emu.emulator import load_program, run_until_complete
+        decoded = [decode_instruction_word(w) for w in encoded]
+        load_program(state, decoded)
+        run_until_complete(state)
+
+        result = state.regfile.get_post_aaq_reg()
+        assert result[:48] == bytearray([1] * 48), "first 48 lanes should be quantized"
+        assert result[48:] == bytearray(464), "remaining bytes should be zero"
 
     def test_str_post_aaq_reg_writes_post_aaq_reg_512_to_xmem(self):
         """STR_POST_AAQ_REG stores POST_AAQ_REG (512 B) to XMEM."""
@@ -1924,7 +2032,7 @@ class TestActivate:
     def test_activate_relu_int32(self):
         state = _make_state(
             """\
-ACTIVATE relu;;
+ACTIVATE relu 0;;
 BKPT;;
 """
         )
@@ -1943,7 +2051,7 @@ BKPT;;
     def test_activate_masks_inactive_lanes(self):
         state = _make_state(
             """\
-ACTIVATE relu;;
+ACTIVATE relu 0;;
 BKPT;;
 """
         )
@@ -1981,7 +2089,7 @@ BKPT;;
     def test_activate_identity_keyword_is_noop(self):
         state = _make_state(
             """\
-ACTIVATE identity;;
+ACTIVATE identity 0;;
 BKPT;;
 """
         )
@@ -1996,7 +2104,7 @@ BKPT;;
     def test_activate_sigmoid_float_lane(self):
         state = _make_state(
             """\
-ACTIVATE sigmoid;;
+ACTIVATE sigmoid 0;;
 BKPT;;
 """
         )
@@ -2014,7 +2122,7 @@ BKPT;;
         for fid, name in enumerate(ACTIVATION_FN_NAMES):
             state = _make_state(
                 f"""\
-ACTIVATE {name};;
+ACTIVATE {name} 0;;
 BKPT;;
 """
             )
@@ -2031,7 +2139,7 @@ BKPT;;
     def test_activate_exp2_float(self):
         state = _make_state(
             """\
-ACTIVATE exp2;;
+ACTIVATE exp2 0;;
 BKPT;;
 """
         )
@@ -2047,7 +2155,7 @@ BKPT;;
     def test_activate_gelu_float(self):
         state = _make_state(
             """\
-ACTIVATE gelu;;
+ACTIVATE gelu 0;;
 BKPT;;
 """
         )
@@ -2067,7 +2175,7 @@ BKPT;;
         alpha = 0.5
         state = _make_state(
             """\
-ACTIVATE elu;;
+ACTIVATE elu 0;;
 BKPT;;
 """,
             elu_alpha=alpha,
@@ -2087,7 +2195,7 @@ BKPT;;
         alpha = 0.125
         state = _make_state(
             """\
-ACTIVATE elu;;
+ACTIVATE elu 0;;
 BKPT;;
 """
         )
@@ -2105,7 +2213,7 @@ BKPT;;
     def test_activate_valid_elements_from_cr15(self):
         state = _make_state(
             """\
-ACTIVATE relu;;
+ACTIVATE relu 0;;
 BKPT;;
 """
         )
@@ -2128,7 +2236,7 @@ BKPT;;
     def test_activate_reciprocal_float(self):
         state = _make_state(
             """\
-ACTIVATE reciprocal;;
+ACTIVATE reciprocal 0;;
 BKPT;;
 """
         )
@@ -2145,7 +2253,7 @@ BKPT;;
     def test_activate_reciprocal_zero_input(self):
         state = _make_state(
             """\
-ACTIVATE reciprocal;;
+ACTIVATE reciprocal 0;;
 BKPT;;
 """
         )
@@ -2161,7 +2269,7 @@ BKPT;;
     def test_activate_rsqrt_float(self):
         state = _make_state(
             """\
-ACTIVATE rsqrt;;
+ACTIVATE rsqrt 0;;
 BKPT;;
 """
         )
@@ -2178,7 +2286,7 @@ BKPT;;
     def test_activate_rsqrt_nonpositive_input(self):
         state = _make_state(
             """\
-ACTIVATE rsqrt;;
+ACTIVATE rsqrt 0;;
 BKPT;;
 """
         )
@@ -2190,3 +2298,37 @@ BKPT;;
         run_until_complete(state)
         out = _post_aaq_lane_f32(state, 0)
         assert out == 0.0
+
+    def test_activate_full_xmem_row_1_ignores_valid_elements(self):
+        """ACTIVATE full_xmem_row=1: activates all 128 lanes even when CR15.valid_elements < 128."""
+        state = _make_state(
+            """\
+ACTIVATE relu 1;;
+BKPT;;
+"""
+        )
+        state.dtype = DType.INT8
+        state.set_cr_dstructure(valid_elements=4)
+        for i in range(128):
+            state.regfile.set_r_acc_word(i, struct.unpack("<I", struct.pack("<i", i + 1))[0])
+        run_until_complete(state)
+        for i in range(128):
+            assert _post_aaq_lane_i32(state, i) == i + 1, f"lane {i} should be activated"
+
+    def test_activate_full_xmem_row_0_uses_valid_elements(self):
+        """ACTIVATE full_xmem_row=0: activates only CR15.valid_elements lanes; rest unchanged."""
+        state = _make_state(
+            """\
+ACTIVATE relu 0;;
+BKPT;;
+"""
+        )
+        state.dtype = DType.INT8
+        state.set_cr_dstructure(valid_elements=4)
+        for i in range(128):
+            state.regfile.set_r_acc_word(i, struct.unpack("<I", struct.pack("<i", i + 1))[0])
+        run_until_complete(state)
+        for i in range(4):
+            assert _post_aaq_lane_i32(state, i) == i + 1, f"lane {i} should be activated"
+        for i in range(4, 128):
+            assert _post_aaq_lane_i32(state, i) == 0, f"lane {i} should be untouched (zero)"

--- a/src/tools/ipu-emu-py/test/test_wide_vector_debug.py
+++ b/src/tools/ipu-emu-py/test/test_wide_vector_debug.py
@@ -86,8 +86,8 @@ RESET_ACC;;
 MULT.EE r0 lr2 0 lr2;;
 acc.first;;
 SET lr0 cr9;;
-ACTIVATE identity;;
-aaq;;
+ACTIVATE identity 0;;
+aaq 0;;
 BKPT;;
 """,
             cr={6: 0x1000, 7: 0x2000, 8: 0, 9: 128},
@@ -116,8 +116,8 @@ RESET_ACC;;
 MULT.EE r0 lr2 0 lr2;;
 acc.first;;
 SET lr0 cr9;;
-ACTIVATE identity;;
-aaq;;
+ACTIVATE identity 0;;
+aaq 0;;
 BKPT;;
 """
         state.regfile.set_cr(6, 0x1000)
@@ -361,7 +361,7 @@ class TestWideVectorAggInt32:
         st.regfile.set_r_acc_bytes(acc)
         st.set_cr_dstructure(128)
         asm = """\
-agg sum inv cr0 aaq0;;
+agg sum inv cr0 aaq0 0;;
 BKPT;;
 """
         encoded = assemble(asm)


### PR DESCRIPTION
- Introduced FullXmemRow as a 1-bit control flag for instructions AGG, AGG.FIRST, AAQ, and ACTIVATE.
- Updated instruction specifications to reflect the new operand, detailing its behavior for lane processing.
- Enhanced the immediate handling with FullXmemRowField class to validate and encode the flag.
- Modified the Ipu class methods to utilize the FullXmemRow flag for determining active lane counts.
- Updated tests to cover scenarios for both FullXmemRow=1 (always 128 lanes) and FullXmemRow=0 (uses CR15.valid_elements).
- Adjusted documentation strings and comments to clarify the new functionality and its implications.