### PR TITLE
AAQ: interim direct INT8 clamp instead of >>24 truncation

### DIFF
--- a/src/tools/ipu-common/src/ipu_common/instruction_spec.py
+++ b/src/tools/ipu-common/src/ipu_common/instruction_spec.py
@@ -783,7 +783,9 @@ INSTRUCTION_SPEC = {
                 operation=(
                     "Requires INT8 mode (IpuState.dtype == DType.INT8 in the Python emulator). "
                     "Let n = 128 if full_xmem_row else min(CR15.valid_elements, 128). "
-                    "For i in [0, n): POST_AAQ_REG[i] = clamp(trunc(POST_AAQ_REG wide lane i), -128, 127). "
+                    "For i in [0, n): POST_AAQ_REG[i] = clamp(POST_AAQ_REG wide lane i, -128, 127) "
+                    "(interim direct INT8 clamp of the post-ACTIVATE lane; a future per-128-element "
+                    "requantize will scale lanes into INT8 range before this step and supersede the clamp). "
                     "POST_AAQ_REG[n..511] = 0."
                 ),
                 example="AAQ 1;;",

--- a/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
@@ -968,8 +968,23 @@ class Ipu:
 
         Source is the **512-byte** ``post_aaq_reg`` buffer (same lane layout as
         ``r_acc``), typically filled by ``ACTIVATE``. Each active 32-bit lane is
-        truncated then clamped to INT8 and stored in the leading bytes of
-        ``post_aaq_reg``; the remainder is zeroed.
+        clamped to the INT8 range ``[-128, 127]`` and stored in the leading bytes
+        of ``post_aaq_reg``; the remainder is zeroed.
+
+        Quantization is an **interim direct clamp** of the post-``ACTIVATE``
+        accumulator lane: ``out[i] = clamp(lane[i], -128, 127)``.  The previous
+        ``lane >> 24`` truncation was the shift half of a fixed-point requantize
+        whose per-lane multiply half is not implemented, so on a real INT8
+        convolution accumulator (magnitudes well below ``2**24``) it produced an
+        all-zero result.
+
+        This clamp is a placeholder, not the final design.  The intended future
+        quantization is a full per-128-element (per-lane) requantize — applied
+        after ``ACTIVATE`` and before write-back to memory — that scales each
+        lane so the result is guaranteed to land in INT8 range; that stage
+        subsumes (and will replace) this clamp.  Until it lands, clamping keeps
+        the ``ACTIVATE`` -> ``AAQ`` path producing usable INT8 output instead of
+        all zeros.
 
         ``full_xmem_row=1``: always process all 128 lanes.
         ``full_xmem_row=0``: process only ``CR15.valid_elements`` lanes (clamped to 128).
@@ -1001,8 +1016,7 @@ class Ipu:
             else:
                 for i in range(active):
                     val = struct.unpack_from("<i", src_buf, i * 4)[0]
-                    truncated = val >> 24
-                    clamped = max(-128, min(127, truncated))
+                    clamped = max(-128, min(127, val))
                     result[i] = clamped & 0xFF
             self.state.regfile.set_post_aaq_reg(result + bytearray(384))
             return
@@ -1011,8 +1025,7 @@ class Ipu:
         result = bytearray(128)
         for i in range(active):
             val = struct.unpack_from("<i", src_buf, i * 4)[0]
-            truncated = val >> 24  # arithmetic right-shift: keeps top 8 bits, range [-128, 127]
-            clamped = max(-128, min(127, truncated))
+            clamped = max(-128, min(127, val))  # direct INT8 clamp (no >>24 truncation)
             result[i] = clamped & 0xFF
         self.state.regfile.set_post_aaq_reg(result + bytearray(384))
 

--- a/src/tools/ipu-emu-py/test/test_execute.py
+++ b/src/tools/ipu-emu-py/test/test_execute.py
@@ -1833,11 +1833,12 @@ class TestAaqQuantize:
         state.regfile.set_r_acc_bytes(buf)
         state.regfile.set_post_aaq_reg(bytearray(buf))
 
-    def test_aaq_basic_truncation(self):
-        """Values that fit in int8 after >> 24: e.g. 1 << 24 → byte 1."""
+    def test_aaq_basic_clamp(self):
+        """Direct clamp: values already in [-128, 127] pass through unchanged."""
         state = IpuState()
         state.dtype = DType.INT8
-        self._set_acc_words(state, [i << 24 for i in range(128)])
+        # Lanes 0..127 hold the signed value (i - 64): -64..63, all in range.
+        self._set_acc_words(state, [i - 64 for i in range(128)])
 
         encoded = assemble("aaq 0;;\nBKPT;;")
         from ipu_emu.execute import decode_instruction_word
@@ -1848,7 +1849,7 @@ class TestAaqQuantize:
 
         result = state.regfile.get_post_aaq_reg()
         for i in range(128):
-            expected = i if i < 128 else i - 256
+            expected = i - 64
             assert result[i] == (expected & 0xFF), f"byte {i}: expected {expected & 0xFF}, got {result[i]}"
         assert result[128:] == bytearray(384), "tail of POST_AAQ_REG should be cleared"
 
@@ -1868,12 +1869,31 @@ class TestAaqQuantize:
         assert state.regfile.get_post_aaq_reg() == bytearray(512)
 
     def test_aaq_positive_clamp(self):
-        """Large positive values clamp to 127 after truncation."""
-        # 0x7FFFFFFF >> 24 = 127, which is already at the boundary — no clamp needed.
-        # Use 0x7F000000 (127 << 24) and 0x80000000 (-128 << 24 in signed) for boundary.
+        """Direct clamp: values above 127 saturate to 127."""
         state = IpuState()
         state.dtype = DType.INT8
-        values = [0x7F000000] * 64 + [0x7FFFFFFF] * 64
+        # 127 stays 127; large positive int32 saturates to 127.
+        values = [127] * 64 + [0x7FFFFFFF] * 64
+        self._set_acc_words(state, values)
+
+        encoded = assemble("aaq 0;;\nBKPT;;")
+        from ipu_emu.execute import decode_instruction_word
+        from ipu_emu.emulator import load_program, run_until_complete
+        decoded = [decode_instruction_word(w) for w in encoded]
+        load_program(state, decoded)
+        run_until_complete(state)
+
+        result = state.regfile.get_post_aaq_reg()
+        for i in range(128):
+            assert result[i] == 127, f"byte {i}: expected 127, got {result[i]}"
+        assert result[128:] == bytearray(384)
+
+    def test_aaq_negative_values(self):
+        """Direct clamp: in-range negatives pass through; below -128 saturates to -128."""
+        state = IpuState()
+        state.dtype = DType.INT8
+        # -1 stays -1 (0xFF); large negative int32 saturates to -128 (0x80).
+        values = [-1] * 64 + [-(1 << 30)] * 64
         self._set_acc_words(state, values)
 
         encoded = assemble("aaq 0;;\nBKPT;;")
@@ -1885,28 +1905,9 @@ class TestAaqQuantize:
 
         result = state.regfile.get_post_aaq_reg()
         for i in range(64):
-            assert result[i] == 127, f"byte {i}: expected 127, got {result[i]}"
-        for i in range(64, 128):
-            assert result[i] == 127, f"byte {i}: expected 127, got {result[i]}"
-        assert result[128:] == bytearray(384)
-
-    def test_aaq_negative_values(self):
-        """Negative accumulator values truncate correctly."""
-        # -1 << 24 = 0xFF000000 (signed int32: -16777216); >> 24 = -1 → 0xFF as byte
-        state = IpuState()
-        state.dtype = DType.INT8
-        self._set_acc_words(state, [(-1) << 24] * 128)
-
-        encoded = assemble("aaq 0;;\nBKPT;;")
-        from ipu_emu.execute import decode_instruction_word
-        from ipu_emu.emulator import load_program, run_until_complete
-        decoded = [decode_instruction_word(w) for w in encoded]
-        load_program(state, decoded)
-        run_until_complete(state)
-
-        result = state.regfile.get_post_aaq_reg()
-        for i in range(128):
             assert result[i] == 0xFF, f"byte {i}: expected 0xFF (-1), got {result[i]}"
+        for i in range(64, 128):
+            assert result[i] == 0x80, f"byte {i}: expected 0x80 (-128), got {result[i]}"
         assert result[128:] == bytearray(384)
 
     def test_aaq_requires_int8_mode(self):
@@ -1922,7 +1923,7 @@ class TestAaqQuantize:
         state = IpuState()
         state.dtype = DType.INT8
         state.set_cr_dstructure(valid_elements=64)
-        self._set_acc_words(state, [1 << 24] * 128)
+        self._set_acc_words(state, [1] * 128)  # in-range; direct clamp leaves 1 -> 1
 
         encoded = assemble("aaq 1;;\nBKPT;;")
         from ipu_emu.execute import decode_instruction_word
@@ -1940,7 +1941,7 @@ class TestAaqQuantize:
         state = IpuState()
         state.dtype = DType.INT8
         state.set_cr_dstructure(valid_elements=48)
-        self._set_acc_words(state, [1 << 24] * 128)
+        self._set_acc_words(state, [1] * 128)  # in-range; direct clamp leaves 1 -> 1
 
         encoded = assemble("aaq 0;;\nBKPT;;")
         from ipu_emu.execute import decode_instruction_word


### PR DESCRIPTION
## Summary
Change the `AAQ` INT8 quantizer from `out[i] = clamp(lane[i] >> 24, -128, 127)` to an **interim direct clamp**: `out[i] = clamp(lane[i], -128, 127)`.

## Why the `>>24` is broken
The `>> 24` is the *shift half* of a fixed-point requantize (`out = clamp(round(acc × M))`, done in HW as "multiply by fixed-point M, then arithmetic-shift-right"). The **multiply half does not exist** in the ISA — there is no per-lane requantize-multiply (`AGG` collapses 128 lanes to a scalar; it's not a per-lane rescale).

So on a real INT8 conv accumulator the shift produces garbage:
- A 3×3×C int8 conv sum is in the hundreds–thousands.
- `1500 >> 24 == 0`; any value below `2^24 ≈ 16.7M` shifts to `0` (or `-1`).
- The quantize stage therefore maps **essentially every output to 0** — non-functional end to end.

This is consistent with the in-tree "work in progress" status of the quantize export (`POST_AAQ_REG` is "temporarily 512 bytes … until end-to-end quantization lands"; `STR_POST_AAQ_REG` is "interim").

## What this does — and that it's interim
Direct clamp keeps the `ACTIVATE → AAQ` path producing **usable INT8 output instead of all zeros**. It is **explicitly a placeholder, not the final design.**

The intended future quantization is a full **per-128-element (per-lane) requantize** — with scale (and zero-point) — applied **after `ACTIVATE` and before write-back to memory**, scaling each lane so the result is guaranteed within INT8 range. That stage will **supersede this clamp**. Until it lands, clamp is the functional stand-in.

## Scope
- `execute_aaq`: INT8 path **and** the wide-vector INT32 comparison path both switch `>>24` → clamp (kept consistent so the debug path mirrors the real path).
- `instruction_spec.py`: AAQ `operation` doc updated, noting the interim nature and the future per-128-element requantize.
- `test_execute.py`: the `TestAaqQuantize` cases that encoded `>>24` rewritten for clamp (pass-through in range, saturate above 127 / below −128); lane-count tests use in-range inputs.

No new instructions, no opcode/encoding changes, no register-layout changes.

## Testing
All emulator / common / assembler suites pass (276 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
