### PR TITLE
Plan: RISC-V host integration (SystemRDL control regfile + Unicorn + Rust firmware)

### DIFF
--- a/docs/content/specs/riscv-host-integration.md
+++ b/docs/content/specs/riscv-host-integration.md
@@ -1,0 +1,321 @@
+# RISC-V Host Integration (Design Spec)
+
+!!! note "Status"
+    **Proposal / design spec.** This page describes a planned *big feature*: an
+    emulated RISC-V host core that drives the IPU emulator through a
+    memory-mapped control register block. The register block is the single
+    source of truth (authored in **SystemRDL**), and is the same definition
+    used by the Python emulator, the on-device **Rust** driver, and the
+    generated documentation. The implementation is tracked as an epic and a
+    set of sub-issues — see [§9 Implementation Plan](#9-implementation-plan).
+
+## 1. Motivation
+
+Today the Python emulator is driven *directly* from Python: a test or app
+harness builds an `IpuState`, loads a program, sets `CR` registers, and calls
+`run_until_complete()`. The real hardware works differently — the
+[Control Stage spec](stage-control.md) and the
+[Cache Unit spec](cache-unit.md) both describe an **external RISC-V host** that
+configures and sequences the IPU over an **APB** slave port: it writes the
+instruction memory and the `CR` file (inactive banks), triggers bank swaps,
+starts/stops the core, and reads back status.
+
+This feature closes the gap between the emulator and the hardware model by:
+
+1. **Emulating the host CPU itself.** A RISC-V core (via the
+   [Unicorn](https://www.unicorn-engine.org/) CPU-emulation framework, embedded
+   in the Python environment) runs the same firmware that would run on real
+   silicon.
+2. **Defining a real control/configuration register block** that both the host
+   firmware and the IPU emulator agree on, authored once in **SystemRDL** so
+   that the Python model, the Rust driver, and the docs are all generated from
+   one source.
+3. **Driving IPU execution through that register block** — start, halt,
+   single-step, reprogram instruction memory, read/write the program counter,
+   and reset — instead of via ad-hoc Python calls.
+
+The end state: an integration test loads a **Rust** firmware image into the
+emulated RISC-V core; the firmware configures the IPU (CRs, dtype, dstructure),
+streams a program into instruction memory, starts the IPU, polls for
+completion, and reads back results — all through MMIO, exactly as it would on
+hardware.
+
+## 2. Goals and Non-Goals
+
+### Goals
+
+- A memory-mapped **IPU host-control register block** authored in SystemRDL.
+- All current configuration surface reachable through the register block:
+  `dtype`, `dstructure` (`valid_elements` / `partition`), `CR2`–`CR14`
+  application constants, and the activation `elu_alpha`.
+- Execution-flow control through the register block:
+    1. **Start** execution.
+    2. **Halt** execution.
+    3. **Reprogram** the IPU instruction memory.
+    4. **Read and write** the program counter.
+    5. **Reset** the IPU (resets everything *except* instruction memory).
+- A RISC-V core emulated in-process via Unicorn, with the register block exposed
+  as MMIO.
+- **Rust** (not C) firmware/driver running on the emulated core, generated from
+  the same SystemRDL source.
+- Single source of truth preserved: no hand-duplicated register metadata.
+
+### Non-Goals (for the initial epic)
+
+- Cycle-accurate co-simulation of host ↔ IPU timing. The host/IPU handshake is
+  functional, not cycle-accurate.
+- Modeling the full APB wire protocol (`psel`/`penable`/`pready` handshakes).
+  We model the *register semantics* the APB slave exposes, addressed as a flat
+  MMIO window; APB timing is out of scope.
+- DMA / CRM cache-unit modeling (see [cache-unit.md](cache-unit.md)). The
+  control block focuses on CTRL-stage configuration and sequencing.
+- Replacing the existing direct-Python harness. `run_until_complete()` and the
+  debug CLI keep working; the host path is additive.
+
+## 3. Architecture Overview
+
+```mermaid
+%%{init: {'flowchart': {'defaultRenderer': 'elk'}}}%%
+flowchart LR
+    subgraph RUST["Rust firmware (no_std)"]
+        FW["application firmware\n(main loop)"]:::purple
+        DRV["ipu-pac\n(generated register driver)"]:::purple
+    end
+
+    subgraph UC["Unicorn RISC-V core (in Python)"]
+        CPU["rv32 / rv64 CPU"]:::teal
+        RAM["code + data + stack RAM"]:::teal
+        MMIO["MMIO window\n(IPU control block)"]:::teal
+    end
+
+    subgraph PY["Python IPU emulator"]
+        BRIDGE["MMIO bridge\n(read/write callbacks)"]:::blue
+        CTRLMODEL["host-control register model\n(generated from SystemRDL)"]:::blue
+        ENGINE["steppable execution engine"]:::blue
+        STATE["IpuState\n(regfile, xmem, PC, inst_mem)"]:::blue
+    end
+
+    RDL["ipu_ctrl.rdl\n(SystemRDL — source of truth)"]:::yellow
+
+    FW --> DRV
+    DRV -->|"lw / sw to MMIO"| CPU
+    CPU --> RAM
+    CPU --> MMIO
+    MMIO -->|read/write callback| BRIDGE
+    BRIDGE --> CTRLMODEL
+    CTRLMODEL -->|"start / halt / step / reset / imem / pc"| ENGINE
+    ENGINE --> STATE
+    CTRLMODEL -.->|"config: dtype, dstructure, CR2-14"| STATE
+
+    RDL -. "peakrdl: Python field constants" .-> CTRLMODEL
+    RDL -. "peakrdl: Rust driver crate" .-> DRV
+    RDL -. "peakrdl-html: docs" .-> DOCS["register-map docs"]:::yellow
+
+    classDef blue fill:#4a80c4,stroke:#2a5090,color:#fff
+    classDef teal fill:#2e9e8c,stroke:#1a7060,color:#fff
+    classDef purple fill:#7b5ea7,stroke:#5a3d8a,color:#fff
+    classDef yellow fill:#e6b800,stroke:#b38a00,color:#000
+```
+
+Data flow for a typical run:
+
+1. The Rust firmware image is loaded into the Unicorn core's RAM; execution
+   starts at the firmware reset vector.
+2. The firmware uses the generated driver to write config registers (dtype,
+   dstructure, `CR2`–`CR14`), then streams the assembled IPU program into the
+   instruction-memory programming port.
+3. The firmware writes `CTRL.START`. The MMIO write callback bridges into the
+   Python execution engine, which runs the IPU program (functionally) and
+   latches `STATUS.HALTED` (plus cycle count / error fields).
+4. The firmware polls `STATUS`, then reads back results from XMEM (or via
+   read-back registers), and the integration test asserts on the final
+   `IpuState`.
+
+## 4. The IPU Host-Control Register Block
+
+The register block models what the CTRL-stage **APB slave** exposes to the
+host. It is addressed as a flat 32-bit MMIO window. Offsets below are a
+**proposed** starting layout — the authoritative layout lives in the SystemRDL
+source delivered by [Issue 1](#9-implementation-plan).
+
+| Offset  | Name          | Access | Description |
+|---------|---------------|--------|-------------|
+| `0x000` | `ID`          | RO     | Magic + version of the control block (sanity check for firmware). |
+| `0x004` | `CTRL`        | RW/W1S | Command bits: `START`, `HALT`, `STEP`, `RESET` (soft, excludes IMEM), `IMEM_SWAP` (bank swap), `CONTINUE`. Self-clearing pulse semantics. |
+| `0x008` | `STATUS`      | RO     | `RUNNING`, `HALTED`, `BREAK` (hit a `BKPT`/`BREAK`), `ERROR`, plus an `ERR_CODE` field. |
+| `0x00C` | `PC`          | RW     | Program counter. Read returns the current PC; write sets the next PC (only valid while halted). |
+| `0x010` | `CYCLES`      | RO     | Cycles executed since the last start/reset. |
+| `0x014` | `MAX_CYCLES`  | RW     | Watchdog limit; `0` = use engine default. Guards against runaway programs. |
+| `0x020` | `DTYPE`       | RW     | Arithmetic data type selector (enum mirroring `DType`). |
+| `0x024` | `DSTRUCTURE`  | RW     | `valid_elements[7:0]`, `partition[11:8]` — mirrors `CR15`. |
+| `0x028` | `ELU_ALPHA`   | RW     | Activation α (IEEE-754 float bits; emulator-only knob). |
+| `0x040` | `CR[0..15]`   | RW\*   | Application config window. `CR0`/`CR1` are hard-wired (`0`/`1`) and reject writes (`ERROR`); `CR15` aliases `DSTRUCTURE`. `CR2`–`CR14` are writable. |
+| `0x080` | `IMEM_ADDR`   | RW     | Instruction-memory word index for the programming port. Optional auto-increment. |
+| `0x084` | `IMEM_WDATA`  | WO     | Write port. A VLIW word is wider than 32 bits, so N sequential writes assemble one decoded instruction; the engine decodes and commits on the final sub-word. |
+| `0x088` | `IMEM_RDATA`  | RO     | Read-back of the addressed instruction word (sub-word streamed). |
+| `0x08C` | `IMEM_CTRL`   | RW     | Programming controls: begin/commit, auto-increment enable, clear-imem, program length. |
+
+Notes:
+
+- **Instruction-memory width.** A compound (VLIW) instruction is word-aligned to
+  32 bits but spans several 32-bit sub-words (see `CompoundInst.bits()` /
+  `_instruction_aligned_bytes()`). The programming port accepts raw encoded
+  32-bit sub-words — the same byte stream the assembler emits with
+  `--format bin` — and the engine decodes them with `decode_instruction_word`
+  before storing into `inst_mem`. This keeps the host-side contract identical to
+  the existing binary format.
+- **Banking.** Hardware double-buffers IMEM and CR (`IMEM_BANKS = 2`,
+  `CR_BANKS = 2`); the host writes the *inactive* bank and swaps. The initial
+  emulator model MAY collapse this to a single bank and treat `IMEM_SWAP` as a
+  commit barrier; full double-buffering can follow.
+
+## 5. Execution-Flow Control Semantics
+
+The control block drives a **steppable execution engine** (see
+[Issue 3](#9-implementation-plan)). The five required operations map to register
+actions as follows.
+
+| Operation | Register action | Engine semantics |
+|-----------|-----------------|------------------|
+| **Start execution** | write `CTRL.START` | Run from the current `PC` until halt, breakpoint, or `MAX_CYCLES`. Sets `STATUS.RUNNING`, then `STATUS.HALTED` on completion. |
+| **Halt execution** | write `CTRL.HALT` | Stop the engine at an instruction boundary; clear `RUNNING`, set `HALTED`. Cooperative when the run is driven inside the MMIO callback; preemptive when driven step-by-step. |
+| **Single step** | write `CTRL.STEP` | Execute exactly one VLIW cycle, then re-enter halted state. Mirrors the existing debug-CLI `step`. |
+| **Reprogram IMEM** | `IMEM_ADDR` + `IMEM_WDATA` + `IMEM_CTRL` | Stream raw encoded words into instruction memory while halted; decode + store into `inst_mem`. |
+| **Read PC** | read `PC` | Returns `IpuState.program_counter`. |
+| **Write PC** | write `PC` | Sets `IpuState.program_counter` (only honored while halted; otherwise `ERROR`). |
+| **Reset** | write `CTRL.RESET` | Resets **everything except instruction memory** (see below). |
+
+### Reset semantics
+
+`CTRL.RESET` performs a **soft reset that preserves `inst_mem`**:
+
+- **Reset:** register file (re-init to defaults — `CR0=0`, `CR1=1`, default
+  `dstructure`), `R_ACC`/`R`/AAQ/post-AAQ staging, `program_counter → 0`,
+  `stats`/`CYCLES`, `STATUS` flags, and XMEM contents.
+- **Preserved:** `inst_mem` (the loaded program) and the program length.
+
+This matches the user requirement ("resets everything but the instruction
+memory") and lets firmware re-run the same program with fresh inputs without
+re-streaming it.
+
+### Decoupling the run loop
+
+The current `run_until_complete()` owns the loop and the halt condition
+(`PC >= INST_MEM_SIZE`). To support host-driven start/halt/step, the engine is
+refactored so a single primitive — "execute one VLIW cycle and report
+`RUNNING`/`HALTED`/`BREAK`" — can be called either in a tight Python loop (today's
+behavior, unchanged) or one step at a time from the MMIO bridge. `is_halted`,
+breakpoints, and `RunStats` are folded into the engine's reported status.
+
+## 6. SystemRDL as the Single Source of Truth
+
+Consistent with the project's existing philosophy (`instruction_spec.py` and
+`registers.py` are single sources of truth), the host-control register block is
+authored **once** in SystemRDL (`ipu_ctrl.rdl`) and all consumers are generated
+from it via the open-source [PeakRDL](https://peakrdl.readthedocs.io/) toolchain:
+
+| Consumer | Generated artifact | Tooling |
+|----------|--------------------|---------|
+| Python emulator | Field offsets / masks / enums (control-register model) | `peakrdl-python` *or* a small custom exporter walking the `systemrdl-compiler` IR |
+| Rust firmware | A PAC-like register-access crate (`ipu-pac`) | `peakrdl` → SVD → `svd2rust`, *or* a custom Rust template over the same IR |
+| Documentation | Register-map HTML / Markdown | `peakrdl-html` (linked from these docs) |
+
+!!! tip "Why a custom IR walker is a strong default for Rust"
+    RDL→SVD→`svd2rust` is the most "standard" Rust path, but the RDL→SVD step
+    relies on community exporters of varying completeness. Because
+    `systemrdl-compiler` exposes a clean Python IR, a small Jinja template that
+    emits both the Python constants *and* a `no_std` Rust module from that same
+    IR keeps the two perfectly in lock-step with the least fragile tooling.
+    [Issue 1](#9-implementation-plan) evaluates both and picks one.
+
+All generation runs under Bazel so the build stays hermetic; generated files are
+build outputs, never hand-edited.
+
+## 7. Emulating the RISC-V Host with Unicorn
+
+[Unicorn](https://www.unicorn-engine.org/) exposes a CPU-only emulator with a
+Python binding (`pip install unicorn`) and a RISC-V backend
+(`UC_ARCH_RISCV`, `UC_MODE_RISCV32` / `UC_MODE_RISCV64`). Integration sketch:
+
+```python
+from unicorn import Uc, UC_ARCH_RISCV, UC_MODE_RISCV32
+from unicorn.riscv_const import UC_RISCV_REG_PC
+
+RAM_BASE,  RAM_SIZE  = 0x8000_0000, 0x0010_0000   # firmware code + data + stack
+MMIO_BASE, MMIO_SIZE = 0x1000_0000, 0x0000_1000   # IPU control block
+
+uc = Uc(UC_ARCH_RISCV, UC_MODE_RISCV32)
+uc.mem_map(RAM_BASE, RAM_SIZE)
+uc.mem_write(RAM_BASE, firmware_image)
+
+# Bridge MMIO accesses into the Python control-register model.
+uc.mmio_map(MMIO_BASE, MMIO_SIZE, read_cb=bridge.on_read, write_cb=bridge.on_write)
+
+uc.reg_write(UC_RISCV_REG_PC, RAM_BASE)
+uc.emu_start(RAM_BASE, RAM_BASE + len(firmware_image))
+```
+
+- `bridge.on_write` decodes the offset against the generated register map,
+  applies the side effect to the control-register model (which may drive the IPU
+  engine — e.g. a `START` write runs the program), and latches status.
+- `bridge.on_read` returns the current register value (e.g. `STATUS`, `PC`,
+  read-back data).
+- The IPU "runs" functionally inside the `START`/`STEP` write callback; from the
+  firmware's point of view the store simply takes a while and `STATUS.HALTED` is
+  set when control returns. This keeps the model simple and deterministic
+  without threads.
+
+The firmware is built for a bare-metal target (e.g.
+`riscv32imac-unknown-none-elf`), linked to the `RAM_BASE` layout, and converted
+to a flat binary for loading.
+
+## 8. Rust Firmware and Driver
+
+The on-device code is **Rust**, `no_std`:
+
+- **`ipu-pac`** — generated register-access crate (volatile reads/writes,
+  typed fields/enums) produced from `ipu_ctrl.rdl` (see §6).
+- **`ipu-rt`** — a thin hand-written HAL on top of `ipu-pac` exposing ergonomic
+  operations: `configure(dtype, dstructure, crs)`, `load_program(words)`,
+  `start()`, `wait_until_halted()`, `read_pc()`, `write_pc()`, `reset()`.
+- **`firmware`** — an example `no_std` binary with a `main` that mirrors the
+  fully-connected app flow: configure → load program → start → wait → done.
+
+Build via `rules_rust` under Bazel, targeting the bare-metal RISC-V triple, and
+emit a flat binary artifact consumed by the integration harness.
+
+## 9. Implementation Plan
+
+The work is tracked as an **epic** plus focused sub-issues. Drafts of every
+issue live under `planning/riscv-host-integration/` in this repository and are
+ready to file.
+
+| # | Issue | Summary |
+|---|-------|---------|
+| 0 | **Epic** | Umbrella tracking issue: emulated RISC-V host drives the IPU through a SystemRDL-defined control register block. |
+| 1 | SystemRDL control-register block + codegen | Author `ipu_ctrl.rdl`; wire PeakRDL into Bazel; generate Python constants, the Rust `ipu-pac` crate, and HTML docs. |
+| 2 | Emulator MMIO control-register model | Map the generated register block onto `IpuState`: config (dtype/dstructure/CR2-14/α) + execution control (start/halt/step/reset/imem/PC). |
+| 3 | Steppable execution engine | Refactor the run loop into a host-drivable engine that reports `RUNNING`/`HALTED`/`BREAK`, with soft-reset (preserving IMEM) and PC R/W. |
+| 4 | Unicorn RISC-V integration | Embed Unicorn; map firmware RAM + the IPU MMIO window; bridge MMIO callbacks to the control-register model. |
+| 5 | Rust firmware + driver | `ipu-rt` HAL over generated `ipu-pac`; example `no_std` firmware; `rules_rust` bare-metal build to a flat binary. |
+| 6 | End-to-end integration + app + tests + docs | Firmware-driven run of an existing app (e.g. fully-connected); tests asserting parity with the direct-Python path; user-facing docs. |
+
+Suggested dependency order: **1 → {2, 3} → 4 → 5 → 6**. Issues 2 and 3 can
+proceed in parallel once the register map (1) is fixed.
+
+## 10. Open Questions / Risks
+
+- **RV32 vs RV64.** RV32IMAC is the smaller, more typical embedded host; RV64 is
+  also supported by Unicorn. Pick in Issue 4/5; the driver is width-agnostic.
+- **Rust register codegen path.** RDL→SVD→`svd2rust` vs a custom IR template
+  (see §6). Resolved in Issue 1 with a small spike.
+- **Run-inside-callback vs cooperative stepping.** Running the whole IPU program
+  inside a single `START` store is simplest and deterministic; a cooperative
+  model (firmware polls while the IPU steps) is more realistic but needs care to
+  avoid re-entrancy. Issue 3/4 decide; the register contract supports both.
+- **Bazel toolchains.** Adds `rules_rust` + a bare-metal RISC-V toolchain and the
+  `unicorn` / `peakrdl*` Python deps. These are new build dependencies and the
+  Cloud Agent environment will need them provisioned.
+- **Double-buffered banking.** Initial model may use a single bank; full
+  `IMEM_BANKS`/`CR_BANKS` double-buffering with host-triggered swaps can be a
+  follow-up.

--- a/docs/content/specs/riscv-host-integration.md
+++ b/docs/content/specs/riscv-host-integration.md
@@ -36,9 +36,9 @@ This feature closes the gap between the emulator and the hardware model by:
 
 The end state: an integration test loads a **Rust** firmware image into the
 emulated RISC-V core; the firmware configures the IPU (CRs, dtype, dstructure),
-streams a program into instruction memory, starts the IPU, polls for
-completion, and reads back results — all through MMIO, exactly as it would on
-hardware.
+loads a program into the fully mapped instruction-memory region, starts the IPU,
+polls for completion, and reads back results — all through MMIO, exactly as it
+would on hardware.
 
 ## 2. Goals and Non-Goals
 
@@ -122,8 +122,8 @@ Data flow for a typical run:
 1. The Rust firmware image is loaded into the Unicorn core's RAM; execution
    starts at the firmware reset vector.
 2. The firmware uses the generated driver to write config registers (dtype,
-   dstructure, `CR2`–`CR14`), then streams the assembled IPU program into the
-   instruction-memory programming port.
+   dstructure, `CR2`–`CR14`), then copies the assembled IPU program into the
+   fully mapped instruction-memory region (while halted).
 3. The firmware writes `CTRL.START`. The MMIO write callback bridges into the
    Python execution engine, which runs the IPU program (functionally) and
    latches `STATUS.HALTED` (plus cycle count / error fields).
@@ -146,28 +146,49 @@ source delivered by [Issue 1](#9-implementation-plan).
 | `0x00C` | `PC`          | RW     | Program counter. Read returns the current PC; write sets the next PC (only valid while halted). |
 | `0x010` | `CYCLES`      | RO     | Cycles executed since the last start/reset. |
 | `0x014` | `MAX_CYCLES`  | RW     | Watchdog limit; `0` = use engine default. Guards against runaway programs. |
+| `0x018` | `PROG_LEN`    | RW     | Program length in VLIW words (entries in `inst_mem`). Writable only while halted; used by the engine halt condition (`PC >= PROG_LEN`). |
 | `0x020` | `DTYPE`       | RW     | Arithmetic data type selector (enum mirroring `DType`). |
 | `0x024` | `DSTRUCTURE`  | RW     | `valid_elements[7:0]`, `partition[11:8]` — mirrors `CR15`. |
 | `0x028` | `ELU_ALPHA`   | RW     | Activation α (IEEE-754 float bits; emulator-only knob). |
 | `0x040` | `CR[0..15]`   | RW\*   | Application config window. `CR0`/`CR1` are hard-wired (`0`/`1`) and reject writes (`ERROR`); `CR15` aliases `DSTRUCTURE`. `CR2`–`CR14` are writable. |
-| `0x080` | `IMEM_ADDR`   | RW     | Instruction-memory word index for the programming port. Optional auto-increment. |
-| `0x084` | `IMEM_WDATA`  | WO     | Write port. A VLIW word is wider than 32 bits, so N sequential writes assemble one decoded instruction; the engine decodes and commits on the final sub-word. |
-| `0x088` | `IMEM_RDATA`  | RO     | Read-back of the addressed instruction word (sub-word streamed). |
-| `0x08C` | `IMEM_CTRL`   | RW     | Programming controls: begin/commit, auto-increment enable, clear-imem, program length. |
 
-Notes:
+The control block occupies the first **4 KiB** of the host MMIO window. Instruction
+memory is **not** accessed through indirect programming registers; it is a
+separate, fully mapped region in the host address space (see below).
 
-- **Instruction-memory width.** A compound (VLIW) instruction is word-aligned to
-  32 bits but spans several 32-bit sub-words (see `CompoundInst.bits()` /
-  `_instruction_aligned_bytes()`). The programming port accepts raw encoded
-  32-bit sub-words — the same byte stream the assembler emits with
-  `--format bin` — and the engine decodes them with `decode_instruction_word`
-  before storing into `inst_mem`. This keeps the host-side contract identical to
-  the existing binary format.
+### Instruction memory (fully mapped)
+
+| Host address (example) | Size | Access | Description |
+|------------------------|------|--------|-------------|
+| `IMEM_BASE` (`0x1001_0000`) | `IMEM_MAP_SIZE` | RW\* | Flat, byte-addressable instruction-memory image. |
+
+- **`IMEM_MAP_SIZE`** = `IMEM_DEPTH × INSTRUCTION_ALIGNED_BYTES`, where
+  `INSTRUCTION_ALIGNED_BYTES` is the per-instruction size of the assembler
+  `--format bin` stream (see `instruction_aligned_bytes_len()` /
+  `_instruction_aligned_bytes()`). The emulator uses `INST_MEM_SIZE` (1024) for
+  `IMEM_DEPTH`; hardware uses `IMEM_DEPTH = 256` per
+  [stage-control.md](stage-control.md) — the SystemRDL parameter drives the
+  generated map size.
+- **Contents.** The mapped region is a verbatim image of the assembled binary:
+  each VLIW occupies `INSTRUCTION_ALIGNED_BYTES` bytes, 32-bit-word-aligned. On
+  **write**, the bridge decodes the affected instruction word(s) with
+  `decode_instruction_word` and updates `inst_mem` (same semantics as
+  `load_program_from_binary`). On **read**, the bridge returns the stored encoded
+  bytes (unprogrammed slots read as zero).
+- **Halt-only access.** Instruction memory is **not** reachable while the IPU is
+  executing. Any read or write to `[IMEM_BASE, IMEM_BASE + IMEM_MAP_SIZE)` when
+  `STATUS.RUNNING` is set must **fail**: latch `STATUS.ERROR`, set
+  `ERR_CODE = IMEM_ACCESS_WHILE_RUNNING`, and return a bus error to the host
+  (Unicorn: failed MMIO callback; hardware: `apb_pslverr`). While halted (and on
+  initial power-up before the first `START`), IMEM is freely readable and
+  writable. This matches the hardware rule that the host programs only the
+  *inactive* IMEM bank and never contends with the execute pipeline.
 - **Banking.** Hardware double-buffers IMEM and CR (`IMEM_BANKS = 2`,
-  `CR_BANKS = 2`); the host writes the *inactive* bank and swaps. The initial
-  emulator model MAY collapse this to a single bank and treat `IMEM_SWAP` as a
-  commit barrier; full double-buffering can follow.
+  `CR_BANKS = 2`); the host maps/writes the *inactive* bank and swaps via
+  `IMEM_SWAP`. The initial emulator model MAY collapse this to a single bank
+  (one `IMEM_BASE` region) and treat `IMEM_SWAP` as a no-op or commit barrier;
+  full double-buffering adds a second `IMEM_BASE` offset or bank-select bit in
+  `CTRL`.
 
 ## 5. Execution-Flow Control Semantics
 
@@ -180,7 +201,7 @@ actions as follows.
 | **Start execution** | write `CTRL.START` | Run from the current `PC` until halt, breakpoint, or `MAX_CYCLES`. Sets `STATUS.RUNNING`, then `STATUS.HALTED` on completion. |
 | **Halt execution** | write `CTRL.HALT` | Stop the engine at an instruction boundary; clear `RUNNING`, set `HALTED`. Cooperative when the run is driven inside the MMIO callback; preemptive when driven step-by-step. |
 | **Single step** | write `CTRL.STEP` | Execute exactly one VLIW cycle, then re-enter halted state. Mirrors the existing debug-CLI `step`. |
-| **Reprogram IMEM** | `IMEM_ADDR` + `IMEM_WDATA` + `IMEM_CTRL` | Stream raw encoded words into instruction memory while halted; decode + store into `inst_mem`. |
+| **Reprogram IMEM** | read/write `IMEM_BASE` region (+ `PROG_LEN`) | Copy or memset the assembled `--format bin` image into the mapped IMEM window while halted; writes decode into `inst_mem`. Set `PROG_LEN` to the number of VLIW words. Rejected with `ERROR` while `RUNNING`. |
 | **Read PC** | read `PC` | Returns `IpuState.program_counter`. |
 | **Write PC** | write `PC` | Sets `IpuState.program_counter` (only honored while halted; otherwise `ERROR`). |
 | **Reset** | write `CTRL.RESET` | Resets **everything except instruction memory** (see below). |
@@ -192,7 +213,8 @@ actions as follows.
 - **Reset:** register file (re-init to defaults — `CR0=0`, `CR1=1`, default
   `dstructure`), `R_ACC`/`R`/AAQ/post-AAQ staging, `program_counter → 0`,
   `stats`/`CYCLES`, `STATUS` flags, and XMEM contents.
-- **Preserved:** `inst_mem` (the loaded program) and the program length.
+- **Preserved:** `inst_mem` (the loaded program), the IMEM map contents, and
+  `PROG_LEN`.
 
 This matches the user requirement ("resets everything but the instruction
 memory") and lets firmware re-run the same program with fresh inputs without
@@ -242,24 +264,27 @@ from unicorn import Uc, UC_ARCH_RISCV, UC_MODE_RISCV32
 from unicorn.riscv_const import UC_RISCV_REG_PC
 
 RAM_BASE,  RAM_SIZE  = 0x8000_0000, 0x0010_0000   # firmware code + data + stack
-MMIO_BASE, MMIO_SIZE = 0x1000_0000, 0x0000_1000   # IPU control block
+MMIO_BASE, MMIO_SIZE = 0x1000_0000, 0x0000_1000   # IPU control registers
+IMEM_BASE, IMEM_SIZE = 0x1001_0000, IMEM_MAP_SIZE # fully mapped instruction memory
 
 uc = Uc(UC_ARCH_RISCV, UC_MODE_RISCV32)
 uc.mem_map(RAM_BASE, RAM_SIZE)
 uc.mem_write(RAM_BASE, firmware_image)
 
-# Bridge MMIO accesses into the Python control-register model.
-uc.mmio_map(MMIO_BASE, MMIO_SIZE, read_cb=bridge.on_read, write_cb=bridge.on_write)
+# Bridge MMIO: control registers + halt-gated IMEM map.
+uc.mmio_map(MMIO_BASE, MMIO_SIZE, read_cb=bridge.on_ctrl_read, write_cb=bridge.on_ctrl_write)
+uc.mmio_map(IMEM_BASE, IMEM_SIZE, read_cb=bridge.on_imem_read, write_cb=bridge.on_imem_write)
 
 uc.reg_write(UC_RISCV_REG_PC, RAM_BASE)
 uc.emu_start(RAM_BASE, RAM_BASE + len(firmware_image))
 ```
 
-- `bridge.on_write` decodes the offset against the generated register map,
-  applies the side effect to the control-register model (which may drive the IPU
-  engine — e.g. a `START` write runs the program), and latches status.
-- `bridge.on_read` returns the current register value (e.g. `STATUS`, `PC`,
-  read-back data).
+- `bridge.on_ctrl_read` / `on_ctrl_write` decode offsets against the generated
+  register map, apply side effects (e.g. a `START` write runs the program), and
+  latch status.
+- `bridge.on_imem_read` / `on_imem_write` perform byte/word accesses into the
+  IMEM map. If `STATUS.RUNNING`, they reject the access (`ERROR`,
+  `IMEM_ACCESS_WHILE_RUNNING`) without modifying `inst_mem`.
 - The IPU "runs" functionally inside the `START`/`STEP` write callback; from the
   firmware's point of view the store simply takes a while and `STATUS.HALTED` is
   set when control returns. This keeps the model simple and deterministic
@@ -276,7 +301,7 @@ The on-device code is **Rust**, `no_std`:
 - **`ipu-pac`** — generated register-access crate (volatile reads/writes,
   typed fields/enums) produced from `ipu_ctrl.rdl` (see §6).
 - **`ipu-rt`** — a thin hand-written HAL on top of `ipu-pac` exposing ergonomic
-  operations: `configure(dtype, dstructure, crs)`, `load_program(words)`,
+  operations: `configure(dtype, dstructure, crs)`, `load_program(ptr, len)`,
   `start()`, `wait_until_halted()`, `read_pc()`, `write_pc()`, `reset()`.
 - **`firmware`** — an example `no_std` binary with a `main` that mirrors the
   fully-connected app flow: configure → load program → start → wait → done.
@@ -294,7 +319,7 @@ ready to file.
 |---|-------|---------|
 | 0 | **Epic** | Umbrella tracking issue: emulated RISC-V host drives the IPU through a SystemRDL-defined control register block. |
 | 1 | SystemRDL control-register block + codegen | Author `ipu_ctrl.rdl`; wire PeakRDL into Bazel; generate Python constants, the Rust `ipu-pac` crate, and HTML docs. |
-| 2 | Emulator MMIO control-register model | Map the generated register block onto `IpuState`: config (dtype/dstructure/CR2-14/α) + execution control (start/halt/step/reset/imem/PC). |
+| 2 | Emulator MMIO control-register model | Map the generated register block onto `IpuState`: config (dtype/dstructure/CR2-14/α) + execution control (start/halt/step/reset/PC) + halt-gated fully mapped IMEM. |
 | 3 | Steppable execution engine | Refactor the run loop into a host-drivable engine that reports `RUNNING`/`HALTED`/`BREAK`, with soft-reset (preserving IMEM) and PC R/W. |
 | 4 | Unicorn RISC-V integration | Embed Unicorn; map firmware RAM + the IPU MMIO window; bridge MMIO callbacks to the control-register model. |
 | 5 | Rust firmware + driver | `ipu-rt` HAL over generated `ipu-pac`; example `no_std` firmware; `rules_rust` bare-metal build to a flat binary. |

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -79,6 +79,7 @@ nav:
       - Cache Unit Specification: specs/cache-unit.md
       - AAQ Stage Specification: specs/stage-aaq.md
       - Control Stage Specification: specs/stage-control.md
+      - RISC-V Host Integration: specs/riscv-host-integration.md
   - Release Log: release-log.md
 markdown_extensions:
   - admonition

--- a/planning/riscv-host-integration/00-epic.md
+++ b/planning/riscv-host-integration/00-epic.md
@@ -1,0 +1,72 @@
+# Epic: Emulated RISC-V host drives the IPU via a SystemRDL control register block
+
+## Goal
+
+Introduce an emulated **RISC-V host core** (via the [Unicorn](https://www.unicorn-engine.org/)
+framework, embedded in the Python environment) that configures and sequences the
+IPU emulator through a **memory-mapped control/configuration register block**.
+The register block is authored once in **SystemRDL** and is the single source of
+truth for the Python emulator model, the on-device **Rust** driver, and the
+generated documentation.
+
+This realizes, in the emulator, the host model already described in the
+[Control Stage spec](../../docs/content/specs/stage-control.md) and the
+[Cache Unit spec](../../docs/content/specs/cache-unit.md): an external RISC-V host
+that configures the IPU, programs instruction memory, and starts/stops the core
+over a host bus.
+
+The full design is captured in
+[`docs/content/specs/riscv-host-integration.md`](../../docs/content/specs/riscv-host-integration.md).
+
+## Scope
+
+The register block must expose **all current configuration** plus the execution
+controls below.
+
+Configuration (parity with today's Python harness):
+
+- `dtype` (arithmetic data type)
+- `dstructure` (`valid_elements` + `partition`, i.e. `CR15`)
+- `CR2`–`CR14` application constants
+- activation `elu_alpha`
+
+Execution-flow control:
+
+1. **Start** execution
+2. **Halt** execution
+3. **Reprogram** the IPU instruction memory
+4. **Read and write** the program counter
+5. **Reset** the IPU — resets everything **except** instruction memory
+
+## Constraints
+
+- **Single source of truth.** No hand-duplicated register metadata; everything
+  generated from the SystemRDL source (consistent with `instruction_spec.py` /
+  `registers.py`).
+- **Rust, not C**, for the on-device driver/firmware.
+- The existing direct-Python path (`run_until_complete`, debug CLI, app
+  harnesses) must keep working — the host path is additive.
+- Builds stay hermetic under Bazel.
+
+## Sub-issues
+
+- [ ] #1 — Define the IPU host-control register block in SystemRDL + codegen
+- [ ] #2 — Emulator MMIO control-register model mapped onto `IpuState`
+- [ ] #3 — Refactor the run loop into a host-drivable, steppable execution engine
+- [ ] #4 — Integrate an emulated RISC-V core (Unicorn) with the IPU MMIO bridge
+- [ ] #5 — Rust `no_std` firmware + generated driver for the IPU host
+- [ ] #6 — End-to-end firmware-driven app run, parity tests, and docs
+
+Dependency order: **1 → {2, 3} → 4 → 5 → 6**.
+
+## Acceptance Criteria
+
+- [ ] A SystemRDL register block is the single source for Python, Rust, and docs.
+- [ ] A Rust `no_std` firmware image, running on an emulated RISC-V core, can
+      configure the IPU, stream a program into instruction memory, start it, poll
+      for completion, read/write the PC, and reset it — all over MMIO.
+- [ ] An end-to-end test runs an existing app (e.g. fully-connected) through the
+      host path and asserts identical results to the direct-Python path.
+- [ ] All new build dependencies (`rules_rust` + bare-metal RISC-V toolchain,
+      `unicorn`, `peakrdl*`) are wired into Bazel, and `bazel test //...` passes.
+- [ ] User-facing docs describe the host path and register map.

--- a/planning/riscv-host-integration/00-epic.md
+++ b/planning/riscv-host-integration/00-epic.md
@@ -63,7 +63,8 @@ Dependency order: **1 → {2, 3} → 4 → 5 → 6**.
 
 - [ ] A SystemRDL register block is the single source for Python, Rust, and docs.
 - [ ] A Rust `no_std` firmware image, running on an emulated RISC-V core, can
-      configure the IPU, stream a program into instruction memory, start it, poll
+      configure the IPU, load a program into the mapped instruction memory, start
+      it, poll
       for completion, read/write the PC, and reset it — all over MMIO.
 - [ ] An end-to-end test runs an existing app (e.g. fully-connected) through the
       host path and asserts identical results to the direct-Python path.

--- a/planning/riscv-host-integration/01-systemrdl-regfile.md
+++ b/planning/riscv-host-integration/01-systemrdl-regfile.md
@@ -23,10 +23,11 @@ Final offsets/fields are owned by the `.rdl` file.
 - `ID` (RO) — magic + version
 - `CTRL` (RW/W1S) — `START`, `HALT`, `STEP`, `RESET`, `IMEM_SWAP`, `CONTINUE`
 - `STATUS` (RO) — `RUNNING`, `HALTED`, `BREAK`, `ERROR`, `ERR_CODE`
-- `PC` (RW), `CYCLES` (RO), `MAX_CYCLES` (RW)
+- `PC` (RW), `CYCLES` (RO), `MAX_CYCLES` (RW), `PROG_LEN` (RW, halted only)
 - `DTYPE` (RW), `DSTRUCTURE` (RW), `ELU_ALPHA` (RW)
 - `CR[0..15]` (RW\*; `CR0`/`CR1` hard-wired, `CR15` aliases `DSTRUCTURE`)
-- `IMEM_ADDR` (RW), `IMEM_WDATA` (WO), `IMEM_RDATA` (RO), `IMEM_CTRL` (RW)
+- **`IMEM` memory region** — fully mapped at `IMEM_BASE`, size
+  `IMEM_DEPTH × INSTRUCTION_ALIGNED_BYTES` (not indirect addr/data ports)
 
 ## Implementation
 

--- a/planning/riscv-host-integration/01-systemrdl-regfile.md
+++ b/planning/riscv-host-integration/01-systemrdl-regfile.md
@@ -1,0 +1,67 @@
+# Define the IPU host-control register block in SystemRDL + codegen
+
+Part of the [RISC-V host integration epic](00-epic.md).
+
+## Goal
+
+Author the IPU **host-control / configuration register block** in **SystemRDL**
+(`ipu_ctrl.rdl`) as the single source of truth, and wire the
+[PeakRDL](https://peakrdl.readthedocs.io/) toolchain into Bazel to generate:
+
+1. Python field offsets / masks / enums for the emulator control model (Issue #2).
+2. A PAC-like **Rust** register-access crate (`ipu-pac`) for the firmware (Issue #5).
+3. Register-map documentation (HTML/Markdown) linked from the docs site.
+
+No consumer hand-duplicates register metadata.
+
+## Register map (starting point)
+
+Implements the layout proposed in
+[`specs/riscv-host-integration.md` §4](../../docs/content/specs/riscv-host-integration.md).
+Final offsets/fields are owned by the `.rdl` file.
+
+- `ID` (RO) — magic + version
+- `CTRL` (RW/W1S) — `START`, `HALT`, `STEP`, `RESET`, `IMEM_SWAP`, `CONTINUE`
+- `STATUS` (RO) — `RUNNING`, `HALTED`, `BREAK`, `ERROR`, `ERR_CODE`
+- `PC` (RW), `CYCLES` (RO), `MAX_CYCLES` (RW)
+- `DTYPE` (RW), `DSTRUCTURE` (RW), `ELU_ALPHA` (RW)
+- `CR[0..15]` (RW\*; `CR0`/`CR1` hard-wired, `CR15` aliases `DSTRUCTURE`)
+- `IMEM_ADDR` (RW), `IMEM_WDATA` (WO), `IMEM_RDATA` (RO), `IMEM_CTRL` (RW)
+
+## Implementation
+
+- Add `src/hw/ipu_ctrl.rdl` (or `src/tools/ipu-ctrl-rdl/`) with the register block.
+- Add a Bazel rule wrapping PeakRDL exporters so generation is hermetic:
+  - Python: `peakrdl-python` **or** a small custom exporter over the
+    `systemrdl-compiler` IR (decide via a short spike — see note below).
+  - Rust: RDL→SVD→`svd2rust` **or** a custom Jinja Rust template over the same IR.
+  - Docs: `peakrdl-html`.
+- Add `peakrdl`, `peakrdl-html`, and any exporter packages to the relevant
+  `pyproject.toml`; regenerate the requirements lock.
+
+> **Spike (Rust path):** RDL→SVD→`svd2rust` is the most "standard" Rust route but
+> the RDL→SVD exporter quality varies. Since `systemrdl-compiler` exposes a clean
+> Python IR, a single Jinja template emitting *both* the Python constants and a
+> `no_std` Rust module from that IR may be the least-fragile option. Pick one and
+> document the choice.
+
+## Docs
+
+- Link the generated register-map page from the docs nav.
+- Cross-reference [`specs/riscv-host-integration.md`](../../docs/content/specs/riscv-host-integration.md)
+  and [`specs/stage-control.md`](../../docs/content/specs/stage-control.md).
+
+## Tests
+
+- [ ] `bazel build` generates Python, Rust, and docs artifacts from `ipu_ctrl.rdl`.
+- [ ] A test asserts the generated Python field offsets/masks match the `.rdl`
+      (e.g. `CTRL.START` bit position, `DSTRUCTURE` field layout).
+- [ ] Generated Rust crate compiles for the bare-metal RISC-V target.
+
+## Acceptance Criteria
+
+- [ ] `ipu_ctrl.rdl` exists and is the single source for all register metadata.
+- [ ] PeakRDL generation is wired into Bazel and hermetic.
+- [ ] Python, Rust, and HTML artifacts all generate from the one source.
+- [ ] Rust-codegen path chosen and documented.
+- [ ] `bazel test //...` passes with the new dependencies.

--- a/planning/riscv-host-integration/02-emulator-mmio-model.md
+++ b/planning/riscv-host-integration/02-emulator-mmio-model.md
@@ -23,9 +23,11 @@ wraps an `IpuState` (and the steppable engine from #3) and offers:
   - **Execution** — `CTRL.START/HALT/STEP/RESET/CONTINUE` drive the engine (#3);
     `PC` read/write maps to `state.program_counter` (writes honored only while
     halted); `STATUS`/`CYCLES` reflect engine state.
-  - **IMEM** — `IMEM_ADDR`/`IMEM_WDATA`/`IMEM_CTRL` accept raw encoded 32-bit
-    sub-words, assemble full VLIW words, decode via `decode_instruction_word`, and
-    write into `inst_mem`. Read-back via `IMEM_RDATA`.
+  - **IMEM** — byte/word accesses to the fully mapped `[IMEM_BASE, IMEM_BASE +
+    IMEM_MAP_SIZE)` region. Writes decode into `inst_mem` (same as
+    `load_program_from_binary`); reads return the encoded image. **Reject** all
+    IMEM accesses while `STATUS.RUNNING` (`ERROR`, `IMEM_ACCESS_WHILE_RUNNING`).
+    `PROG_LEN` sets the active program length.
 
 ### Reset semantics
 
@@ -44,10 +46,11 @@ XMEM, set `PC=0`, clear stats/cycles, and preserve the loaded program + length.
 - [ ] Writing `DTYPE`/`DSTRUCTURE`/`ELU_ALPHA`/`CR[n]` produces the same
       `IpuState` as the equivalent direct-Python setup.
 - [ ] Writing to `CR0`/`CR1` sets `STATUS.ERROR` and leaves them unchanged.
-- [ ] Streaming an assembled program through the IMEM port yields `inst_mem`
-      identical to `load_program_from_binary`.
+- [ ] Writing an assembled `--format bin` image into the IMEM map yields
+      `inst_mem` identical to `load_program_from_binary`.
+- [ ] IMEM read/write while `RUNNING` sets `ERROR` and does not modify state.
 - [ ] `CTRL.RESET` clears state but preserves `inst_mem`; a re-run reproduces
-      results without re-streaming the program.
+      results without reloading the program image.
 - [ ] `PC` read/write round-trips; writes while `RUNNING` are rejected.
 
 ## Acceptance Criteria

--- a/planning/riscv-host-integration/02-emulator-mmio-model.md
+++ b/planning/riscv-host-integration/02-emulator-mmio-model.md
@@ -1,0 +1,58 @@
+# Emulator MMIO control-register model mapped onto `IpuState`
+
+Part of the [RISC-V host integration epic](00-epic.md). Depends on #1.
+
+## Goal
+
+Implement a Python **control-register model** that interprets reads/writes to the
+generated register block (#1) and applies them to an `IpuState`, covering both
+configuration and execution control. This is the bridge target that the Unicorn
+MMIO callbacks (#4) will call.
+
+## Implementation
+
+Add a module (e.g. `ipu_emu/host_ctrl.py`) exposing an `IpuHostController` that
+wraps an `IpuState` (and the steppable engine from #3) and offers:
+
+- `read(offset) -> int` and `write(offset, value)` decoded against the generated
+  register map (no magic numbers — import offsets/masks from the #1 artifacts).
+- Side effects per register:
+  - **Config** — `DTYPE` → `state.dtype`; `DSTRUCTURE` → `state.set_cr_dstructure`;
+    `ELU_ALPHA` → `state.set_activation_alphas`; `CR[n]` → `regfile.set_cr`
+    (rejecting `CR0`/`CR1`, aliasing `CR15` to `DSTRUCTURE`, raising `ERROR`).
+  - **Execution** — `CTRL.START/HALT/STEP/RESET/CONTINUE` drive the engine (#3);
+    `PC` read/write maps to `state.program_counter` (writes honored only while
+    halted); `STATUS`/`CYCLES` reflect engine state.
+  - **IMEM** — `IMEM_ADDR`/`IMEM_WDATA`/`IMEM_CTRL` accept raw encoded 32-bit
+    sub-words, assemble full VLIW words, decode via `decode_instruction_word`, and
+    write into `inst_mem`. Read-back via `IMEM_RDATA`.
+
+### Reset semantics
+
+`CTRL.RESET` must reset **everything except `inst_mem`**: re-init the register
+file (`CR0=0`, `CR1=1`, default dstructure), clear `R_ACC`/`R`/AAQ/post-AAQ and
+XMEM, set `PC=0`, clear stats/cycles, and preserve the loaded program + length.
+
+## Docs
+
+- Document the register semantics and reset behavior in
+  [`specs/riscv-host-integration.md`](../../docs/content/specs/riscv-host-integration.md)
+  (already drafted) — keep it in sync with the final field set.
+
+## Tests
+
+- [ ] Writing `DTYPE`/`DSTRUCTURE`/`ELU_ALPHA`/`CR[n]` produces the same
+      `IpuState` as the equivalent direct-Python setup.
+- [ ] Writing to `CR0`/`CR1` sets `STATUS.ERROR` and leaves them unchanged.
+- [ ] Streaming an assembled program through the IMEM port yields `inst_mem`
+      identical to `load_program_from_binary`.
+- [ ] `CTRL.RESET` clears state but preserves `inst_mem`; a re-run reproduces
+      results without re-streaming the program.
+- [ ] `PC` read/write round-trips; writes while `RUNNING` are rejected.
+
+## Acceptance Criteria
+
+- [ ] All config + execution controls reachable purely through `read`/`write`.
+- [ ] Offsets/masks imported from #1 artifacts (no duplication).
+- [ ] Reset preserves only instruction memory.
+- [ ] Unit tests pass under `bazel test`.

--- a/planning/riscv-host-integration/03-steppable-engine.md
+++ b/planning/riscv-host-integration/03-steppable-engine.md
@@ -1,0 +1,53 @@
+# Refactor the run loop into a host-drivable, steppable execution engine
+
+Part of the [RISC-V host integration epic](00-epic.md). Can proceed in parallel with #2.
+
+## Goal
+
+Decouple IPU execution from the monolithic `run_until_complete()` loop so the
+host-control model (#2) can **start, halt, single-step, and reset** the IPU and
+**read/write the PC**, while the existing direct-Python path keeps working
+unchanged.
+
+## Background
+
+Today `emulator.run_until_complete()` owns the loop and the halt condition
+(`PC >= INST_MEM_SIZE`), and `run_with_debug()` layers breakpoints on top. There
+is no externally drivable "advance one cycle and tell me the status" primitive.
+
+## Implementation
+
+- Introduce an engine abstraction (e.g. `ipu_emu/engine.py`) over `IpuState`
+  with:
+  - `step() -> RunStatus` — execute exactly one VLIW cycle; report
+    `RUNNING` / `HALTED` / `BREAK`.
+  - `run(max_cycles) -> RunStatus` — loop `step()` until halt/break/limit
+    (this is what `run_until_complete`/`run_with_debug` become, preserving
+    current behavior).
+  - `halt()` — request a cooperative stop at the next instruction boundary.
+  - `reset(preserve_imem=True)` — soft reset (see #2 reset semantics).
+  - `get_pc()` / `set_pc(value)` — PC read/write (set honored only when halted).
+  - status surface: `running`, `halted`, `break_hit`, `cycles`, `error`.
+- Re-express `run_until_complete()` / `run_with_debug()` in terms of the engine
+  so behavior and tests are unchanged.
+- Fold `RunStats` cycle counting and `is_halted` into the engine status.
+
+## Docs
+
+- Note the engine API in the spec and (briefly) in `debugging.md` since
+  single-step mirrors the debug-CLI `step`.
+
+## Tests
+
+- [ ] `run()` reproduces `run_until_complete` results across existing programs.
+- [ ] `step()` advances exactly one cycle and updates PC/cycles/status.
+- [ ] `halt()` stops at an instruction boundary; `run()` can resume.
+- [ ] `reset(preserve_imem=True)` clears state but keeps `inst_mem`.
+- [ ] `set_pc` while running is rejected; while halted it takes effect.
+- [ ] No regressions: `bazel test //src/tools/ipu-emu-py/...` and app tests pass.
+
+## Acceptance Criteria
+
+- [ ] A steppable, host-drivable engine exists with start/halt/step/reset/PC R-W.
+- [ ] Existing run/debug APIs are thin wrappers over it (no behavior change).
+- [ ] Full test suite passes.

--- a/planning/riscv-host-integration/04-unicorn-riscv.md
+++ b/planning/riscv-host-integration/04-unicorn-riscv.md
@@ -1,0 +1,53 @@
+# Integrate an emulated RISC-V core (Unicorn) with the IPU MMIO bridge
+
+Part of the [RISC-V host integration epic](00-epic.md). Depends on #1, #2, #3.
+
+## Goal
+
+Embed an emulated **RISC-V** core in the Python environment using
+[Unicorn](https://www.unicorn-engine.org/), expose the IPU host-control register
+block (#1/#2) as an **MMIO** window, and bridge Unicorn's memory callbacks into
+the control-register model so firmware running on the core can drive the IPU.
+
+## Implementation
+
+- Add the `unicorn` Python package to the relevant `pyproject.toml`; regenerate
+  the requirements lock; confirm the RISC-V backend is available
+  (`UC_ARCH_RISCV`, `UC_MODE_RISCV32`/`RISCV64`).
+- Add a host module (e.g. `ipu_emu/riscv_host.py`) that:
+  - Creates a `Uc` instance, maps a **RAM** region for firmware code/data/stack,
+    and `mmio_map`s the IPU control window.
+  - Routes MMIO `read`/`write` callbacks to `IpuHostController` (#2).
+  - Loads a flat firmware binary, sets the reset PC, and runs via `emu_start`.
+- Define the address map (RAM base/size, MMIO base/size) and keep it consistent
+  with the firmware linker layout (#5).
+- **Execution model:** run the IPU functionally inside the `START`/`STEP` write
+  callback (deterministic, no threads). Document the alternative cooperative
+  model and why it was deferred (see spec §10).
+
+```python
+uc = Uc(UC_ARCH_RISCV, UC_MODE_RISCV32)
+uc.mem_map(RAM_BASE, RAM_SIZE)
+uc.mem_write(RAM_BASE, firmware_image)
+uc.mmio_map(MMIO_BASE, MMIO_SIZE, read_cb=bridge.on_read, write_cb=bridge.on_write)
+uc.reg_write(UC_RISCV_REG_PC, RAM_BASE)
+uc.emu_start(RAM_BASE, RAM_BASE + len(firmware_image))
+```
+
+## Docs
+
+- Document the Unicorn integration and address map in the spec.
+
+## Tests
+
+- [ ] A minimal RISC-V test stub (hand-written words or a tiny assembled blob)
+      that does `sw` to `STATUS`/`CR` offsets triggers the expected control-model
+      side effects through the MMIO bridge.
+- [ ] Reads of `STATUS`/`PC`/`ID` return the correct values to the core.
+- [ ] `bazel test //...` passes with `unicorn` available.
+
+## Acceptance Criteria
+
+- [ ] Unicorn RISC-V core boots in-process and reaches the firmware entry.
+- [ ] MMIO reads/writes are correctly bridged to the control-register model.
+- [ ] The IPU runs to halt in response to a `CTRL.START` store from the core.

--- a/planning/riscv-host-integration/04-unicorn-riscv.md
+++ b/planning/riscv-host-integration/04-unicorn-riscv.md
@@ -19,8 +19,9 @@ the control-register model so firmware running on the core can drive the IPU.
     and `mmio_map`s the IPU control window.
   - Routes MMIO `read`/`write` callbacks to `IpuHostController` (#2).
   - Loads a flat firmware binary, sets the reset PC, and runs via `emu_start`.
-- Define the address map (RAM base/size, MMIO base/size) and keep it consistent
-  with the firmware linker layout (#5).
+- Define the address map (RAM base/size, control MMIO base/size, `IMEM_BASE`/
+  `IMEM_MAP_SIZE`) and keep it consistent with the firmware linker layout (#5).
+  Map IMEM as a second `mmio_map` region with halt-gated callbacks (#2).
 - **Execution model:** run the IPU functionally inside the `START`/`STEP` write
   callback (deterministic, no threads). Document the alternative cooperative
   model and why it was deferred (see spec §10).

--- a/planning/riscv-host-integration/05-rust-firmware.md
+++ b/planning/riscv-host-integration/05-rust-firmware.md
@@ -15,7 +15,7 @@ into the Unicorn core (#4).
   access (fields + enums). Build output, not hand-edited.
 - **`ipu-rt`** — thin hand-written HAL over `ipu-pac` exposing:
   - `configure(dtype, dstructure, crs)`
-  - `load_program(words)` (streams via the IMEM port)
+  - `load_program(src, len)` (memcpy into `IMEM_BASE` while halted; sets `PROG_LEN`)
   - `start()`, `wait_until_halted()`
   - `read_pc()`, `write_pc(addr)`
   - `reset()`

--- a/planning/riscv-host-integration/05-rust-firmware.md
+++ b/planning/riscv-host-integration/05-rust-firmware.md
@@ -1,0 +1,53 @@
+# Rust `no_std` firmware + generated driver for the IPU host
+
+Part of the [RISC-V host integration epic](00-epic.md). Depends on #1, #4.
+
+## Goal
+
+Write the on-device host code in **Rust** (`no_std`): a generated register-access
+crate, a small HAL, and an example firmware that drives the IPU entirely through
+the MMIO control block, then build it for a bare-metal RISC-V target and load it
+into the Unicorn core (#4).
+
+## Crates
+
+- **`ipu-pac`** — generated from `ipu_ctrl.rdl` (#1): typed, volatile register
+  access (fields + enums). Build output, not hand-edited.
+- **`ipu-rt`** — thin hand-written HAL over `ipu-pac` exposing:
+  - `configure(dtype, dstructure, crs)`
+  - `load_program(words)` (streams via the IMEM port)
+  - `start()`, `wait_until_halted()`
+  - `read_pc()`, `write_pc(addr)`
+  - `reset()`
+- **`firmware`** — example `no_std` binary whose `main` mirrors an app flow:
+  configure → load program → start → wait → done.
+
+## Implementation
+
+- Add `rules_rust` to `MODULE.bazel`; register a bare-metal RISC-V toolchain
+  (e.g. `riscv32imac-unknown-none-elf`).
+- Provide a linker script / memory layout matching the host RAM base from #4;
+  emit a **flat binary** artifact for loading into Unicorn.
+- Use `core`-only Rust (no `std`), a minimal `_start`/reset handler, and a panic
+  handler.
+- Wire firmware build outputs so the integration harness (#6) can consume the
+  flat binary as a Bazel data dependency.
+
+## Docs
+
+- Document how to build the firmware and the driver API in the spec; add a short
+  "writing host firmware" snippet.
+
+## Tests
+
+- [ ] `ipu-pac` + `ipu-rt` + `firmware` compile for the bare-metal target under
+      Bazel.
+- [ ] The produced flat binary loads and runs in the Unicorn core (smoke test
+      from #4 harness): firmware writes reach the control model.
+
+## Acceptance Criteria
+
+- [ ] Rust (not C) firmware + driver, generated register access from the single
+      SystemRDL source.
+- [ ] Bare-metal RISC-V build wired into Bazel producing a loadable flat binary.
+- [ ] Firmware drives configure/load/start/wait/reset over MMIO.

--- a/planning/riscv-host-integration/06-end-to-end.md
+++ b/planning/riscv-host-integration/06-end-to-end.md
@@ -5,9 +5,10 @@ Part of the [RISC-V host integration epic](00-epic.md). Depends on #2–#5.
 ## Goal
 
 Tie everything together: a **Rust firmware** image running on the emulated
-RISC-V core (#4/#5) configures the IPU, streams an assembled program into
-instruction memory, starts it, polls for halt, reads/writes the PC, and can
-reset and re-run — all through the SystemRDL control block (#1/#2). Prove parity
+RISC-V core (#4/#5) configures the IPU, loads an assembled program into the
+fully mapped instruction-memory region, starts it, polls for halt, reads/writes
+the PC, and can reset and re-run — all through the SystemRDL-defined address
+space (#1/#2). Prove parity
 with the existing direct-Python path and document the workflow.
 
 ## Implementation
@@ -33,7 +34,7 @@ with the existing direct-Python path and document the workflow.
 
 - [ ] End-to-end host-path run matches the direct-Python result for the chosen app.
 - [ ] Halt/step/PC-R/W/reset are each exercised and asserted.
-- [ ] Reset-preserving-IMEM allows a second run with fresh inputs, no re-stream.
+- [ ] Reset-preserving-IMEM allows a second run with fresh inputs, no IMEM reload.
 - [ ] `bazel test //...` is green, including the new integration target.
 
 ## Acceptance Criteria

--- a/planning/riscv-host-integration/06-end-to-end.md
+++ b/planning/riscv-host-integration/06-end-to-end.md
@@ -1,0 +1,44 @@
+# End-to-end firmware-driven app run, parity tests, and docs
+
+Part of the [RISC-V host integration epic](00-epic.md). Depends on #2–#5.
+
+## Goal
+
+Tie everything together: a **Rust firmware** image running on the emulated
+RISC-V core (#4/#5) configures the IPU, streams an assembled program into
+instruction memory, starts it, polls for halt, reads/writes the PC, and can
+reset and re-run — all through the SystemRDL control block (#1/#2). Prove parity
+with the existing direct-Python path and document the workflow.
+
+## Implementation
+
+- Pick an existing app (e.g. `fully_connected`) as the reference workload.
+- Author firmware (using `ipu-rt` from #5) that reproduces that app's setup
+  (CRs, dtype, dstructure) and program load, then `start()` + `wait_until_halted()`.
+- Add an integration harness/test that:
+  1. Assembles the app program (existing Bazel `assemble_*` target).
+  2. Boots the Unicorn core with the firmware and the program/inputs available.
+  3. Runs to completion via the host path.
+  4. Asserts the resulting `IpuState`/XMEM output equals the direct-Python run.
+- Exercise the full control surface in tests: start, halt/step, PC read+write,
+  reprogram IMEM, and reset-preserving-IMEM (re-run with new inputs).
+
+## Docs
+
+- Add a user-facing page (or expand the spec) showing the host-driven workflow
+  end to end, including how to build firmware and read back results.
+- Link it from the docs nav alongside the design spec.
+
+## Tests
+
+- [ ] End-to-end host-path run matches the direct-Python result for the chosen app.
+- [ ] Halt/step/PC-R/W/reset are each exercised and asserted.
+- [ ] Reset-preserving-IMEM allows a second run with fresh inputs, no re-stream.
+- [ ] `bazel test //...` is green, including the new integration target.
+
+## Acceptance Criteria
+
+- [ ] A Rust-firmware-driven run of a real app produces identical results to the
+      direct-Python path.
+- [ ] All five required execution controls are demonstrated end to end.
+- [ ] Documentation describes the complete host-driven workflow.

--- a/planning/riscv-host-integration/README.md
+++ b/planning/riscv-host-integration/README.md
@@ -1,0 +1,30 @@
+# RISC-V Host Integration — Issue Drafts
+
+This directory holds ready-to-file GitHub issue drafts for the **RISC-V host
+integration** feature. The accompanying design spec lives at
+[`docs/content/specs/riscv-host-integration.md`](../../docs/content/specs/riscv-host-integration.md).
+
+These are markdown drafts (the Cloud Agent cannot open GitHub issues directly);
+paste each file's body into a new issue, or file them with `gh issue create`.
+
+## Index
+
+| # | File | Title | Labels |
+|---|------|-------|--------|
+| 0 | [`00-epic.md`](00-epic.md) | Epic: Emulated RISC-V host drives the IPU via a SystemRDL control register block | enhancement |
+| 1 | [`01-systemrdl-regfile.md`](01-systemrdl-regfile.md) | Define the IPU host-control register block in SystemRDL + codegen | enhancement |
+| 2 | [`02-emulator-mmio-model.md`](02-emulator-mmio-model.md) | Emulator MMIO control-register model mapped onto `IpuState` | enhancement |
+| 3 | [`03-steppable-engine.md`](03-steppable-engine.md) | Refactor the run loop into a host-drivable, steppable execution engine | enhancement |
+| 4 | [`04-unicorn-riscv.md`](04-unicorn-riscv.md) | Integrate an emulated RISC-V core (Unicorn) with the IPU MMIO bridge | enhancement |
+| 5 | [`05-rust-firmware.md`](05-rust-firmware.md) | Rust `no_std` firmware + generated driver for the IPU host | enhancement |
+| 6 | [`06-end-to-end.md`](06-end-to-end.md) | End-to-end firmware-driven app run, parity tests, and docs | enhancement |
+
+## Suggested order
+
+```
+1 ──▶ 2 ──▶ 4 ──▶ 5 ──▶ 6
+  └──▶ 3 ──┘
+```
+
+Issue 1 fixes the register contract. Issues 2 and 3 can proceed in parallel,
+then 4 wires the host in, 5 adds firmware, and 6 ties it all together.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Planning artifacts for a **big feature**: an emulated **RISC-V host core** (via the [Unicorn](https://www.unicorn-engine.org/) framework, embedded in the Python environment) that configures and sequences the IPU emulator through a **memory-mapped control/configuration register block**. The register block is authored once in **SystemRDL** and is the single source of truth for the Python emulator model, the on-device **Rust** driver, and the generated docs.

This realizes, in the emulator, the host model already described in [`specs/stage-control.md`](../blob/master/docs/content/specs/stage-control.md) and [`specs/cache-unit.md`](../blob/master/docs/content/specs/cache-unit.md) (an external RISC-V host configuring the IPU over an APB slave).

No emulator/assembler behavior changes here — this PR adds a design spec and ready-to-file issue drafts only.

## What's in this PR

- **`docs/content/specs/riscv-host-integration.md`** — full design spec: motivation, architecture diagram, the proposed host-control register map, **fully mapped instruction memory** (not an indirect programming port), **halt-only IMEM access** (bus error / `ERROR` while running), execution-control + reset semantics, SystemRDL-as-single-source-of-truth codegen plan (PeakRDL → Python/Rust/HTML), Unicorn integration sketch, Rust `no_std` firmware plan, implementation/issue breakdown, and open questions/risks.
- **`planning/riscv-host-integration/`** — an epic plus 6 ready-to-file sub-issue drafts.
- **mkdocs** — spec added to the Specs nav.

## Address-space change (vs earlier draft)

- **Removed:** `IMEM_ADDR`, `IMEM_WDATA`, `IMEM_RDATA`, `IMEM_CTRL` indirect programming port.
- **Added:** flat `IMEM_BASE` region (`0x1001_0000` in the sketch) sized `IMEM_DEPTH × INSTRUCTION_ALIGNED_BYTES`, byte-addressable mirror of `--format bin`.
- **Added:** `PROG_LEN` register for active program length.
- **Halt-only IMEM:** any IMEM read/write while `STATUS.RUNNING` latches `ERROR` (`IMEM_ACCESS_WHILE_RUNNING`) and fails the host bus access.

## Requirements coverage

All requested controls are routed through the register block / host map:

1. **Start** execution — `CTRL.START`
2. **Halt** execution — `CTRL.HALT`
3. **Reprogram** instruction memory — write the `IMEM_BASE` map (+ `PROG_LEN`) while halted
4. **Read/Write** the program counter — `PC`
5. **Reset** the IPU (everything **except** instruction memory) — `CTRL.RESET`

Plus configuration: `dtype`, `dstructure`, `CR2`–`CR14`, and `elu_alpha`.

## Proposed issues

| # | Title |
|---|-------|
| 0 | Epic: Emulated RISC-V host drives the IPU via a SystemRDL control register block |
| 1 | Define the IPU host-control register block in SystemRDL + codegen |
| 2 | Emulator MMIO control-register model mapped onto `IpuState` |
| 3 | Refactor the run loop into a host-drivable, steppable execution engine |
| 4 | Integrate an emulated RISC-V core (Unicorn) with the IPU MMIO bridge |
| 5 | Rust `no_std` firmware + generated driver for the IPU host |
| 6 | End-to-end firmware-driven app run, parity tests, and docs |

Dependency order: **1 → {2, 3} → 4 → 5 → 6**.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1112c967-b7a7-4f37-8151-2bc6cfc540b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1112c967-b7a7-4f37-8151-2bc6cfc540b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

