### PR TITLE
ACC Slot Redesign: AAQ Operations 

### DIFF
--- a/src/tools/ipu-common/src/ipu_common/instruction_spec.py
+++ b/src/tools/ipu-common/src/ipu_common/instruction_spec.py
@@ -525,7 +525,7 @@ INSTRUCTION_SPEC = {
 
     # =========================================================================
     # ACC Slot (Accumulator Instructions)
-    # Opcode = position: ACC=0, ACC.FIRST=1, RESET_ACC=2, ACC_NOP=3, ACC.ADD_AAQ=4, ACC.ADD_AAQ.FIRST=5, ACC.MAX=6, ACC.MAX.FIRST=7, ACC.STRIDE=8
+    # Opcode = position: ACC=0, ACC.FIRST=1, RESET_ACC=2, ACC_NOP=3, ACC.STRIDE=4, ACC.ADD.AAQ=5, ACC.SUB.AAQ=6, ACC.MAX.AAQ=7, ACC.INT.AAQ=8
     # =========================================================================
     "acc": {
         "ACC": {
@@ -572,80 +572,6 @@ INSTRUCTION_SPEC = {
             ),
             "execute_fn": "execute_acc_nop",
         },
-        "ACC.ADD_AAQ": {
-            "operands": [
-                {"name": "aaq_rf_idx", "type": "AaqRegIdx"},
-            ],
-            "doc": InstructionDoc(
-                title="Accumulate and Add AAQ",
-                summary="Accumulate multiply result, then ADD the selected AAQ register (32-bit) to each of the 128 accumulator words.",
-                syntax="ACC.ADD_AAQ aaq_rf_idx",
-                operands=[
-                    "aaq_rf_idx: AAQ register index (AAQ0–AAQ3)",
-                ],
-                operation=(
-                    "R_ACC += multiply_result;\n"
-                    "for i in [0, 128): R_ACC[i] += AAQ_REGS[aaq_rf_idx]"
-                ),
-                example="ACC.ADD_AAQ AAQ0;;",
-            ),
-            "execute_fn": "execute_acc_add_aaq",
-        },
-        "ACC.ADD_AAQ.FIRST": {
-            "operands": [
-                {"name": "aaq_rf_idx", "type": "AaqRegIdx"},
-            ],
-            "doc": InstructionDoc(
-                title="Accumulate and Add AAQ (First)",
-                summary="Set accumulator to multiply result plus selected AAQ register (do not ADD to previous R_ACC).",
-                syntax="ACC.ADD_AAQ.FIRST aaq_rf_idx",
-                operands=[
-                    "aaq_rf_idx: AAQ register index (AAQ0–AAQ3)",
-                ],
-                operation=(
-                    "R_ACC = multiply_result;\n"
-                    "for i in [0, 128): R_ACC[i] += AAQ_REGS[aaq_rf_idx]"
-                ),
-                example="ACC.ADD_AAQ.FIRST AAQ0;;",
-            ),
-            "execute_fn": "execute_acc_add_aaq_first",
-        },
-        "ACC.MAX": {
-            "operands": [
-                {"name": "aaq_rf_idx", "type": "AaqRegIdx"},
-            ],
-            "doc": InstructionDoc(
-                title="Accumulator Max",
-                summary="For each element, SET R_ACC[i] = max(R_ACC[i], MULT_RES[i], AAQ_REGS[aaq_rf_idx]).",
-                syntax="ACC.MAX aaq_rf_idx",
-                operands=[
-                    "aaq_rf_idx: AAQ register index (AAQ0–AAQ3)",
-                ],
-                operation=(
-                    "for i in [0, 128): R_ACC[i] = max(R_ACC[i], MULT_RES[i], AAQ_REGS[aaq_rf_idx])"
-                ),
-                example="ACC.MAX AAQ0;;",
-            ),
-            "execute_fn": "execute_acc_max",
-        },
-        "ACC.MAX.FIRST": {
-            "operands": [
-                {"name": "aaq_rf_idx", "type": "AaqRegIdx"},
-            ],
-            "doc": InstructionDoc(
-                title="Accumulator Max (First)",
-                summary="For each element, SET R_ACC[i] = max(MULT_RES[i], AAQ_REGS[aaq_rf_idx]). Previous R_ACC is ignored (treated as 0).",
-                syntax="ACC.MAX.FIRST aaq_rf_idx",
-                operands=[
-                    "aaq_rf_idx: AAQ register index (AAQ0–AAQ3)",
-                ],
-                operation=(
-                    "for i in [0, 128): R_ACC[i] = max(MULT_RES[i], AAQ_REGS[aaq_rf_idx])"
-                ),
-                example="ACC.MAX.FIRST AAQ0;;",
-            ),
-            "execute_fn": "execute_acc_max_first",
-        },
         "ACC.STRIDE": {
             "operands": [
                 {"name": "elements_in_row", "type": "ElementsInRow"},
@@ -670,6 +596,70 @@ INSTRUCTION_SPEC = {
                 example="ACC.STRIDE 8, off, off, LR0;;",
             ),
             "execute_fn": "execute_acc_stride",
+        },
+        "ACC.ADD.AAQ": {
+            "operands": [
+                {"name": "aaq_rf_idx", "type": "AaqRegIdx"},
+            ],
+            "doc": InstructionDoc(
+                title="Accumulator Add AAQ",
+                summary="Add the selected AAQ register to each accumulator lane (no multiply result involved).",
+                syntax="ACC.ADD.AAQ aaq_rf_idx",
+                operands=[
+                    "aaq_rf_idx: AAQ register index (AAQ0–AAQ3)",
+                ],
+                operation="for i in [0, 128): R_ACC[i] += AAQ_REGS[aaq_rf_idx]",
+                example="ACC.ADD.AAQ AAQ0;;",
+            ),
+            "execute_fn": "execute_acc_aaq_add",
+        },
+        "ACC.SUB.AAQ": {
+            "operands": [
+                {"name": "aaq_rf_idx", "type": "AaqRegIdx"},
+            ],
+            "doc": InstructionDoc(
+                title="Accumulator Subtract AAQ",
+                summary="Subtract the selected AAQ register from each accumulator lane (no multiply result involved).",
+                syntax="ACC.SUB.AAQ aaq_rf_idx",
+                operands=[
+                    "aaq_rf_idx: AAQ register index (AAQ0–AAQ3)",
+                ],
+                operation="for i in [0, 128): R_ACC[i] -= AAQ_REGS[aaq_rf_idx]",
+                example="ACC.SUB.AAQ AAQ0;;",
+            ),
+            "execute_fn": "execute_acc_aaq_sub",
+        },
+        "ACC.MAX.AAQ": {
+            "operands": [
+                {"name": "aaq_rf_idx", "type": "AaqRegIdx"},
+            ],
+            "doc": InstructionDoc(
+                title="Accumulator Max AAQ",
+                summary="For each lane set R_ACC[i] = max(R_ACC[i], AAQ_REGS[aaq_rf_idx]) (no multiply result involved).",
+                syntax="ACC.MAX.AAQ aaq_rf_idx",
+                operands=[
+                    "aaq_rf_idx: AAQ register index (AAQ0–AAQ3)",
+                ],
+                operation="for i in [0, 128): R_ACC[i] = max(R_ACC[i], AAQ_REGS[aaq_rf_idx])",
+                example="ACC.MAX.AAQ AAQ0;;",
+            ),
+            "execute_fn": "execute_acc_aaq_max",
+        },
+        "ACC.INT.AAQ": {
+            "operands": [
+                {"name": "aaq_rf_idx", "type": "AaqRegIdx"},
+            ],
+            "doc": InstructionDoc(
+                title="Accumulator Initialise from AAQ",
+                summary="Set every accumulator lane to the selected AAQ register value (previous R_ACC ignored).",
+                syntax="ACC.INT.AAQ aaq_rf_idx",
+                operands=[
+                    "aaq_rf_idx: AAQ register index (AAQ0–AAQ3)",
+                ],
+                operation="for i in [0, 128): R_ACC[i] = AAQ_REGS[aaq_rf_idx]",
+                example="ACC.INT.AAQ AAQ0;;",
+            ),
+            "execute_fn": "execute_acc_aaq_init",
         },
     },
 

--- a/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
@@ -23,7 +23,7 @@ from typing import Any
 
 from ipu_emu.ipu_state import IpuState, INST_MEM_SIZE, WideVectorArithmetic
 from ipu_emu.regfile import RegFile
-from ipu_emu.ipu_math import ipu_mult, ipu_add, dtype_one_byte, DType
+from ipu_emu.ipu_math import ipu_mult, ipu_add, ipu_sub, dtype_one_byte, DType
 from ipu_emu.ipu_config import REGISTER_WORD_VALUE_MASK, LR_CR_SCALAR_BITS, Partition
 from ipu_common.instruction_spec import (
     INSTRUCTION_SPEC,
@@ -258,8 +258,13 @@ class Ipu:
             return float(a) + float(b)
         return ipu_add(int(a), int(b), DType.INT8)
 
+    def _wide_sub_lane(self, a: float | int, b: float | int) -> float | int:
+        if self.state.wide_vector_arithmetic == WideVectorArithmetic.FP32:
+            return float(a) - float(b)
+        return ipu_sub(int(a), int(b), DType.INT8)
+
     def _wide_aaq_scalar(self, aaq_rf_idx: int) -> float | int:
-        raw = self.state.regfile.get_aaq(aaq_rf_idx) & 0xFFFFFFFF
+        raw = self.snapshot.get_aaq(aaq_rf_idx) & 0xFFFFFFFF
         if self.state.wide_vector_arithmetic == WideVectorArithmetic.FP32:
             return struct.unpack("<f", struct.pack("<I", raw))[0]
         return struct.unpack("<i", struct.pack("<I", raw))[0]
@@ -878,82 +883,6 @@ class Ipu:
             mult_val = struct.unpack_from(fmt, mult_res, i * 4)[0]
             struct.pack_into(fmt, acc_buf, i * 4, mult_val)
 
-    def execute_acc_add_aaq(self, *, aaq_rf_idx: int) -> None:
-        """Execute ACC.ADD_AAQ: Accumulate mult_res, then add aaq[aaq_rf_idx] to each of the 128 accumulator words."""
-        dtype = self.state.dtype
-        acc_buf = self.state.regfile.raw("r_acc")
-        mult_res = self.state.regfile.raw("mult_res")
-        snap_acc = self.snapshot.raw("r_acc")
-        fmt = self._acc_agg_lane_fmt()
-        if self._wide_vector_active():
-            aaq_lane = self._wide_aaq_scalar(aaq_rf_idx)
-        else:
-            aaq_lane = self.state.regfile.get_aaq(aaq_rf_idx)
-
-        for i in range(R_REG_SIZE):
-            acc_val = struct.unpack_from(fmt, snap_acc, i * 4)[0]
-            mult_val = struct.unpack_from(fmt, mult_res, i * 4)[0]
-            if self._wide_vector_active():
-                result = self._wide_add_lane(self._wide_add_lane(acc_val, mult_val), aaq_lane)
-            else:
-                result = ipu_add(ipu_add(acc_val, mult_val, dtype), aaq_lane, dtype)
-            struct.pack_into(fmt, acc_buf, i * 4, result)
-
-    def execute_acc_add_aaq_first(self, *, aaq_rf_idx: int) -> None:
-        """Execute ACC.ADD_AAQ.FIRST: Set r_acc to mult_res + aaq[aaq_rf_idx] (no previous sum)."""
-        dtype = self.state.dtype
-        acc_buf = self.state.regfile.raw("r_acc")
-        mult_res = self.state.regfile.raw("mult_res")
-        fmt = self._acc_agg_lane_fmt()
-        if self._wide_vector_active():
-            aaq_lane = self._wide_aaq_scalar(aaq_rf_idx)
-        else:
-            aaq_lane = self.state.regfile.get_aaq(aaq_rf_idx)
-
-        for i in range(R_REG_SIZE):
-            mult_val = struct.unpack_from(fmt, mult_res, i * 4)[0]
-            if self._wide_vector_active():
-                result = self._wide_add_lane(mult_val, aaq_lane)
-            else:
-                result = ipu_add(mult_val, aaq_lane, dtype)
-            struct.pack_into(fmt, acc_buf, i * 4, result)
-
-    def execute_acc_max(self, *, aaq_rf_idx: int) -> None:
-        """Execute ACC.MAX: r_acc[i] = max(r_acc[i], mult_res[i], aaq_reg[aaq_rf_idx]).
-
-        All register values are interpreted as signed (int32 for INT8 dtype, float32 for FP8).
-        """
-        dtype = self.state.dtype
-        acc_buf = self.state.regfile.raw("r_acc")
-        mult_res = self.state.regfile.raw("mult_res")
-        snap_acc = self.snapshot.raw("r_acc")
-        aaq_raw = self.state.regfile.get_aaq(aaq_rf_idx) & 0xFFFFFFFF
-        fmt = self._acc_agg_lane_fmt()
-        aaq_val = struct.unpack(fmt, struct.pack("<I", aaq_raw))[0]
-
-        for i in range(R_REG_SIZE):
-            acc_val = struct.unpack_from(fmt, snap_acc, i * 4)[0]
-            mult_val = struct.unpack_from(fmt, mult_res, i * 4)[0]
-            result = max(acc_val, mult_val, aaq_val)
-            struct.pack_into(fmt, acc_buf, i * 4, result)
-
-    def execute_acc_max_first(self, *, aaq_rf_idx: int) -> None:
-        """Execute ACC.MAX.FIRST: r_acc[i] = max(mult_res[i], aaq_reg[aaq_rf_idx]). Previous r_acc ignored.
-
-        All register values are interpreted as signed (int32 for INT8 dtype, float32 for FP8).
-        """
-        dtype = self.state.dtype
-        acc_buf = self.state.regfile.raw("r_acc")
-        mult_res = self.state.regfile.raw("mult_res")
-        aaq_raw = self.state.regfile.get_aaq(aaq_rf_idx) & 0xFFFFFFFF
-        fmt = self._acc_agg_lane_fmt()
-        aaq_val = struct.unpack(fmt, struct.pack("<I", aaq_raw))[0]
-
-        for i in range(R_REG_SIZE):
-            mult_val = struct.unpack_from(fmt, mult_res, i * 4)[0]
-            result = max(mult_val, aaq_val)
-            struct.pack_into(fmt, acc_buf, i * 4, result)
-
     def execute_acc_stride(
         self,
         *,
@@ -1015,6 +944,75 @@ class Ipu:
             else:
                 val = 0.0 if fmt == "<f" else 0
             struct.pack_into(fmt, acc_buf, (base + i) * 4, val)
+
+    def execute_acc_aaq_add(self, *, aaq_rf_idx: int) -> None:
+        """Execute ACC.ADD.AAQ: R_ACC[i] += AAQ_REGS[aaq_rf_idx] for all 128 lanes (no mult_res)."""
+        dtype = self.state.dtype
+        acc_buf = self.state.regfile.raw("r_acc")
+        snap_acc = self.snapshot.raw("r_acc")
+        fmt = self._acc_agg_lane_fmt()
+        if self._wide_vector_active():
+            aaq_lane = self._wide_aaq_scalar(aaq_rf_idx)
+        else:
+            aaq_lane = self.snapshot.get_aaq(aaq_rf_idx)
+
+        for i in range(R_REG_SIZE):
+            acc_val = struct.unpack_from(fmt, snap_acc, i * 4)[0]
+            if self._wide_vector_active():
+                result = self._wide_add_lane(acc_val, aaq_lane)
+            else:
+                result = ipu_add(acc_val, aaq_lane, dtype)
+            struct.pack_into(fmt, acc_buf, i * 4, result)
+
+    def execute_acc_aaq_sub(self, *, aaq_rf_idx: int) -> None:
+        """Execute ACC.SUB.AAQ: R_ACC[i] -= AAQ_REGS[aaq_rf_idx] for all 128 lanes (no mult_res)."""
+        dtype = self.state.dtype
+        acc_buf = self.state.regfile.raw("r_acc")
+        snap_acc = self.snapshot.raw("r_acc")
+        fmt = self._acc_agg_lane_fmt()
+        if self._wide_vector_active():
+            aaq_lane = self._wide_aaq_scalar(aaq_rf_idx)
+        else:
+            aaq_lane = self.snapshot.get_aaq(aaq_rf_idx)
+
+        for i in range(R_REG_SIZE):
+            acc_val = struct.unpack_from(fmt, snap_acc, i * 4)[0]
+            if self._wide_vector_active():
+                result = self._wide_sub_lane(acc_val, aaq_lane)
+            else:
+                result = ipu_sub(acc_val, aaq_lane, dtype)
+            struct.pack_into(fmt, acc_buf, i * 4, result)
+
+    def execute_acc_aaq_max(self, *, aaq_rf_idx: int) -> None:
+        """Execute ACC.MAX.AAQ: R_ACC[i] = max(R_ACC[i], AAQ_REGS[aaq_rf_idx]) for all 128 lanes (no mult_res)."""
+        dtype = self.state.dtype
+        acc_buf = self.state.regfile.raw("r_acc")
+        snap_acc = self.snapshot.raw("r_acc")
+        fmt = self._acc_agg_lane_fmt()
+        if self._wide_vector_active():
+            aaq_val = self._wide_aaq_scalar(aaq_rf_idx)
+        else:
+            aaq_raw = self.snapshot.get_aaq(aaq_rf_idx) & 0xFFFFFFFF
+            aaq_val = struct.unpack(fmt, struct.pack("<I", aaq_raw))[0]
+
+        for i in range(R_REG_SIZE):
+            acc_val = struct.unpack_from(fmt, snap_acc, i * 4)[0]
+            result = max(acc_val, aaq_val)
+            struct.pack_into(fmt, acc_buf, i * 4, result)
+
+    def execute_acc_aaq_init(self, *, aaq_rf_idx: int) -> None:
+        """Execute ACC.INT.AAQ: R_ACC[i] = AAQ_REGS[aaq_rf_idx] for all 128 lanes (previous R_ACC ignored)."""
+        dtype = self.state.dtype
+        acc_buf = self.state.regfile.raw("r_acc")
+        fmt = self._acc_agg_lane_fmt()
+        if self._wide_vector_active():
+            aaq_val = self._wide_aaq_scalar(aaq_rf_idx)
+        else:
+            aaq_raw = self.snapshot.get_aaq(aaq_rf_idx) & 0xFFFFFFFF
+            aaq_val = struct.unpack(fmt, struct.pack("<I", aaq_raw))[0]
+
+        for i in range(R_REG_SIZE):
+            struct.pack_into(fmt, acc_buf, i * 4, aaq_val)
 
     def execute_aaq_nop(self) -> None:
         """Execute AAQ_NOP: No operation for AAQ slot."""

--- a/src/tools/ipu-emu-py/src/ipu_emu/ipu_math.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/ipu_math.py
@@ -206,3 +206,12 @@ def ipu_add(a_word: int | float, b_word: int | float, dtype: int) -> int | float
     else:
         # FP8 variants: accumulator is float
         return a_word + b_word
+
+
+def ipu_sub(a_word: int | float, b_word: int | float, dtype: int) -> int | float:
+    """Subtract b from a according to *dtype* (accumulator-width values)."""
+    if dtype == DType.INT8:
+        result = (a_word - b_word) & 0xFFFFFFFF
+        return result - 0x100000000 if result >= 0x80000000 else result
+    else:
+        return a_word - b_word

--- a/src/tools/ipu-emu-py/test/test_execute.py
+++ b/src/tools/ipu-emu-py/test/test_execute.py
@@ -708,31 +708,6 @@ class TestAccumulator:
         for i in range(128):
             assert state.regfile.get_r_acc_word(i) == 0
 
-    def test_acc_add_aaq(self):
-        """ACC.ADD_AAQ adds the selected AAQ register (32-bit) to each of the 128 accumulator words."""
-        state = _make_state(
-            """\
-RESET_ACC;;
-ACC.ADD_AAQ aaq1;;
-BKPT;;
-"""
-        )
-        # INT8 dtype
-        state.dtype = DType.INT8
-        # mult_res = 2 in each word; acc starts at 0
-        for i in range(128):
-            state.regfile.set_r_acc_word(i, 0)
-        mult_buf = state.regfile.raw("mult_res")
-        for i in range(128):
-            struct.pack_into("<i", mult_buf, i * 4, 2)
-        # aaq1 = 100 (added to every word)
-        state.regfile.set_aaq(1, 100)
-        run_until_complete(state)
-        # Each word should be 0 + 2 + 100 = 102
-        for i in range(128):
-            w = state.regfile.get_r_acc_word(i)
-            assert w == 102, f"word {i}: expected 102, got {w}"
-
     def test_acc_first(self):
         """ACC.FIRST sets r_acc to mult_res without adding previous r_acc."""
         state = _make_state(
@@ -751,89 +726,6 @@ BKPT;;
         run_until_complete(state)
         for i in range(128):
             assert state.regfile.get_r_acc_word(i) == 7, f"word {i}: expected 7, got {state.regfile.get_r_acc_word(i)}"
-
-    def test_acc_add_aaq_first(self):
-        """ACC.ADD_AAQ.FIRST sets r_acc to mult_res + aaq (no previous sum)."""
-        state = _make_state(
-            """\
-ACC.ADD_AAQ.FIRST aaq2;;
-BKPT;;
-"""
-        )
-        state.dtype = DType.INT8
-        for i in range(128):
-            state.regfile.set_r_acc_word(i, 9999)  # should be ignored
-        mult_buf = state.regfile.raw("mult_res")
-        for i in range(128):
-            struct.pack_into("<i", mult_buf, i * 4, 3)
-        state.regfile.set_aaq(2, 10)
-        run_until_complete(state)
-        for i in range(128):
-            w = state.regfile.get_r_acc_word(i)
-            assert w == 13, f"word {i}: expected 13 (3+10), got {w}"
-
-    def test_acc_max(self):
-        """ACC.MAX sets r_acc[i] = max(r_acc[i], mult_res[i], aaq_reg)."""
-        state = _make_state(
-            """\
-ACC.MAX aaq1;;
-BKPT;;
-"""
-        )
-        state.dtype = DType.INT8
-        # r_acc: 1, mult_res: 2, aaq1: 3 → max(1,2,3)=3
-        for i in range(128):
-            state.regfile.set_r_acc_word(i, 1)
-        mult_buf = state.regfile.raw("mult_res")
-        for i in range(128):
-            struct.pack_into("<i", mult_buf, i * 4, 2)
-        state.regfile.set_aaq(1, 3)
-        run_until_complete(state)
-        for i in range(128):
-            w = state.regfile.get_r_acc_word(i)
-            assert w == 3, f"word {i}: expected max(1,2,3)=3, got {w}"
-
-    def test_acc_max_signed(self):
-        """ACC.MAX treats register values as signed int32; negative values compare correctly."""
-        state = _make_state(
-            """\
-ACC.MAX aaq0;;
-BKPT;;
-"""
-        )
-        state.dtype = DType.INT8
-        # r_acc: -10, mult_res: 2, aaq0: 5 → max(-10, 2, 5) = 5 (signed comparison)
-        acc_buf = state.regfile.raw("r_acc")
-        for i in range(128):
-            struct.pack_into("<i", acc_buf, i * 4, -10)
-        mult_buf = state.regfile.raw("mult_res")
-        for i in range(128):
-            struct.pack_into("<i", mult_buf, i * 4, 2)
-        state.regfile.set_aaq(0, struct.unpack("<I", struct.pack("<i", 5))[0])
-        run_until_complete(state)
-        for i in range(128):
-            val = struct.unpack_from("<i", state.regfile.raw("r_acc"), i * 4)[0]
-            assert val == 5, f"word {i}: expected max(-10, 2, 5)=5 (signed), got {val}"
-
-    def test_acc_max_first(self):
-        """ACC.MAX.FIRST sets r_acc[i] = max(mult_res[i], aaq_reg); previous r_acc ignored."""
-        state = _make_state(
-            """\
-ACC.MAX.FIRST aaq0;;
-BKPT;;
-"""
-        )
-        state.dtype = DType.INT8
-        for i in range(128):
-            state.regfile.set_r_acc_word(i, 9999)  # should be ignored
-        mult_buf = state.regfile.raw("mult_res")
-        for i in range(128):
-            struct.pack_into("<i", mult_buf, i * 4, 5)
-        state.regfile.set_aaq(0, 10)
-        run_until_complete(state)
-        for i in range(128):
-            w = state.regfile.get_r_acc_word(i)
-            assert w == 10, f"word {i}: expected max(5,10)=10, got {w}"
 
     def test_acc_stride_no_stride(self):
         """ACC.STRIDE with both strides off copies all 128 mult_res words to r_acc from start 0."""
@@ -901,6 +793,93 @@ BKPT;;
         for i in range(96, 128):
             w = state.regfile.get_r_acc_word(i)
             assert w == 0, f"word {i} (after segment): expected 0, got {w}"
+
+    def test_acc_add_aaq_standalone(self):
+        """ACC.ADD.AAQ: R_ACC[i] += aaq (no mult_res involved)."""
+        state = _make_state(
+            """\
+ACC.ADD.AAQ aaq1;;
+BKPT;;
+"""
+        )
+        state.dtype = DType.INT8
+        for i in range(128):
+            state.regfile.set_r_acc_word(i, 10)
+        state.regfile.set_aaq(1, 5)
+        run_until_complete(state)
+        for i in range(128):
+            w = state.regfile.get_r_acc_word(i)
+            assert w == 15, f"word {i}: expected 15 (10+5), got {w}"
+
+    def test_acc_sub_aaq(self):
+        """ACC.SUB.AAQ: R_ACC[i] -= aaq (no mult_res involved)."""
+        state = _make_state(
+            """\
+ACC.SUB.AAQ aaq0;;
+BKPT;;
+"""
+        )
+        state.dtype = DType.INT8
+        for i in range(128):
+            state.regfile.set_r_acc_word(i, 20)
+        state.regfile.set_aaq(0, 7)
+        run_until_complete(state)
+        for i in range(128):
+            w = state.regfile.get_r_acc_word(i)
+            assert w == 13, f"word {i}: expected 13 (20-7), got {w}"
+
+    def test_acc_sub_aaq_negative_result(self):
+        """ACC.SUB.AAQ: result wraps correctly when aaq > acc (signed int32)."""
+        state = _make_state(
+            """\
+ACC.SUB.AAQ aaq2;;
+BKPT;;
+"""
+        )
+        state.dtype = DType.INT8
+        for i in range(128):
+            state.regfile.set_r_acc_word(i, 3)
+        state.regfile.set_aaq(2, 8)
+        run_until_complete(state)
+        for i in range(128):
+            raw = state.regfile.get_r_acc_word(i)
+            w = struct.unpack("<i", struct.pack("<I", raw))[0]
+            assert w == -5, f"word {i}: expected -5 (3-8), got {w}"
+
+    def test_acc_max_aaq_standalone(self):
+        """ACC.MAX.AAQ: R_ACC[i] = max(R_ACC[i], aaq) (no mult_res involved)."""
+        state = _make_state(
+            """\
+ACC.MAX.AAQ aaq1;;
+BKPT;;
+"""
+        )
+        state.dtype = DType.INT8
+        for i in range(128):
+            state.regfile.set_r_acc_word(i, 5 if i % 2 == 0 else 15)
+        state.regfile.set_aaq(1, 10)
+        run_until_complete(state)
+        for i in range(128):
+            w = state.regfile.get_r_acc_word(i)
+            expected = 10 if i % 2 == 0 else 15
+            assert w == expected, f"word {i}: expected {expected}, got {w}"
+
+    def test_acc_int_aaq(self):
+        """ACC.INT.AAQ: R_ACC[i] = aaq, ignoring previous R_ACC."""
+        state = _make_state(
+            """\
+ACC.INT.AAQ aaq0;;
+BKPT;;
+"""
+        )
+        state.dtype = DType.INT8
+        for i in range(128):
+            state.regfile.set_r_acc_word(i, 9999)  # should be ignored
+        state.regfile.set_aaq(0, 42)
+        run_until_complete(state)
+        for i in range(128):
+            w = state.regfile.get_r_acc_word(i)
+            assert w == 42, f"word {i}: expected 42, got {w}"
 
     def test_acc_agg_sum_value(self):
         """agg sum value: sum of 128 r_acc words, identity post fn, store to aaq0."""


### PR DESCRIPTION
## ACC Slot Redesign: AAQ Operations

### Overview

This PR redesigns the accumulator (ACC) slot instruction set to introduce a clean set of pure-AAQ operations, removes several now-redundant instructions, and fixes a latent VLIW read-before-write bug that affected all ACC handlers.

---

### New Instructions

Four new ACC slot instructions have been added (opcodes 5–8). All operate directly on the accumulator register file using only an AAQ register — the multiply-stage result (`mult_res`) is **not** involved:

| Instruction | Operation |
|---|---|
| `ACC.ADD.AAQ aaq_rf_idx` | `R_ACC[i] += AAQ_REGS[aaq_rf_idx]` |
| `ACC.SUB.AAQ aaq_rf_idx` | `R_ACC[i] -= AAQ_REGS[aaq_rf_idx]` |
| `ACC.MAX.AAQ aaq_rf_idx` | `R_ACC[i] = max(R_ACC[i], AAQ_REGS[aaq_rf_idx])` |
| `ACC.INT.AAQ aaq_rf_idx` | `R_ACC[i] = AAQ_REGS[aaq_rf_idx]` (initialise) |

A new `ipu_sub` helper was added to `ipu_math.py` (mirroring `ipu_add`) to implement subtraction with correct signed int32 wrap-around for the INT8 dtype.

---

### Removed Instructions

The following instructions were removed as part of the redesign:

- `ACC.ADD_AAQ` — combined mult + AAQ accumulate
- `ACC.ADD_AAQ.FIRST` — first-cycle variant of the above
- `ACC.MAX` — three-way max across acc, mult, and AAQ
- `ACC.MAX.FIRST` — first-cycle variant of the above

The ACC slot opcode table is now compact at positions 0–8.

---

### Bug Fix: VLIW Snapshot Consistency

All ACC handlers that read an AAQ register were reading from `self.state.regfile` (the live register file) instead of `self.snapshot` (the frozen copy taken at the start of each VLIW cycle). This violated the read-before-write guarantee: if any slot writes an AAQ register in the same cycle that an ACC handler reads it, the ACC handler would silently observe the updated value rather than the cycle-start value.

The fix applies to `_wide_aaq_scalar` and all non-wide ACC handler paths — they now consistently read AAQ from `self.snapshot`.

---

### Documentation

The generated Assembly Syntax, Operand Types, and Instruction Reference pages have been regenerated to reflect all additions and removals.