### PR TITLE
Refactor CR register handling in IPU execution

### DIFF
--- a/src/tools/ipu-apps/src/ipu_apps/fully_connected/fully_connected.asm
+++ b/src/tools/ipu-apps/src/ipu_apps/fully_connected/fully_connected.asm
@@ -17,7 +17,7 @@ element_loop:
     LDR_CYCLIC_MULT_REG lr4 cr13 lr15;
     ADD                 lr4 lr4 cr3;
     ADD                 lr5 lr5 cr4;
-    MULT.VE.CYCLIC      lr15 0 lr15 lr5;
+    MULT.VE.CYCLIC      lr15 0 lr15 lr5 CR15;
     ACC;
     BNE                 lr5 lr6 element_loop;;
 

--- a/src/tools/ipu-as-py/src/ipu_as/gen_docs.py
+++ b/src/tools/ipu-as-py/src/ipu_as/gen_docs.py
@@ -24,20 +24,17 @@ OPERAND_TYPE_DETAILS: dict[str, str] = {
     "CrIdx": (
         "Constant-register index: **`cr0`** … **`cr15`**. CRs are **read-only** in assembly; the "
         "harness initializes them (e.g. base pointers, strides). **`SET`** in the LR slot "
-        "copies the full **32-bit** CR value into an LR. **Note:** `cr15` is only valid as `cr_idx` "
-        "when the same instruction's `cr_dstructure` is not also `CR15` — the assembler raises an "
-        "error if both operands resolve to `CR15` in the same instruction."
+        "copies the full **32-bit** CR value into an LR. **Note:** in `MULT.VE.CR`, `cr_idx` and "
+        "`cr_dstructure` cannot both be `CR15` — the assembler raises an error."
     ),
     "LcrIdx": (
         "LR **or** CR index in one field: lower indices map to **`lr0`–`lr15`**, higher indices to "
-        "`**cr0`–`cr14`** in the usual combined ordering used by the assembler. `cr15` is reserved "
-        "and is not a valid operand."
+        "**`cr0`–`cr15`** in the usual combined ordering used by the assembler."
     ),
     "AddSubSrcB": (
-        "Second source for **`ADD`** / **`SUB`** in the LR slot: **`lr0`–`lr15`**, **`cr0`–`cr14`**, "
+        "Second source for **`ADD`** / **`SUB`** in the LR slot: **`lr0`–`lr15`**, **`cr0`–`cr15`**, "
         "or an **unsigned 5-bit immediate** (`0`–`31`). Encoded in **6 bits**: **`0`–`31`** use the "
-        "same ordering as **`LcrIdx`**; **`32`–`63`** encode immediates as **`32 + imm`**. `cr15` is "
-        "reserved and is not a valid operand."
+        "same ordering as **`LcrIdx`**; **`32`–`63`** encode immediates as **`32 + imm`**."
     ),
     "ElementsInRow": (
         "ACC-slot immediate: encoded **elements-per-row** selector (see `acc_stride_enums` in "
@@ -69,12 +66,6 @@ OPERAND_TYPE_DETAILS: dict[str, str] = {
         "**`mask_shift`** remains an **`LrIdx`**."
     ),
     "BreakImmediate": "16-bit value for **`BREAK`** / breakpoint slot conditions.",
-    "CrDstructureIdx": (
-        "CR register index (**`CR0`**–**`CR15`**, including **`CR15`**) whose encoded dstructure "
-        "value supplies configuration for the instruction: ``valid_elements`` (active lane count, "
-        "clamped to 128) for ACC/AAQ instructions, and ``partition`` (mask-shift group boundary) "
-        "for MULT instructions. Defaults to **`CR15`** when omitted; **4 bits** in the binary word."
-    ),
     "Label": (
         "Branch target: a symbolic **`label`** or a relative offset accepted by the cond slot "
         "(e.g. `loop`, `+3`)."

--- a/src/tools/ipu-as-py/src/ipu_as/gen_docs.py
+++ b/src/tools/ipu-as-py/src/ipu_as/gen_docs.py
@@ -22,10 +22,11 @@ OPERAND_TYPE_DETAILS: dict[str, str] = {
         "LR value after earlier slots in the same cycle."
     ),
     "CrIdx": (
-        "Constant-register index: **`cr0`** … **`cr14`**. CRs are **read-only** in assembly; the "
-        "harness initializes them (e.g. base pointers, strides). `cr15` is reserved for dstructure "
-        "configuration and is not a valid ISA operand. **`SET`** in the LR slot "
-        "copies the full **32-bit** CR value into an LR."
+        "Constant-register index: **`cr0`** … **`cr15`**. CRs are **read-only** in assembly; the "
+        "harness initializes them (e.g. base pointers, strides). **`SET`** in the LR slot "
+        "copies the full **32-bit** CR value into an LR. **Note:** `cr15` is only valid as `cr_idx` "
+        "when the same instruction's `cr_dstructure` is not also `CR15` — the assembler raises an "
+        "error if both operands resolve to `CR15` in the same instruction."
     ),
     "LcrIdx": (
         "LR **or** CR index in one field: lower indices map to **`lr0`–`lr15`**, higher indices to "
@@ -68,10 +69,11 @@ OPERAND_TYPE_DETAILS: dict[str, str] = {
         "**`mask_shift`** remains an **`LrIdx`**."
     ),
     "BreakImmediate": "16-bit value for **`BREAK`** / breakpoint slot conditions.",
-    "FullXmemRow": (
-        "1-bit control flag on **`AAQ`**: **`1`** = always process all **128 lanes** (full XMEM row, "
-        "ignores ``CR15.valid_elements``); **`0`** = process only the first ``CR15.valid_elements`` "
-        "lanes (clamped to 128) and zero the rest. Defaults to **`1`** for backward compatibility."
+    "CrDstructureIdx": (
+        "CR register index (**`CR0`**–**`CR15`**, including **`CR15`**) whose encoded dstructure "
+        "value supplies configuration for the instruction: ``valid_elements`` (active lane count, "
+        "clamped to 128) for ACC/AAQ instructions, and ``partition`` (mask-shift group boundary) "
+        "for MULT instructions. Defaults to **`CR15`** when omitted; **4 bits** in the binary word."
     ),
     "Label": (
         "Branch target: a symbolic **`label`** or a relative offset accepted by the cond slot "

--- a/src/tools/ipu-as-py/src/ipu_as/immediate.py
+++ b/src/tools/ipu-as-py/src/ipu_as/immediate.py
@@ -114,7 +114,7 @@ _ADD_SUB_SRC_B_IMM_BASE = 32
 
 
 class AddSubSrcBField(ipu_token.IpuToken):
-    """Second source for ``add`` / ``sub``: lr0–lr15, cr0–cr15, or unsigned IMM5 (0–31).
+    """Second source for ``add`` / ``sub``: lr0–lr15, cr0–cr15 (including cr15), or unsigned IMM5 (0–31).
 
     Encoded in 6 bits: register indices use the same mapping as ``LcrIdx`` (0–31);
     immediates use ``32 + imm``.
@@ -131,10 +131,6 @@ class AddSubSrcBField(ipu_token.IpuToken):
     def __init__(self, token: ipu_token.AnnotatedToken):
         super().__init__(token)
         raw = self.token.value.lower()
-        if raw == "cr15":
-            self._raise_error(
-                "CR15 is reserved for dstructure configuration and cannot be used as an ISA operand"
-            )
         if raw in _ADD_SUB_SRC_B_REGS:
             self._encoded = _ADD_SUB_SRC_B_REGS.index(raw)
             return
@@ -142,7 +138,7 @@ class AddSubSrcBField(ipu_token.IpuToken):
             imm = int(self.token.value, 0)
         except ValueError:
             self._raise_error(
-                "Expected lr0–lr15, cr0–cr14, or an unsigned 5-bit immediate (0–31)"
+                "Expected lr0–lr15, cr0–cr15, or an unsigned 5-bit immediate (0–31)"
             )
         if not (0 <= imm <= 31):
             self._raise_error(f"Immediate operand must be in range [0, 31], got {imm}")

--- a/src/tools/ipu-as-py/src/ipu_as/inst.py
+++ b/src/tools/ipu-as-py/src/ipu_as/inst.py
@@ -36,7 +36,6 @@ OPERAND_TYPE_MAP: dict[str, type[ipu_token.IpuToken]] = {
     "LrIdx": reg.LrRegField,
     "CrIdx": reg.CrRegField,
     "LcrIdx": reg.LcrRegField,
-    "CrDstructureIdx": reg.CrDstructureIdxField,
     "AddSubSrcB": immediate.AddSubSrcBField,
     "ElementsInRow": immediate.ElementsInRowField,
     "HorizontalStride": immediate.HorizontalStrideField,
@@ -90,14 +89,7 @@ class Inst:
 
         n_provided = len(inst["operands"])
         n_expected = len(operand_types)
-        # A trailing CrDstructureIdx operand is optional: when omitted it
-        # defaults to CR15 via _get_full_token_list → CrDstructureIdxField.default().
-        _optional_tail = (
-            n_provided == n_expected - 1
-            and operand_types
-            and operand_types[-1] is reg.CrDstructureIdxField
-        )
-        if not _optional_tail and n_provided != n_expected:
+        if n_provided != n_expected:
             raise ValueError(
                 f"Instruction {inst['opcode'].token.value} expects {n_expected} operands, "
                 f"got {n_provided}, in Line {self.opcode.token.line}, Column {self.opcode.token.column}."
@@ -108,23 +100,22 @@ class Inst:
         ]
         self.specific_operand_types = operand_types
 
-        # CrRegField=CR15 conflicts with CrDstructureIdx=CR15: they would both
-        # read CR15 for different purposes in the same instruction.
-        _cr_idx_is_cr15 = any(
-            op.encode() == 15
-            for op, t in zip(self.operands, operand_types)
-            if t is reg.CrRegField
-        )
-        _cr_dstruct_is_cr15 = _optional_tail or any(
-            op.encode() == 15
-            for op, t in zip(self.operands, operand_types)
-            if t is reg.CrDstructureIdxField
-        )
-        if _cr_idx_is_cr15 and _cr_dstruct_is_cr15:
+        # CR15 cannot serve as both cr_idx and cr_dstructure in the same instruction.
+        spec_operands = INSTRUCTION_SPEC[self._slot_type_name()].get(
+            struct_names[opcode_idx], {}
+        ).get("operands", [])
+        op_names = [op["name"] for op in spec_operands]
+        _cr_idx_pos = next((i for i, n in enumerate(op_names) if n == "cr_idx"), None)
+        _cr_dst_pos = next((i for i, n in enumerate(op_names) if n == "cr_dstructure"), None)
+        if (
+            _cr_idx_pos is not None
+            and _cr_dst_pos is not None
+            and self.operands[_cr_idx_pos].encode() == 15
+            and self.operands[_cr_dst_pos].encode() == 15
+        ):
             raise ValueError(
-                f"Instruction {inst['opcode'].token.value}: CR15 cannot be used as cr_idx "
-                f"when cr_dstructure is also CR15 (explicitly or by default) — "
-                f"the same register would serve two conflicting roles.\n"
+                f"Instruction {inst['opcode'].token.value}: CR15 cannot be used as both "
+                f"cr_idx and cr_dstructure — the same register would serve two conflicting roles.\n"
                 f"In Line {self.opcode.token.line}, Column {self.opcode.token.column}"
             )
 

--- a/src/tools/ipu-as-py/src/ipu_as/inst.py
+++ b/src/tools/ipu-as-py/src/ipu_as/inst.py
@@ -100,7 +100,7 @@ class Inst:
         ]
         self.specific_operand_types = operand_types
 
-        # CR15 cannot serve as both cr_idx and cr_dstructure in the same instruction.
+        # cr_idx and cr_dstructure cannot be the same register in the same instruction.
         spec_operands = INSTRUCTION_SPEC[self._slot_type_name()].get(
             struct_names[opcode_idx], {}
         ).get("operands", [])
@@ -110,11 +110,11 @@ class Inst:
         if (
             _cr_idx_pos is not None
             and _cr_dst_pos is not None
-            and self.operands[_cr_idx_pos].encode() == 15
-            and self.operands[_cr_dst_pos].encode() == 15
+            and self.operands[_cr_idx_pos].encode() == self.operands[_cr_dst_pos].encode()
         ):
+            cr_num = self.operands[_cr_idx_pos].encode()
             raise ValueError(
-                f"Instruction {inst['opcode'].token.value}: CR15 cannot be used as both "
+                f"Instruction {inst['opcode'].token.value}: CR{cr_num} cannot be used as both "
                 f"cr_idx and cr_dstructure — the same register would serve two conflicting roles.\n"
                 f"In Line {self.opcode.token.line}, Column {self.opcode.token.column}"
             )

--- a/src/tools/ipu-as-py/src/ipu_as/inst.py
+++ b/src/tools/ipu-as-py/src/ipu_as/inst.py
@@ -36,6 +36,7 @@ OPERAND_TYPE_MAP: dict[str, type[ipu_token.IpuToken]] = {
     "LrIdx": reg.LrRegField,
     "CrIdx": reg.CrRegField,
     "LcrIdx": reg.LcrRegField,
+    "CrDstructureIdx": reg.CrDstructureIdxField,
     "AddSubSrcB": immediate.AddSubSrcBField,
     "ElementsInRow": immediate.ElementsInRowField,
     "HorizontalStride": immediate.HorizontalStrideField,
@@ -44,7 +45,6 @@ OPERAND_TYPE_MAP: dict[str, type[ipu_token.IpuToken]] = {
     "MultMaskOffsetImmediate": immediate.MultMaskOffsetImmediate,
     "ActivationFn": immediate.ActivationFnField,
     "BreakImmediate": immediate.BreakImmediateType,
-    "FullXmemRow": immediate.FullXmemRowField,
     "Label": ipu_token.LabelToken,
 }
 
@@ -88,16 +88,45 @@ class Inst:
         struct_entry = struct_table[struct_names[opcode_idx]]
         operand_types = self._operand_types_from_struct(struct_entry)
 
-        if len(inst["operands"]) != len(operand_types):
+        n_provided = len(inst["operands"])
+        n_expected = len(operand_types)
+        # A trailing CrDstructureIdx operand is optional: when omitted it
+        # defaults to CR15 via _get_full_token_list → CrDstructureIdxField.default().
+        _optional_tail = (
+            n_provided == n_expected - 1
+            and operand_types
+            and operand_types[-1] is reg.CrDstructureIdxField
+        )
+        if not _optional_tail and n_provided != n_expected:
             raise ValueError(
-                f"Instruction {inst['opcode'].token.value} expects {len(operand_types)} operands, "
-                f"got {len(inst['operands'])}, in Line {self.opcode.token.line}, Column {self.opcode.token.column}."
+                f"Instruction {inst['opcode'].token.value} expects {n_expected} operands, "
+                f"got {n_provided}, in Line {self.opcode.token.line}, Column {self.opcode.token.column}."
             )
 
         self.operands = [
             op_type(op) for op_type, op in zip(operand_types, inst["operands"])
         ]
         self.specific_operand_types = operand_types
+
+        # CrRegField=CR15 conflicts with CrDstructureIdx=CR15: they would both
+        # read CR15 for different purposes in the same instruction.
+        _cr_idx_is_cr15 = any(
+            op.encode() == 15
+            for op, t in zip(self.operands, operand_types)
+            if t is reg.CrRegField
+        )
+        _cr_dstruct_is_cr15 = _optional_tail or any(
+            op.encode() == 15
+            for op, t in zip(self.operands, operand_types)
+            if t is reg.CrDstructureIdxField
+        )
+        if _cr_idx_is_cr15 and _cr_dstruct_is_cr15:
+            raise ValueError(
+                f"Instruction {inst['opcode'].token.value}: CR15 cannot be used as cr_idx "
+                f"when cr_dstructure is also CR15 (explicitly or by default) — "
+                f"the same register would serve two conflicting roles.\n"
+                f"In Line {self.opcode.token.line}, Column {self.opcode.token.column}"
+            )
 
     def _get_full_token_list(self) -> list[ipu_token.IpuToken]:
         full_token_list = [None for _ in range(1 + len(self.operand_types()))]

--- a/src/tools/ipu-as-py/src/ipu_as/reg.py
+++ b/src/tools/ipu-as-py/src/ipu_as/reg.py
@@ -8,6 +8,7 @@ Old code uses: from ipu_as.reg import MultStageRegField, LrRegField, etc.
 New code uses: from ipu_common.registers import create_regfile_schema, etc.
 """
 
+import lark
 import ipu_as.ipu_token as ipu_token
 from ipu_common.registers import create_assembler_reg_classes, create_assembler_reg_enums
 
@@ -56,15 +57,21 @@ def _reject_cr15(token: "ipu_token.AnnotatedToken", cls_name: str) -> None:
 
 
 class CrRegField(_CrRegFieldBase):
-    def __init__(self, token: ipu_token.AnnotatedToken):
-        _reject_cr15(token, "CrRegField")
-        super().__init__(token)
+    pass
 
 
 class LcrRegField(_LcrRegFieldBase):
     def __init__(self, token: ipu_token.AnnotatedToken):
         _reject_cr15(token, "LcrRegField")
         super().__init__(token)
+
+
+class CrDstructureIdxField(_CrRegFieldBase):
+    """CR register index for dstructure operands: accepts CR0–CR15 (including CR15), defaults to CR15."""
+
+    @classmethod
+    def default(cls) -> "ipu_token.IpuToken":
+        return cls(ipu_token.AnnotatedToken(lark.Token("TOKEN", "cr15"), 0))
 
 # For documentation and introspection, also expose the enum arrays
 _enums = create_assembler_reg_enums()
@@ -86,6 +93,7 @@ __all__ = [
     "LrRegField",
     "CrRegField",
     "LcrRegField",
+    "CrDstructureIdxField",
     # Field lists
     "MULT_STAGE_REG_R_FIELDS",
     "LR_REG_FIELDS",

--- a/src/tools/ipu-as-py/src/ipu_as/reg.py
+++ b/src/tools/ipu-as-py/src/ipu_as/reg.py
@@ -8,7 +8,6 @@ Old code uses: from ipu_as.reg import MultStageRegField, LrRegField, etc.
 New code uses: from ipu_common.registers import create_regfile_schema, etc.
 """
 
-import lark
 import ipu_as.ipu_token as ipu_token
 from ipu_common.registers import create_assembler_reg_classes, create_assembler_reg_enums
 
@@ -48,30 +47,13 @@ _CrRegFieldBase = _generated_classes.get("CrRegField")
 _LcrRegFieldBase = _generated_classes.get("LcrRegField")
 
 
-def _reject_cr15(token: "ipu_token.AnnotatedToken", cls_name: str) -> None:
-    if token.token.value.lower() == "cr15":
-        raise ValueError(
-            f"CR15 is reserved for dstructure configuration and cannot be used as an ISA operand.\n"
-            f"In Line {token.token.line}, Column {token.token.column}"
-        )
-
-
 class CrRegField(_CrRegFieldBase):
     pass
 
 
 class LcrRegField(_LcrRegFieldBase):
-    def __init__(self, token: ipu_token.AnnotatedToken):
-        _reject_cr15(token, "LcrRegField")
-        super().__init__(token)
+    pass
 
-
-class CrDstructureIdxField(_CrRegFieldBase):
-    """CR register index for dstructure operands: accepts CR0–CR15 (including CR15), defaults to CR15."""
-
-    @classmethod
-    def default(cls) -> "ipu_token.IpuToken":
-        return cls(ipu_token.AnnotatedToken(lark.Token("TOKEN", "cr15"), 0))
 
 # For documentation and introspection, also expose the enum arrays
 _enums = create_assembler_reg_enums()
@@ -93,7 +75,6 @@ __all__ = [
     "LrRegField",
     "CrRegField",
     "LcrRegField",
-    "CrDstructureIdxField",
     # Field lists
     "MULT_STAGE_REG_R_FIELDS",
     "LR_REG_FIELDS",

--- a/src/tools/ipu-common/src/ipu_common/instruction_spec.py
+++ b/src/tools/ipu-common/src/ipu_common/instruction_spec.py
@@ -24,7 +24,7 @@ KEY DESIGN PRINCIPLES:
 OPERAND TYPE NAMES (resolved by ipu_as into actual token classes):
   - "MultStageReg": R0 or R1 (MultStageRegField); 2-bit encoding in the VLIW word
   - "LrIdx": LR0–LR15 (LrRegField)  
-  - "CrIdx": CR0–CR15 (CrRegField); using CR15 as cr_idx conflicts with cr_dstructure=CR15 in the same instruction
+  - "CrIdx": CR0–CR15 (CrRegField); used both for scalar-source registers and for the cr_dstructure register index
   - "LcrIdx": LR0–LR15 or CR0–CR14 (LcrRegField)
   - "AddSubSrcB": second operand for ADD/SUB — LR, CR, or unsigned IMM5 (AddSubSrcBField; 6-bit encoding)
   - "LrModPow2KImmediate": k operand for INCR_MOD_POW2 (semantic k ∈ [1, 9]; encoded as k−1 in 4 bits)
@@ -436,7 +436,7 @@ INSTRUCTION_SPEC = {
                 {"name": "cyclic_offset", "type": "LrIdx", "read": "live"},
                 {"name": "mask_offset", "type": "MultMaskOffsetImmediate"},
                 {"name": "mask_shift", "type": "LrIdx", "read": "live"},
-                {"name": "cr_dstructure", "type": "CrDstructureIdx", "read": "live"},
+                {"name": "cr_dstructure", "type": "CrIdx", "read": "live"},
             ],
             "doc": InstructionDoc(
                 title="Element-wise Multiply",
@@ -447,7 +447,7 @@ INSTRUCTION_SPEC = {
                     "`cyclic_offset`: **`LR0`**…**`LR15`** — base byte offset into **`R_CYCLIC`**.",
                     "`mask_offset`: immediate mask slot **`0`**…**`7`** — selects one of eight 128-bit masks in **`R_MASK`**.",
                     "`mask_shift`: **`LR0`**…**`LR15`** — index ∈ [−3, +3] (values >3 clamp to 3, values <−3 clamp to −3) selecting one of seven masks via sequential shift-and-AND: positive indices use partition_vector (0 at group start), negative indices use inverse_partition_vector (0 at group end).",
-                    "`cr_dstructure`: **`CR0`**…**`CR15`** — CR register supplying partition configuration for the mask shift; defaults to **`CR15`**.",
+                    "`cr_dstructure`: **`CR0`**…**`CR15`** — CR register supplying partition configuration for the mask shift.",
                 ],
                 operation="For each lane i: MULT_RES[i] = ipu_mult(ra[i], R_CYCLIC[cyclic_offset + i]); then apply mask and shift using partition from cr_dstructure.",
                 example="MULT.EE R0, LR0, 0, LR2, CR15;;",
@@ -461,7 +461,7 @@ INSTRUCTION_SPEC = {
                 {"name": "mask_offset", "type": "MultMaskOffsetImmediate"},
                 {"name": "mask_shift", "type": "LrIdx", "read": "live"},
                 {"name": "fixed_idx", "type": "LrIdx", "read": "live"},
-                {"name": "cr_dstructure", "type": "CrDstructureIdx", "read": "live"},
+                {"name": "cr_dstructure", "type": "CrIdx", "read": "live"},
             ],
             "doc": InstructionDoc(
                 title="Vector-Element Multiply (cyclic RC)",
@@ -476,7 +476,7 @@ INSTRUCTION_SPEC = {
                     "`mask_offset`: immediate mask slot **`0`**…**`7`** — selects one of eight 128-bit masks in **`R_MASK`**.",
                     "`mask_shift`: **`LR0`**…**`LR15`** — index ∈ [−3, +3] (values >3 clamp to 3, values <−3 clamp to −3) selecting one of seven masks via sequential shift-and-AND: positive indices use partition_vector (0 at group start), negative indices use inverse_partition_vector (0 at group end).",
                     "`fixed_idx`: **`LR0`**…**`LR15`** (value read live) — scalar index into **`R0`**/**`R1`**.",
-                    "`cr_dstructure`: **`CR0`**…**`CR15`** — CR register supplying partition configuration for the mask shift; defaults to **`CR15`**.",
+                    "`cr_dstructure`: **`CR0`**…**`CR15`** — CR register supplying partition configuration for the mask shift.",
                 ],
                 operation="For i in [0, 128): rb = R_CYCLIC[(cyclic_offset + i) % 512]; scalar from R0/R1 via fixed_idx; MULT_RES[i] = scalar * rb (then mask/shift using partition from cr_dstructure).",
                 example="MULT.VE.CYCLIC LR0, 0, LR2, LR3, CR15;;",
@@ -490,7 +490,7 @@ INSTRUCTION_SPEC = {
                 {"name": "mask_offset", "type": "MultMaskOffsetImmediate"},
                 {"name": "mask_shift", "type": "LrIdx", "read": "live"},
                 {"name": "fixed_idx", "type": "LrIdx", "read": "live"},
-                {"name": "cr_dstructure", "type": "CrDstructureIdx", "read": "live"},
+                {"name": "cr_dstructure", "type": "CrIdx", "read": "live"},
             ],
             "doc": InstructionDoc(
                 title="Vector-Element Multiply (padded RC)",
@@ -504,7 +504,7 @@ INSTRUCTION_SPEC = {
                     "`mask_offset`: immediate mask slot **`0`**…**`7`** — selects one of eight 128-bit masks in `R_MASK`.",
                     "`mask_shift`: **`LR0`**…**`LR15`** — index ∈ [−3, +3] (values >3 clamp to 3, values <−3 clamp to −3) selecting one of seven masks via sequential shift-and-AND: positive indices use partition_vector (0 at group start), negative indices use inverse_partition_vector (0 at group end).",
                     "`fixed_idx`: **`LR0`**…**`LR15`** (value read live) — scalar index into **`R0`**/**`R1`**.",
-                    "`cr_dstructure`: **`CR0`**…**`CR15`** — CR register supplying partition configuration for the mask shift; defaults to **`CR15`**.",
+                    "`cr_dstructure`: **`CR0`**…**`CR15`** — CR register supplying partition configuration for the mask shift.",
                 ],
                 operation="For i in [0, 128): rb = R_CYCLIC[cyclic_offset + i] if in bounds else dtype_one; scalar from R0/R1; MULT_RES[i] = scalar * rb (then mask/shift using partition from cr_dstructure).",
                 example="MULT.VE.PADDED LR0, 0, LR2, LR3, CR15;;",
@@ -528,7 +528,7 @@ INSTRUCTION_SPEC = {
                 {"name": "mask_offset", "type": "MultMaskOffsetImmediate"},
                 {"name": "mask_shift", "type": "LrIdx", "read": "live"},
                 {"name": "cr_idx", "type": "CrIdx"},
-                {"name": "cr_dstructure", "type": "CrDstructureIdx", "read": "live"},
+                {"name": "cr_dstructure", "type": "CrIdx", "read": "live"},
             ],
             "doc": InstructionDoc(
                 title="Vector-Element Multiply (CR scalar)",
@@ -539,7 +539,7 @@ INSTRUCTION_SPEC = {
                     "mask_offset: Immediate mask slot 0–7 (128-bit slice of R_MASK)",
                     "mask_shift: index ∈ [−3, +3] (values >3 clamp to 3, values <−3 clamp to −3) selecting one of seven masks via sequential shift-and-AND: positive indices use partition_vector (0 at group start), negative indices use inverse_partition_vector (0 at group end)",
                     "cr_idx: CR register whose low byte supplies the fixed scalar multiplier (CR0–CR15; CR15 is only valid when cr_dstructure is not CR15)",
-                    "cr_dstructure: CR register supplying partition configuration for the mask shift (CR0–CR15); defaults to CR15",
+                    "cr_dstructure: CR register supplying partition configuration for the mask shift (CR0–CR15)",
                 ],
                 operation="For i in [0,128): rb = RC[cyclic_offset+i] if in bounds else dtype_one; MULT_RES[i] = CR[cr_idx][0] * rb; mask/shift using partition from cr_dstructure",
                 example="MULT.VE.CR LR0, 0, LR15, CR3, CR15;;",
@@ -552,7 +552,7 @@ INSTRUCTION_SPEC = {
                 {"name": "ra", "type": "MultStageReg", "read": "live"},
                 {"name": "mask_offset", "type": "MultMaskOffsetImmediate"},
                 {"name": "mask_shift", "type": "LrIdx", "read": "live"},
-                {"name": "cr_dstructure", "type": "CrDstructureIdx", "read": "live"},
+                {"name": "cr_dstructure", "type": "CrIdx", "read": "live"},
             ],
             "doc": InstructionDoc(
                 title="Multi-Element Multiply (register by register)",
@@ -566,7 +566,7 @@ INSTRUCTION_SPEC = {
                     "`ra`: **`R0`** | **`R1`** — selects the MEE mode; the chosen register is both multiplicand and multiplier (same cycle as `LDR_MULT_REG` into **`R0`**/**`R1`** is allowed).",
                     "`mask_offset`: immediate mask slot **`0`**…**`7`** — selects one of eight 128-bit masks in **`r_mask`**.",
                     "`mask_shift`: **`LR0`**…**`LR15`** — index ∈ [−3, +3] (values >3 clamp to 3, values <−3 clamp to −3) selecting one of seven masks via sequential shift-and-AND: positive indices use partition_vector (0 at group start), negative indices use inverse_partition_vector (0 at group end).",
-                    "`cr_dstructure`: **`CR0`**…**`CR15`** — CR register supplying partition configuration for the mask shift; defaults to **`CR15`**.",
+                    "`cr_dstructure`: **`CR0`**…**`CR15`** — CR register supplying partition configuration for the mask shift.",
                 ],
                 operation="For each lane i: mult_res[i] = ipu_mult(ra[i], ra[i]); then apply mask and shift using partition from cr_dstructure.",
                 example="MULT.EE.RR R0, 0, LR2, CR15;;",
@@ -653,19 +653,19 @@ INSTRUCTION_SPEC = {
         "AGG.SUM.FIRST": {
             "operands": [
                 {"name": "dest_slot", "type": "LrIdx", "read": "snapshot"},
-                {"name": "cr_dstructure", "type": "CrDstructureIdx", "read": "live"},
+                {"name": "cr_dstructure", "type": "CrIdx", "read": "live"},
             ],
             "doc": InstructionDoc(
                 title="Aggregate Sum (First)",
                 summary=(
                     "Sum active R_ACC lanes and write the result into R_ACC at the slot given by LR. "
                     "The current value at the destination slot is NOT included in the sum (clean initialisation). "
-                    "The active lane count is read from ``cr_dstructure.valid_elements`` (defaults to CR15)."
+                    "The active lane count is read from ``cr_dstructure.valid_elements``."
                 ),
                 syntax="AGG.SUM.FIRST dest_slot, cr_dstructure",
                 operands=[
                     "dest_slot: LR register whose value gives the destination slot in R_ACC (0–127)",
-                    "cr_dstructure: CR register (CR0–CR15) supplying valid_elements; defaults to CR15",
+                    "cr_dstructure: CR register (CR0–CR15) supplying valid_elements",
                 ],
                 operation=(
                     "Let n = min(cr_dstructure.valid_elements, 128). "
@@ -679,19 +679,19 @@ INSTRUCTION_SPEC = {
         "AGG.SUM": {
             "operands": [
                 {"name": "dest_slot", "type": "LrIdx", "read": "snapshot"},
-                {"name": "cr_dstructure", "type": "CrDstructureIdx", "read": "live"},
+                {"name": "cr_dstructure", "type": "CrIdx", "read": "live"},
             ],
             "doc": InstructionDoc(
                 title="Aggregate Sum",
                 summary=(
                     "Sum active R_ACC lanes and ADD the result to R_ACC at the slot given by LR "
                     "(running cross-cycle accumulation). "
-                    "The active lane count is read from ``cr_dstructure.valid_elements`` (defaults to CR15)."
+                    "The active lane count is read from ``cr_dstructure.valid_elements``."
                 ),
                 syntax="AGG.SUM dest_slot, cr_dstructure",
                 operands=[
                     "dest_slot: LR register whose value gives the destination slot in R_ACC (0–127)",
-                    "cr_dstructure: CR register (CR0–CR15) supplying valid_elements; defaults to CR15",
+                    "cr_dstructure: CR register (CR0–CR15) supplying valid_elements",
                 ],
                 operation=(
                     "Let n = min(cr_dstructure.valid_elements, 128). "
@@ -705,19 +705,19 @@ INSTRUCTION_SPEC = {
         "AGG.MAX.FIRST": {
             "operands": [
                 {"name": "dest_slot", "type": "LrIdx", "read": "snapshot"},
-                {"name": "cr_dstructure", "type": "CrDstructureIdx", "read": "live"},
+                {"name": "cr_dstructure", "type": "CrIdx", "read": "live"},
             ],
             "doc": InstructionDoc(
                 title="Aggregate Max (First)",
                 summary=(
                     "Find the maximum of active R_ACC lanes and write it into R_ACC at the slot given by LR. "
                     "The current value at the destination slot is NOT used as a seed (clean initialisation). "
-                    "The active lane count is read from ``cr_dstructure.valid_elements`` (defaults to CR15)."
+                    "The active lane count is read from ``cr_dstructure.valid_elements``."
                 ),
                 syntax="AGG.MAX.FIRST dest_slot, cr_dstructure",
                 operands=[
                     "dest_slot: LR register whose value gives the destination slot in R_ACC (0–127)",
-                    "cr_dstructure: CR register (CR0–CR15) supplying valid_elements; defaults to CR15",
+                    "cr_dstructure: CR register (CR0–CR15) supplying valid_elements",
                 ],
                 operation=(
                     "Let n = min(cr_dstructure.valid_elements, 128). "
@@ -732,19 +732,19 @@ INSTRUCTION_SPEC = {
         "AGG.MAX": {
             "operands": [
                 {"name": "dest_slot", "type": "LrIdx", "read": "snapshot"},
-                {"name": "cr_dstructure", "type": "CrDstructureIdx", "read": "live"},
+                {"name": "cr_dstructure", "type": "CrIdx", "read": "live"},
             ],
             "doc": InstructionDoc(
                 title="Aggregate Max",
                 summary=(
                     "Find the maximum of active R_ACC lanes seeded with the current destination slot value "
                     "(running cross-cycle max). "
-                    "The active lane count is read from ``cr_dstructure.valid_elements`` (defaults to CR15)."
+                    "The active lane count is read from ``cr_dstructure.valid_elements``."
                 ),
                 syntax="AGG.MAX dest_slot, cr_dstructure",
                 operands=[
                     "dest_slot: LR register whose value gives the destination slot in R_ACC (0–127)",
-                    "cr_dstructure: CR register (CR0–CR15) supplying valid_elements; defaults to CR15",
+                    "cr_dstructure: CR register (CR0–CR15) supplying valid_elements",
                 ],
                 operation=(
                     "Let n = min(cr_dstructure.valid_elements, 128). "
@@ -774,7 +774,7 @@ INSTRUCTION_SPEC = {
         },
         "AAQ": {
             "operands": [
-                {"name": "cr_dstructure", "type": "CrDstructureIdx", "read": "live"},
+                {"name": "cr_dstructure", "type": "CrIdx", "read": "live"},
             ],
             "doc": InstructionDoc(
                 title="AAQ Quantize",
@@ -783,11 +783,11 @@ INSTRUCTION_SPEC = {
                     "to INT8, storing clamped bytes in the **leading 128 bytes** of **`POST_AAQ_REG`** "
                     "and clearing the rest of the register. Wide lanes are normally produced by "
                     "**`ACTIVATE`** (from ``r_acc``). Requires INT8 mode. "
-                    "The active lane count is read from ``cr_dstructure.valid_elements`` (defaults to CR15)."
+                    "The active lane count is read from ``cr_dstructure.valid_elements``."
                 ),
                 syntax="AAQ cr_dstructure",
                 operands=[
-                    "cr_dstructure: CR register (CR0–CR15) supplying valid_elements lane count; defaults to CR15",
+                    "cr_dstructure: CR register (CR0–CR15) supplying valid_elements lane count",
                 ],
                 operation=(
                     "Requires INT8 mode (IpuState.dtype == DType.INT8 in the Python emulator). "
@@ -804,14 +804,14 @@ INSTRUCTION_SPEC = {
         "ACTIVATE": {
             "operands": [
                 {"name": "activation_fn", "type": "ActivationFn"},
-                {"name": "cr_dstructure", "type": "CrDstructureIdx", "read": "live"},
+                {"name": "cr_dstructure", "type": "CrIdx", "read": "live"},
             ],
             "doc": InstructionDoc(
                 title="Accumulator Activation",
                 summary=(
                     "Read active lanes from ``r_acc``, apply the selected element-wise activation, "
                     "and write results into the same lane indices of ``POST_AAQ_REG`` (``r_acc`` is unchanged). "
-                    "The active lane count is read from ``cr_dstructure.valid_elements`` (defaults to CR15). "
+                    "The active lane count is read from ``cr_dstructure.valid_elements``. "
                     "The activation is selected by keyword (see ACTIVATION_FN_NAMES). The available "
                     "activation functions are: ``identity`` (0), ``relu`` (1), ``relu6`` (2), "
                     "``sigmoid`` (3), ``tanh`` (4), ``gelu`` (5), ``softplus`` (6), ``elu`` (7), "
@@ -821,7 +821,7 @@ INSTRUCTION_SPEC = {
                 syntax="ACTIVATE activation_fn, cr_dstructure",
                 operands=[
                     "activation_fn: keyword naming the activation (one of identity, relu, relu6, sigmoid, tanh, gelu, softplus, elu, exp2; see ACTIVATION_FN_NAMES)",
-                    "cr_dstructure: CR register (CR0–CR15) supplying valid_elements lane count; defaults to CR15",
+                    "cr_dstructure: CR register (CR0–CR15) supplying valid_elements lane count",
                 ],
                 operation=(
                     "Let n = min(cr_dstructure.valid_elements, 128) "
@@ -1255,7 +1255,6 @@ VALID_OPERAND_TYPES: frozenset[str] = frozenset(
         "BreakImmediate",
         "Label",
         "AddSubSrcB",
-        "CrDstructureIdx",
     }
 )
 

--- a/src/tools/ipu-common/src/ipu_common/instruction_spec.py
+++ b/src/tools/ipu-common/src/ipu_common/instruction_spec.py
@@ -24,7 +24,7 @@ KEY DESIGN PRINCIPLES:
 OPERAND TYPE NAMES (resolved by ipu_as into actual token classes):
   - "MultStageReg": R0 or R1 (MultStageRegField); 2-bit encoding in the VLIW word
   - "LrIdx": LR0–LR15 (LrRegField)  
-  - "CrIdx": CR0–CR14 (CrRegField)
+  - "CrIdx": CR0–CR15 (CrRegField); using CR15 as cr_idx conflicts with cr_dstructure=CR15 in the same instruction
   - "LcrIdx": LR0–LR15 or CR0–CR14 (LcrRegField)
   - "AddSubSrcB": second operand for ADD/SUB — LR, CR, or unsigned IMM5 (AddSubSrcBField; 6-bit encoding)
   - "LrModPow2KImmediate": k operand for INCR_MOD_POW2 (semantic k ∈ [1, 9]; encoded as k−1 in 4 bits)
@@ -436,19 +436,21 @@ INSTRUCTION_SPEC = {
                 {"name": "cyclic_offset", "type": "LrIdx", "read": "live"},
                 {"name": "mask_offset", "type": "MultMaskOffsetImmediate"},
                 {"name": "mask_shift", "type": "LrIdx", "read": "live"},
+                {"name": "cr_dstructure", "type": "CrDstructureIdx", "read": "live"},
             ],
             "doc": InstructionDoc(
                 title="Element-wise Multiply",
                 summary="Multiply elements of two registers element by element.",
-                syntax="MULT.EE ra, cyclic_offset, mask_offset, mask_shift",
+                syntax="MULT.EE ra, cyclic_offset, mask_offset, mask_shift, cr_dstructure",
                 operands=[
                     "`ra`: **`R0`** | **`R1`** — multiplicand mult-stage register (same cycle as `LDR_MULT_REG` into **`R0`**/**`R1`** is allowed).",
                     "`cyclic_offset`: **`LR0`**…**`LR15`** — base byte offset into **`R_CYCLIC`**.",
                     "`mask_offset`: immediate mask slot **`0`**…**`7`** — selects one of eight 128-bit masks in **`R_MASK`**.",
                     "`mask_shift`: **`LR0`**…**`LR15`** — index ∈ [−3, +3] (values >3 clamp to 3, values <−3 clamp to −3) selecting one of seven masks via sequential shift-and-AND: positive indices use partition_vector (0 at group start), negative indices use inverse_partition_vector (0 at group end).",
+                    "`cr_dstructure`: **`CR0`**…**`CR15`** — CR register supplying partition configuration for the mask shift; defaults to **`CR15`**.",
                 ],
-                operation="For each lane i: MULT_RES[i] = ipu_mult(ra[i], R_CYCLIC[cyclic_offset + i]); then apply mask and shift.",
-                example="MULT.EE R0, LR0, 0, LR2;;",
+                operation="For each lane i: MULT_RES[i] = ipu_mult(ra[i], R_CYCLIC[cyclic_offset + i]); then apply mask and shift using partition from cr_dstructure.",
+                example="MULT.EE R0, LR0, 0, LR2, CR15;;",
                 notes="Lane masking via `mask_offset` and `mask_shift` zeroes lanes whose derived mask bit is **0** (deactivated) in `MULT_RES` before accumulation; lanes with bit **1** pass through. See [Masking](assembly-syntax.md#masking) for the full algorithm.",
             ),
             "execute_fn": "execute_mult_ee",
@@ -459,6 +461,7 @@ INSTRUCTION_SPEC = {
                 {"name": "mask_offset", "type": "MultMaskOffsetImmediate"},
                 {"name": "mask_shift", "type": "LrIdx", "read": "live"},
                 {"name": "fixed_idx", "type": "LrIdx", "read": "live"},
+                {"name": "cr_dstructure", "type": "CrDstructureIdx", "read": "live"},
             ],
             "doc": InstructionDoc(
                 title="Vector-Element Multiply (cyclic RC)",
@@ -467,15 +470,16 @@ INSTRUCTION_SPEC = {
                     "`fixed_idx` 0..127 selects `R0[fixed_idx]`, 128..255 selects `R1[fixed_idx - 128]`. "
                     "R_CYCLIC is addressed cyclically modulo 512 elements (no padding with 1 past the boundary)."
                 ),
-                syntax="MULT.VE.CYCLIC cyclic_offset, mask_offset, mask_shift, fixed_idx",
+                syntax="MULT.VE.CYCLIC cyclic_offset, mask_offset, mask_shift, fixed_idx, cr_dstructure",
                 operands=[
                     "`cyclic_offset`: **`LR0`**…**`LR15`** — base byte offset into **`R_CYCLIC`** (reduced mod 512).",
                     "`mask_offset`: immediate mask slot **`0`**…**`7`** — selects one of eight 128-bit masks in **`R_MASK`**.",
                     "`mask_shift`: **`LR0`**…**`LR15`** — index ∈ [−3, +3] (values >3 clamp to 3, values <−3 clamp to −3) selecting one of seven masks via sequential shift-and-AND: positive indices use partition_vector (0 at group start), negative indices use inverse_partition_vector (0 at group end).",
                     "`fixed_idx`: **`LR0`**…**`LR15`** (value read live) — scalar index into **`R0`**/**`R1`**.",
+                    "`cr_dstructure`: **`CR0`**…**`CR15`** — CR register supplying partition configuration for the mask shift; defaults to **`CR15`**.",
                 ],
-                operation="For i in [0, 128): rb = R_CYCLIC[(cyclic_offset + i) % 512]; scalar from R0/R1 via fixed_idx; MULT_RES[i] = scalar * rb (then mask/shift).",
-                example="MULT.VE.CYCLIC LR0, 0, LR2, LR3;;",
+                operation="For i in [0, 128): rb = R_CYCLIC[(cyclic_offset + i) % 512]; scalar from R0/R1 via fixed_idx; MULT_RES[i] = scalar * rb (then mask/shift using partition from cr_dstructure).",
+                example="MULT.VE.CYCLIC LR0, 0, LR2, LR3, CR15;;",
                 notes="Lane masking via `mask_offset` and `mask_shift` zeroes lanes whose derived mask bit is **0** (deactivated) in `MULT_RES` before accumulation; lanes with bit **1** pass through. See [Masking](assembly-syntax.md#masking) for the full algorithm.",
             ),
             "execute_fn": "execute_mult_ve_cyclic",
@@ -486,6 +490,7 @@ INSTRUCTION_SPEC = {
                 {"name": "mask_offset", "type": "MultMaskOffsetImmediate"},
                 {"name": "mask_shift", "type": "LrIdx", "read": "live"},
                 {"name": "fixed_idx", "type": "LrIdx", "read": "live"},
+                {"name": "cr_dstructure", "type": "CrDstructureIdx", "read": "live"},
             ],
             "doc": InstructionDoc(
                 title="Vector-Element Multiply (padded RC)",
@@ -493,15 +498,16 @@ INSTRUCTION_SPEC = {
                     "Same scalar × RC row as `MULT.VE.CYCLIC`, but indices at or past the 512-byte RC "
                     "boundary within the 128-element window use a dtype-specific 1 instead of wrapping."
                 ),
-                syntax="MULT.VE.PADDED cyclic_offset, mask_offset, mask_shift, fixed_idx",
+                syntax="MULT.VE.PADDED cyclic_offset, mask_offset, mask_shift, fixed_idx, cr_dstructure",
                 operands=[
                     "`cyclic_offset`: **`LR0`**…**`LR15`** — base byte offset into `R_CYCLIC`; out-of-range lanes use dtype 1.",
                     "`mask_offset`: immediate mask slot **`0`**…**`7`** — selects one of eight 128-bit masks in `R_MASK`.",
                     "`mask_shift`: **`LR0`**…**`LR15`** — index ∈ [−3, +3] (values >3 clamp to 3, values <−3 clamp to −3) selecting one of seven masks via sequential shift-and-AND: positive indices use partition_vector (0 at group start), negative indices use inverse_partition_vector (0 at group end).",
                     "`fixed_idx`: **`LR0`**…**`LR15`** (value read live) — scalar index into **`R0`**/**`R1`**.",
+                    "`cr_dstructure`: **`CR0`**…**`CR15`** — CR register supplying partition configuration for the mask shift; defaults to **`CR15`**.",
                 ],
-                operation="For i in [0, 128): rb = R_CYCLIC[cyclic_offset + i] if in bounds else dtype_one; scalar from R0/R1; MULT_RES[i] = scalar * rb (then mask/shift).",
-                example="MULT.VE.PADDED LR0, 0, LR2, LR3;;",
+                operation="For i in [0, 128): rb = R_CYCLIC[cyclic_offset + i] if in bounds else dtype_one; scalar from R0/R1; MULT_RES[i] = scalar * rb (then mask/shift using partition from cr_dstructure).",
+                example="MULT.VE.PADDED LR0, 0, LR2, LR3, CR15;;",
                 notes="Lane masking via `mask_offset` and `mask_shift` zeroes lanes whose derived mask bit is **0** (deactivated) in `MULT_RES` before accumulation; lanes with bit **1** pass through. See [Masking](assembly-syntax.md#masking) for the full algorithm.",
             ),
             "execute_fn": "execute_mult_ve_padded",
@@ -522,19 +528,21 @@ INSTRUCTION_SPEC = {
                 {"name": "mask_offset", "type": "MultMaskOffsetImmediate"},
                 {"name": "mask_shift", "type": "LrIdx", "read": "live"},
                 {"name": "cr_idx", "type": "CrIdx"},
+                {"name": "cr_dstructure", "type": "CrDstructureIdx", "read": "live"},
             ],
             "doc": InstructionDoc(
                 title="Vector-Element Multiply (CR scalar)",
                 summary="Multiply each element of RC[cyclic_offset:cyclic_offset+128] by a scalar from a CR register. Elements beyond RC boundary are treated as 1 (dtype-specific).",
-                syntax="MULT.VE.CR cyclic_offset, mask_offset, mask_shift, cr_idx",
+                syntax="MULT.VE.CR cyclic_offset, mask_offset, mask_shift, cr_idx, cr_dstructure",
                 operands=[
                     "cyclic_offset: Base offset into RC (cyclic register); non-cyclic — out-of-bounds elements are padded with 1",
                     "mask_offset: Immediate mask slot 0–7 (128-bit slice of R_MASK)",
                     "mask_shift: index ∈ [−3, +3] (values >3 clamp to 3, values <−3 clamp to −3) selecting one of seven masks via sequential shift-and-AND: positive indices use partition_vector (0 at group start), negative indices use inverse_partition_vector (0 at group end)",
-                    "cr_idx: CR register whose low byte supplies the fixed scalar multiplier (CR0–CR14)",
+                    "cr_idx: CR register whose low byte supplies the fixed scalar multiplier (CR0–CR15; CR15 is only valid when cr_dstructure is not CR15)",
+                    "cr_dstructure: CR register supplying partition configuration for the mask shift (CR0–CR15); defaults to CR15",
                 ],
-                operation="For i in [0,128): rb = RC[cyclic_offset+i] if in bounds else dtype_one; MULT_RES[i] = CR[cr_idx][0] * rb",
-                example="MULT.VE.CR LR0, 0, LR15, CR3;;",
+                operation="For i in [0,128): rb = RC[cyclic_offset+i] if in bounds else dtype_one; MULT_RES[i] = CR[cr_idx][0] * rb; mask/shift using partition from cr_dstructure",
+                example="MULT.VE.CR LR0, 0, LR15, CR3, CR15;;",
                 notes="Lane masking via `mask_offset` and `mask_shift` zeroes lanes whose derived mask bit is **0** (deactivated) in `MULT_RES` before accumulation; lanes with bit **1** pass through. See [Masking](assembly-syntax.md#masking) for the full algorithm.",
             ),
             "execute_fn": "execute_mult_ve_cr",
@@ -544,6 +552,7 @@ INSTRUCTION_SPEC = {
                 {"name": "ra", "type": "MultStageReg", "read": "live"},
                 {"name": "mask_offset", "type": "MultMaskOffsetImmediate"},
                 {"name": "mask_shift", "type": "LrIdx", "read": "live"},
+                {"name": "cr_dstructure", "type": "CrDstructureIdx", "read": "live"},
             ],
             "doc": InstructionDoc(
                 title="Multi-Element Multiply (register by register)",
@@ -552,14 +561,15 @@ INSTRUCTION_SPEC = {
                     "element by element against itself. `ra` selects the execution "
                     "mode — **`R0`** gives r0-by-r0, **`R1`** gives r1-by-r1."
                 ),
-                syntax="MULT.EE.RR ra, mask_offset, mask_shift",
+                syntax="MULT.EE.RR ra, mask_offset, mask_shift, cr_dstructure",
                 operands=[
                     "`ra`: **`R0`** | **`R1`** — selects the MEE mode; the chosen register is both multiplicand and multiplier (same cycle as `LDR_MULT_REG` into **`R0`**/**`R1`** is allowed).",
                     "`mask_offset`: immediate mask slot **`0`**…**`7`** — selects one of eight 128-bit masks in **`r_mask`**.",
                     "`mask_shift`: **`LR0`**…**`LR15`** — index ∈ [−3, +3] (values >3 clamp to 3, values <−3 clamp to −3) selecting one of seven masks via sequential shift-and-AND: positive indices use partition_vector (0 at group start), negative indices use inverse_partition_vector (0 at group end).",
+                    "`cr_dstructure`: **`CR0`**…**`CR15`** — CR register supplying partition configuration for the mask shift; defaults to **`CR15`**.",
                 ],
-                operation="For each lane i: mult_res[i] = ipu_mult(ra[i], ra[i]); then apply mask and shift.",
-                example="MULT.EE.RR R0, 0, LR2;;",
+                operation="For each lane i: mult_res[i] = ipu_mult(ra[i], ra[i]); then apply mask and shift using partition from cr_dstructure.",
+                example="MULT.EE.RR R0, 0, LR2, CR15;;",
                 notes="Lane masking via `mask_offset` and `mask_shift` zeroes lanes whose derived mask bit is **0** (deactivated) in `MULT_RES` before accumulation; lanes with bit **1** pass through. See [Masking](assembly-syntax.md#masking) for the full algorithm.",
             ),
             "execute_fn": "execute_mult_ee_rr",
@@ -643,105 +653,105 @@ INSTRUCTION_SPEC = {
         "AGG.SUM.FIRST": {
             "operands": [
                 {"name": "dest_slot", "type": "LrIdx", "read": "snapshot"},
-                {"name": "full_xmem_row", "type": "FullXmemRow"},
+                {"name": "cr_dstructure", "type": "CrDstructureIdx", "read": "live"},
             ],
             "doc": InstructionDoc(
                 title="Aggregate Sum (First)",
                 summary=(
                     "Sum active R_ACC lanes and write the result into R_ACC at the slot given by LR. "
                     "The current value at the destination slot is NOT included in the sum (clean initialisation). "
-                    "``full_xmem_row=1`` always uses 128 lanes; ``full_xmem_row=0`` uses CR15.valid_elements."
+                    "The active lane count is read from ``cr_dstructure.valid_elements`` (defaults to CR15)."
                 ),
-                syntax="AGG.SUM.FIRST dest_slot, full_xmem_row",
+                syntax="AGG.SUM.FIRST dest_slot, cr_dstructure",
                 operands=[
                     "dest_slot: LR register whose value gives the destination slot in R_ACC (0–127)",
-                    "full_xmem_row: 1 = always 128 lanes; 0 = use CR15.valid_elements",
+                    "cr_dstructure: CR register (CR0–CR15) supplying valid_elements; defaults to CR15",
                 ],
                 operation=(
-                    "Let n = 128 if full_xmem_row else min(CR15.valid_elements, 128). "
+                    "Let n = min(cr_dstructure.valid_elements, 128). "
                     "dest = LR[dest_slot] % 128. "
                     "R_ACC[dest] = sum(R_ACC[0..n-1])."
                 ),
-                example="AGG.SUM.FIRST LR0, 0;;",
+                example="AGG.SUM.FIRST LR0, CR15;;",
             ),
             "execute_fn": "execute_agg_sum_first",
         },
         "AGG.SUM": {
             "operands": [
                 {"name": "dest_slot", "type": "LrIdx", "read": "snapshot"},
-                {"name": "full_xmem_row", "type": "FullXmemRow"},
+                {"name": "cr_dstructure", "type": "CrDstructureIdx", "read": "live"},
             ],
             "doc": InstructionDoc(
                 title="Aggregate Sum",
                 summary=(
                     "Sum active R_ACC lanes and ADD the result to R_ACC at the slot given by LR "
                     "(running cross-cycle accumulation). "
-                    "``full_xmem_row=1`` always uses 128 lanes; ``full_xmem_row=0`` uses CR15.valid_elements."
+                    "The active lane count is read from ``cr_dstructure.valid_elements`` (defaults to CR15)."
                 ),
-                syntax="AGG.SUM dest_slot, full_xmem_row",
+                syntax="AGG.SUM dest_slot, cr_dstructure",
                 operands=[
                     "dest_slot: LR register whose value gives the destination slot in R_ACC (0–127)",
-                    "full_xmem_row: 1 = always 128 lanes; 0 = use CR15.valid_elements",
+                    "cr_dstructure: CR register (CR0–CR15) supplying valid_elements; defaults to CR15",
                 ],
                 operation=(
-                    "Let n = 128 if full_xmem_row else min(CR15.valid_elements, 128). "
+                    "Let n = min(cr_dstructure.valid_elements, 128). "
                     "dest = LR[dest_slot] % 128. "
                     "R_ACC[dest] = sum(R_ACC[0..n-1]) + R_ACC[dest]."
                 ),
-                example="AGG.SUM LR0, 0;;",
+                example="AGG.SUM LR0, CR15;;",
             ),
             "execute_fn": "execute_agg_sum",
         },
         "AGG.MAX.FIRST": {
             "operands": [
                 {"name": "dest_slot", "type": "LrIdx", "read": "snapshot"},
-                {"name": "full_xmem_row", "type": "FullXmemRow"},
+                {"name": "cr_dstructure", "type": "CrDstructureIdx", "read": "live"},
             ],
             "doc": InstructionDoc(
                 title="Aggregate Max (First)",
                 summary=(
                     "Find the maximum of active R_ACC lanes and write it into R_ACC at the slot given by LR. "
                     "The current value at the destination slot is NOT used as a seed (clean initialisation). "
-                    "``full_xmem_row=1`` always uses 128 lanes; ``full_xmem_row=0`` uses CR15.valid_elements."
+                    "The active lane count is read from ``cr_dstructure.valid_elements`` (defaults to CR15)."
                 ),
-                syntax="AGG.MAX.FIRST dest_slot, full_xmem_row",
+                syntax="AGG.MAX.FIRST dest_slot, cr_dstructure",
                 operands=[
                     "dest_slot: LR register whose value gives the destination slot in R_ACC (0–127)",
-                    "full_xmem_row: 1 = always 128 lanes; 0 = use CR15.valid_elements",
+                    "cr_dstructure: CR register (CR0–CR15) supplying valid_elements; defaults to CR15",
                 ],
                 operation=(
-                    "Let n = 128 if full_xmem_row else min(CR15.valid_elements, 128). "
+                    "Let n = min(cr_dstructure.valid_elements, 128). "
                     "dest = LR[dest_slot] % 128. "
                     "R_ACC[dest] = max(R_ACC[0..n-1]); when n = 0 the identity seed "
                     "(INT32_MIN for integer lanes, -inf for float lanes) is written."
                 ),
-                example="AGG.MAX.FIRST LR0, 0;;",
+                example="AGG.MAX.FIRST LR0, CR15;;",
             ),
             "execute_fn": "execute_agg_max_first",
         },
         "AGG.MAX": {
             "operands": [
                 {"name": "dest_slot", "type": "LrIdx", "read": "snapshot"},
-                {"name": "full_xmem_row", "type": "FullXmemRow"},
+                {"name": "cr_dstructure", "type": "CrDstructureIdx", "read": "live"},
             ],
             "doc": InstructionDoc(
                 title="Aggregate Max",
                 summary=(
                     "Find the maximum of active R_ACC lanes seeded with the current destination slot value "
                     "(running cross-cycle max). "
-                    "``full_xmem_row=1`` always uses 128 lanes; ``full_xmem_row=0`` uses CR15.valid_elements."
+                    "The active lane count is read from ``cr_dstructure.valid_elements`` (defaults to CR15)."
                 ),
-                syntax="AGG.MAX dest_slot, full_xmem_row",
+                syntax="AGG.MAX dest_slot, cr_dstructure",
                 operands=[
                     "dest_slot: LR register whose value gives the destination slot in R_ACC (0–127)",
-                    "full_xmem_row: 1 = always 128 lanes; 0 = use CR15.valid_elements",
+                    "cr_dstructure: CR register (CR0–CR15) supplying valid_elements; defaults to CR15",
                 ],
                 operation=(
-                    "Let n = 128 if full_xmem_row else min(CR15.valid_elements, 128). "
+                    "Let n = min(cr_dstructure.valid_elements, 128). "
                     "dest = LR[dest_slot] % 128. "
                     "R_ACC[dest] = max(R_ACC[0..n-1], R_ACC[dest])."
                 ),
-                example="AGG.MAX LR0, 0;;",
+                example="AGG.MAX LR0, CR15;;",
             ),
             "execute_fn": "execute_agg_max",
         },
@@ -764,7 +774,7 @@ INSTRUCTION_SPEC = {
         },
         "AAQ": {
             "operands": [
-                {"name": "full_xmem_row", "type": "FullXmemRow"},
+                {"name": "cr_dstructure", "type": "CrDstructureIdx", "read": "live"},
             ],
             "doc": InstructionDoc(
                 title="AAQ Quantize",
@@ -773,49 +783,48 @@ INSTRUCTION_SPEC = {
                     "to INT8, storing clamped bytes in the **leading 128 bytes** of **`POST_AAQ_REG`** "
                     "and clearing the rest of the register. Wide lanes are normally produced by "
                     "**`ACTIVATE`** (from ``r_acc``). Requires INT8 mode. "
-                    "``full_xmem_row=1`` always processes all 128 lanes; "
-                    "``full_xmem_row=0`` uses ``CR15.valid_elements`` as the active lane count."
+                    "The active lane count is read from ``cr_dstructure.valid_elements`` (defaults to CR15)."
                 ),
-                syntax="AAQ full_xmem_row",
+                syntax="AAQ cr_dstructure",
                 operands=[
-                    "full_xmem_row: 1 = always 128 lanes (full XMEM row); 0 = use CR15.valid_elements lane count",
+                    "cr_dstructure: CR register (CR0–CR15) supplying valid_elements lane count; defaults to CR15",
                 ],
                 operation=(
                     "Requires INT8 mode (IpuState.dtype == DType.INT8 in the Python emulator). "
-                    "Let n = 128 if full_xmem_row else min(CR15.valid_elements, 128). "
+                    "Let n = min(cr_dstructure.valid_elements, 128). "
                     "For i in [0, n): POST_AAQ_REG[i] = clamp(POST_AAQ_REG wide lane i, -128, 127) "
                     "(interim direct INT8 clamp of the post-ACTIVATE lane; a future per-128-element "
                     "requantize will scale lanes into INT8 range before this step and supersede the clamp). "
                     "POST_AAQ_REG[n..511] = 0."
                 ),
-                example="AAQ 1;;",
+                example="AAQ CR15;;",
             ),
             "execute_fn": "execute_aaq",
         },
         "ACTIVATE": {
             "operands": [
                 {"name": "activation_fn", "type": "ActivationFn"},
-                {"name": "full_xmem_row", "type": "FullXmemRow"},
+                {"name": "cr_dstructure", "type": "CrDstructureIdx", "read": "live"},
             ],
             "doc": InstructionDoc(
                 title="Accumulator Activation",
                 summary=(
                     "Read active lanes from ``r_acc``, apply the selected element-wise activation, "
                     "and write results into the same lane indices of ``POST_AAQ_REG`` (``r_acc`` is unchanged). "
-                    "``full_xmem_row=1`` always activates all 128 lanes; ``full_xmem_row=0`` uses CR15.valid_elements. "
+                    "The active lane count is read from ``cr_dstructure.valid_elements`` (defaults to CR15). "
                     "The activation is selected by keyword (see ACTIVATION_FN_NAMES). The available "
                     "activation functions are: ``identity`` (0), ``relu`` (1), ``relu6`` (2), "
                     "``sigmoid`` (3), ``tanh`` (4), ``gelu`` (5), ``softplus`` (6), ``elu`` (7), "
                     "``exp2`` (8), ``reciprocal`` (9), ``rsqrt`` (10). For Python emulator calibration (virtual α), see "
                     "docs/content/building-applications.md#activations-emulator."
                 ),
-                syntax="ACTIVATE activation_fn, full_xmem_row",
+                syntax="ACTIVATE activation_fn, cr_dstructure",
                 operands=[
                     "activation_fn: keyword naming the activation (one of identity, relu, relu6, sigmoid, tanh, gelu, softplus, elu, exp2; see ACTIVATION_FN_NAMES)",
-                    "full_xmem_row: 1 = always 128 lanes; 0 = use CR15.valid_elements (default 0)",
+                    "cr_dstructure: CR register (CR0–CR15) supplying valid_elements lane count; defaults to CR15",
                 ],
                 operation=(
-                    "Let n = 128 if full_xmem_row else min(CR15.valid_elements, 128) "
+                    "Let n = min(cr_dstructure.valid_elements, 128) "
                     "and k = encoded activation index. "
                     "For i in [0, n): POST_AAQ_REG[i] = activation_k(R_ACC[i]) (same 32-bit lane format as R_ACC). "
                     "R_ACC is not modified. The selector uses four bits; encodings outside the eleven named "
@@ -823,7 +832,7 @@ INSTRUCTION_SPEC = {
                     "α for elu is not an ISA operand; see "
                     "docs/content/building-applications.md#activations-emulator."
                 ),
-                example="ACTIVATE relu, 0;;",
+                example="ACTIVATE relu, CR15;;",
             ),
             "execute_fn": "execute_activate",
         },
@@ -1246,7 +1255,7 @@ VALID_OPERAND_TYPES: frozenset[str] = frozenset(
         "BreakImmediate",
         "Label",
         "AddSubSrcB",
-        "FullXmemRow",
+        "CrDstructureIdx",
     }
 )
 

--- a/src/tools/ipu-common/src/ipu_common/union_layout.py
+++ b/src/tools/ipu-common/src/ipu_common/union_layout.py
@@ -57,7 +57,7 @@ def get_operand_type_bits() -> dict[str, int]:
         "HorizontalStride": _enum_bits(HORIZONTAL_STRIDE_NAMES),
         "VerticalStride": _enum_bits(VERTICAL_STRIDE_NAMES),
         "ActivationFn": _enum_bits(ACTIVATION_FN_NAMES),
-        "FullXmemRow": 1,
+        "CrDstructureIdx": 4,  # 4 bits to encode CR0–CR15
     }
 
 

--- a/src/tools/ipu-common/src/ipu_common/union_layout.py
+++ b/src/tools/ipu-common/src/ipu_common/union_layout.py
@@ -57,7 +57,6 @@ def get_operand_type_bits() -> dict[str, int]:
         "HorizontalStride": _enum_bits(HORIZONTAL_STRIDE_NAMES),
         "VerticalStride": _enum_bits(VERTICAL_STRIDE_NAMES),
         "ActivationFn": _enum_bits(ACTIVATION_FN_NAMES),
-        "CrDstructureIdx": 4,  # 4 bits to encode CR0–CR15
     }
 
 

--- a/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
@@ -85,7 +85,6 @@ _TYPE_FIELD_SUFFIX = {
     "LrIdx": "lr_reg_field",
     "CrIdx": "cr_reg_field",
     "LcrIdx": "lcr_reg_field",
-    "CrDstructureIdx": "cr_dstructure_idx_field",
     "AddSubSrcB": "add_sub_src_b_field",
     "ElementsInRow": "elements_in_row_field",
     "HorizontalStride": "horizontal_stride_field",
@@ -294,7 +293,7 @@ class Ipu:
         """
         if op_type == "LrIdx":
             return source.get_lr(raw_value)
-        elif op_type in ("CrIdx", "CrDstructureIdx"):
+        elif op_type == "CrIdx":
             return source.get_cr(raw_value)
         elif op_type == "LcrIdx":
             if raw_value < LR_REG_COUNT:

--- a/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
@@ -24,7 +24,13 @@ from typing import Any
 from ipu_emu.ipu_state import IpuState, INST_MEM_SIZE, WideVectorArithmetic
 from ipu_emu.regfile import RegFile
 from ipu_emu.ipu_math import ipu_mult, ipu_add, ipu_sub, dtype_one_byte, DType
-from ipu_emu.ipu_config import REGISTER_WORD_VALUE_MASK, LR_CR_SCALAR_BITS, Partition
+from ipu_emu.ipu_config import (
+    REGISTER_WORD_VALUE_MASK,
+    LR_CR_SCALAR_BITS,
+    Partition,
+    get_config_valid_elements,
+    get_config_partition,
+)
 from ipu_common.instruction_spec import (
     INSTRUCTION_SPEC,
     SLOT_BINARY_LAYOUT,
@@ -79,6 +85,7 @@ _TYPE_FIELD_SUFFIX = {
     "LrIdx": "lr_reg_field",
     "CrIdx": "cr_reg_field",
     "LcrIdx": "lcr_reg_field",
+    "CrDstructureIdx": "cr_dstructure_idx_field",
     "AddSubSrcB": "add_sub_src_b_field",
     "ElementsInRow": "elements_in_row_field",
     "HorizontalStride": "horizontal_stride_field",
@@ -88,7 +95,6 @@ _TYPE_FIELD_SUFFIX = {
     "ActivationFn": "activation_fn_field",
     "BreakImmediate": "break_immediate_type",
     "Label": "label_token",
-    "FullXmemRow": "full_xmem_row_field",
 }
 
 # Field prefix for each slot type (matches compound_inst naming)
@@ -288,7 +294,7 @@ class Ipu:
         """
         if op_type == "LrIdx":
             return source.get_lr(raw_value)
-        elif op_type == "CrIdx":
+        elif op_type in ("CrIdx", "CrDstructureIdx"):
             return source.get_cr(raw_value)
         elif op_type == "LcrIdx":
             if raw_value < LR_REG_COUNT:
@@ -359,7 +365,7 @@ class Ipu:
                 result |= (1 << i)
         return result
 
-    def _mult_mask_and_shift(self, mask_idx: int, shift: int) -> None:
+    def _mult_mask_and_shift(self, mask_idx: int, shift: int, cr_dstructure_value: int) -> None:
         """Apply sequential shift-and-AND mask generation, then gate mult_res.
 
         ``shift`` is interpreted as ``mask_shift_idx`` ∈ [−3, +3] (clamped).
@@ -369,7 +375,7 @@ class Ipu:
           idx +k → shift left  k times, ANDing with partition_vector after each step
           idx −k → shift right k times, ANDing with inverse_partition_vector after each step
 
-        Two partition vectors, both derived from CR15.partition:
+        Two partition vectors, both derived from the partition field of cr_dstructure_value:
           partition_vector         — 0 at the START of each group (used for left shifts)
           inverse_partition_vector — 0 at the END   of each group (used for right shifts)
 
@@ -390,7 +396,7 @@ class Ipu:
         _128_BIT_MASK = (1 << R_REG_SIZE) - 1
         base_mask = int.from_bytes(mask_bytes[offset:offset + 16], byteorder="little") & _128_BIT_MASK
 
-        num_partitions = self.state.get_config_partition()
+        num_partitions = get_config_partition(cr_dstructure_value)
 
         # Generate the shifted mask via sequential shift-and-AND
         mask_int = base_mask
@@ -575,7 +581,7 @@ class Ipu:
         pass
 
     def execute_mult_ee(self, *, ra: bytearray | int, cyclic_offset: int,
-                        mask_offset: int, mask_shift: int) -> None:
+                        mask_offset: int, mask_shift: int, cr_dstructure: int) -> None:
         """Execute MULT.EE: Element-wise multiplication."""
         mult_res = self.state.regfile.raw("mult_res")
 
@@ -591,7 +597,7 @@ class Ipu:
                     struct.pack_into(
                         "<i", mult_res, i * 4, self._wide_imult32(int(ra_vals[i]), int(rb_vals[i]))
                     )
-            self._mult_mask_and_shift(mask_offset, mask_shift)
+            self._mult_mask_and_shift(mask_offset, mask_shift, cr_dstructure)
             return
 
         dtype = self.state.dtype
@@ -601,10 +607,10 @@ class Ipu:
             result = ipu_mult(ra[i], rb[i], dtype)
             struct.pack_into("<i" if dtype == DType.INT8 else "<f", mult_res, i * 4, result)
 
-        self._mult_mask_and_shift(mask_offset, mask_shift)
+        self._mult_mask_and_shift(mask_offset, mask_shift, cr_dstructure)
 
     def execute_mult_ee_rr(self, *, ra: bytearray | int,
-                           mask_offset: int, mask_shift: int) -> None:
+                           mask_offset: int, mask_shift: int, cr_dstructure: int) -> None:
         """Execute MULT.EE.RR: multi-element multiply of a mult-stage register by itself.
 
         ``ra`` selects the MEE mode: R0 → r0-by-r0, R1 → r1-by-r1. Each lane is
@@ -625,7 +631,7 @@ class Ipu:
                         "<i", mult_res, i * 4,
                         self._wide_imult32(int(ra_vals[i]), int(ra_vals[i])),
                     )
-            self._mult_mask_and_shift(mask_offset, mask_shift)
+            self._mult_mask_and_shift(mask_offset, mask_shift, cr_dstructure)
             return
 
         dtype = self.state.dtype
@@ -634,7 +640,7 @@ class Ipu:
             result = ipu_mult(ra[i], ra[i], dtype)
             struct.pack_into("<i" if dtype == DType.INT8 else "<f", mult_res, i * 4, result)
 
-        self._mult_mask_and_shift(mask_offset, mask_shift)
+        self._mult_mask_and_shift(mask_offset, mask_shift, cr_dstructure)
 
     def _execute_mult_ve_variant(
         self,
@@ -644,6 +650,7 @@ class Ipu:
         mask_offset: int,
         mask_shift: int,
         fixed_idx: int,
+        cr_dstructure: int,
     ) -> None:
         """Shared mult.ve.cyclic / mult.ve.padded implementation."""
         raw = cyclic_offset & 0xFFFFFFFF
@@ -681,7 +688,7 @@ class Ipu:
                     struct.pack_into(
                         "<i", mult_res, i * 4, self._wide_imult32(int(ra_fixed), rb_lane)
                     )
-            self._mult_mask_and_shift(mask_offset, mask_shift)
+            self._mult_mask_and_shift(mask_offset, mask_shift, cr_dstructure)
             return
 
         dtype = self.state.dtype
@@ -706,10 +713,11 @@ class Ipu:
                 result = ipu_mult(ra_fixed, rb_byte, dtype)
                 struct.pack_into(fmt, mult_res, i * 4, result)
 
-        self._mult_mask_and_shift(mask_offset, mask_shift)
+        self._mult_mask_and_shift(mask_offset, mask_shift, cr_dstructure)
 
     def execute_mult_ve_cyclic(self, *, cyclic_offset: int,
-                               mask_offset: int, mask_shift: int, fixed_idx: int) -> None:
+                               mask_offset: int, mask_shift: int, fixed_idx: int,
+                               cr_dstructure: int) -> None:
         """Execute MULT.VE.CYCLIC: fixed r0/r1 element × r_cyclic row with cyclic addressing."""
         self._execute_mult_ve_variant(
             pad_128_ones=False,
@@ -717,10 +725,12 @@ class Ipu:
             mask_offset=mask_offset,
             mask_shift=mask_shift,
             fixed_idx=fixed_idx,
+            cr_dstructure=cr_dstructure,
         )
 
     def execute_mult_ve_padded(self, *, cyclic_offset: int,
-                               mask_offset: int, mask_shift: int, fixed_idx: int) -> None:
+                               mask_offset: int, mask_shift: int, fixed_idx: int,
+                               cr_dstructure: int) -> None:
         """Execute MULT.VE.PADDED: fixed r0/r1 element × r_cyclic row with boundary padding."""
         self._execute_mult_ve_variant(
             pad_128_ones=True,
@@ -728,10 +738,11 @@ class Ipu:
             mask_offset=mask_offset,
             mask_shift=mask_shift,
             fixed_idx=fixed_idx,
+            cr_dstructure=cr_dstructure,
         )
 
     def execute_mult_ve_cr(self, *, cyclic_offset: int, mask_offset: int,
-                           mask_shift: int, cr_idx: int) -> None:
+                           mask_shift: int, cr_idx: int, cr_dstructure: int) -> None:
         """Execute MULT.VE.CR: CR scalar × r_cyclic elements with boundary padding.
 
         Multiplies the low byte of CR[cr_idx] against each byte of
@@ -761,7 +772,7 @@ class Ipu:
                     struct.pack_into(
                         "<i", mult_res, i * 4, self._wide_imult32(cr_scalar, rb_lane)
                     )
-            self._mult_mask_and_shift(mask_offset, mask_shift)
+            self._mult_mask_and_shift(mask_offset, mask_shift, cr_dstructure)
             return
 
         scalar_byte = self.state.regfile.get_cr(cr_idx) & 0xFF
@@ -775,7 +786,7 @@ class Ipu:
             result = ipu_mult(scalar_byte, rb_byte, dtype)
             struct.pack_into(fmt, mult_res, i * 4, result)
 
-        self._mult_mask_and_shift(mask_offset, mask_shift)
+        self._mult_mask_and_shift(mask_offset, mask_shift, cr_dstructure)
 
     # -----------------------------------------------------------------------
     # ACC Instruction Handlers
@@ -910,9 +921,9 @@ class Ipu:
                 best = v
         return best
 
-    def execute_agg_sum_first(self, *, dest_slot: int, full_xmem_row: int) -> None:
+    def execute_agg_sum_first(self, *, dest_slot: int, cr_dstructure: int) -> None:
         """Execute AGG.SUM.FIRST: sum active R_ACC lanes, write to R_ACC[dest] (clean init)."""
-        valid_elements = 128 if full_xmem_row else self.state.get_config_valid_elements()
+        valid_elements = get_config_valid_elements(cr_dstructure)
         fmt = self._acc_agg_lane_fmt()
         snap_acc = self.snapshot.raw("r_acc")
         active = self._agg_active_lane_count(valid_elements)
@@ -922,9 +933,9 @@ class Ipu:
             result = self._to_int32(result)
         struct.pack_into(fmt, self.state.regfile.raw("r_acc"), dest * 4, result)
 
-    def execute_agg_sum(self, *, dest_slot: int, full_xmem_row: int) -> None:
+    def execute_agg_sum(self, *, dest_slot: int, cr_dstructure: int) -> None:
         """Execute AGG.SUM: sum active R_ACC lanes and add to R_ACC[dest] (running accumulation)."""
-        valid_elements = 128 if full_xmem_row else self.state.get_config_valid_elements()
+        valid_elements = get_config_valid_elements(cr_dstructure)
         fmt = self._acc_agg_lane_fmt()
         snap_acc = self.snapshot.raw("r_acc")
         active = self._agg_active_lane_count(valid_elements)
@@ -937,13 +948,13 @@ class Ipu:
             result = ipu_add(self._to_int32(partial), int(snap_dest), DType.INT8)
         struct.pack_into(fmt, self.state.regfile.raw("r_acc"), dest * 4, result)
 
-    def execute_agg_max_first(self, *, dest_slot: int, full_xmem_row: int) -> None:
+    def execute_agg_max_first(self, *, dest_slot: int, cr_dstructure: int) -> None:
         """Execute AGG.MAX.FIRST: max of active R_ACC lanes, write to R_ACC[dest] (no seed).
 
         When no lanes are active (valid_elements=0) the identity seed
         (INT32_MIN / -inf) is written, so the destination is always defined.
         """
-        valid_elements = 128 if full_xmem_row else self.state.get_config_valid_elements()
+        valid_elements = get_config_valid_elements(cr_dstructure)
         fmt = self._acc_agg_lane_fmt()
         snap_acc = self.snapshot.raw("r_acc")
         active = self._agg_active_lane_count(valid_elements)
@@ -952,9 +963,9 @@ class Ipu:
         dest = int(dest_slot) % (R_ACC_SIZE // 4)
         struct.pack_into(fmt, self.state.regfile.raw("r_acc"), dest * 4, result)
 
-    def execute_agg_max(self, *, dest_slot: int, full_xmem_row: int) -> None:
+    def execute_agg_max(self, *, dest_slot: int, cr_dstructure: int) -> None:
         """Execute AGG.MAX: max of active R_ACC lanes seeded with R_ACC[dest] (running max)."""
-        valid_elements = 128 if full_xmem_row else self.state.get_config_valid_elements()
+        valid_elements = get_config_valid_elements(cr_dstructure)
         fmt = self._acc_agg_lane_fmt()
         snap_acc = self.snapshot.raw("r_acc")
         active = self._agg_active_lane_count(valid_elements)
@@ -963,7 +974,7 @@ class Ipu:
         result = self._agg_max_lanes(fmt, snap_acc, active, snap_dest)
         struct.pack_into(fmt, self.state.regfile.raw("r_acc"), dest * 4, result)
 
-    def execute_aaq(self, *, full_xmem_row: int) -> None:
+    def execute_aaq(self, *, cr_dstructure: int) -> None:
         """Execute AAQ: Quantize wide lanes in ``POST_AAQ_REG`` (128 × 32-bit) → leading bytes.
 
         Source is the **512-byte** ``post_aaq_reg`` buffer (same lane layout as
@@ -986,8 +997,7 @@ class Ipu:
         the ``ACTIVATE`` -> ``AAQ`` path producing usable INT8 output instead of
         all zeros.
 
-        ``full_xmem_row=1``: always process all 128 lanes.
-        ``full_xmem_row=0``: process only ``CR15.valid_elements`` lanes (clamped to 128).
+        ``cr_dstructure``: CR register whose valid_elements field gives the active lane count.
 
         Requires INT8 mode.
 
@@ -999,9 +1009,7 @@ class Ipu:
         if dtype != DType.INT8:
             raise EmulatorError("AAQ instruction requires INT8 mode")
 
-        active = 128 if full_xmem_row else self._agg_active_lane_count(
-            self.state.get_config_valid_elements()
-        )
+        active = self._agg_active_lane_count(get_config_valid_elements(cr_dstructure))
 
         if self._wide_vector_active():
             if not self.state.wide_vector_quantize_output:
@@ -1029,7 +1037,7 @@ class Ipu:
             result[i] = clamped & 0xFF
         self.state.regfile.set_post_aaq_reg(result + bytearray(384))
 
-    def execute_activate(self, *, activation_fn: int, full_xmem_row: int) -> None:
+    def execute_activate(self, *, activation_fn: int, cr_dstructure: int) -> None:
         """Apply element-wise activation to active lanes.
 
         Reads each active lane from ``r_acc`` and writes the result into the same
@@ -1038,10 +1046,10 @@ class Ipu:
         unchanged.
 
         ``activation_fn`` is the encoded enum index (0–8) from the instruction word.
-        full_xmem_row=1: always use 128 lanes. full_xmem_row=0: lane count from CR15.valid_elements.
+        ``cr_dstructure``: CR register whose valid_elements field gives the active lane count.
         """
         fn_id = int(activation_fn) & REGISTER_WORD_VALUE_MASK
-        valid_elements = 128 if full_xmem_row else self.state.get_config_valid_elements()
+        valid_elements = get_config_valid_elements(cr_dstructure)
         active = self._agg_active_lane_count(valid_elements)
         fmt = self._acc_agg_lane_fmt()
         acc_buf = self.snapshot.raw("r_acc")

--- a/src/tools/ipu-emu-py/src/ipu_emu/ipu_config.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/ipu_config.py
@@ -9,7 +9,6 @@ CR_REGISTER_NAME = "cr"
 
 CR_ZERO_REG_INDEX = 0
 CR_ONE_REG_INDEX = 1
-CR_DSTRUCTURE_REG_INDEX = 15
 
 CR_ZERO_REG_VALUE = 0
 CR_ONE_REG_VALUE = 1
@@ -34,7 +33,7 @@ DEFAULT_VALID_ELEMENTS = 128
 
 
 class Partition(IntEnum):
-    """Valid CR15.partition values. Controls how the 128 lanes are grouped for mask shifts."""
+    """Valid dstructure partition values. Controls how the 128 lanes are grouped for mask shifts."""
     P0  = 0   # no partitioning — all 128 lanes in one group
     P2  = 2   # 2 groups of 64 lanes
     P4  = 4   # 4 groups of 32 lanes
@@ -47,7 +46,7 @@ DEFAULT_PARTITION = Partition.P0
 
 @dataclass(frozen=True)
 class DStructureConfig:
-    """Decoded CR15 dstructure configuration."""
+    """Decoded dstructure configuration from a CR register."""
 
     valid_elements: int = DEFAULT_VALID_ELEMENTS
     partition: Partition = DEFAULT_PARTITION
@@ -58,7 +57,7 @@ class DStructureConfig:
         yield self.partition
 
     def to_register_value(self) -> int:
-        """Pack this dstructure into the CR15 register word."""
+        """Pack this dstructure into a CR register word."""
         return encode_dstructure(
             valid_elements=self.valid_elements,
             partition=self.partition,
@@ -69,7 +68,7 @@ DEFAULT_DSTRUCTURE = DStructureConfig()
 
 
 def encode_dstructure(*, valid_elements: int, partition: Partition | int = DEFAULT_PARTITION) -> int:
-    """Pack dstructure fields into the CR15 register value."""
+    """Pack dstructure fields into a CR register value."""
     partition = Partition(partition)   # validates and converts; raises ValueError if invalid
     valid = int(valid_elements) & DSTRUCTURE_VALID_ELEMENTS_MASK
     part = int(partition) & DSTRUCTURE_PARTITION_MASK
@@ -77,7 +76,7 @@ def encode_dstructure(*, valid_elements: int, partition: Partition | int = DEFAU
 
 
 def decode_dstructure(value: int) -> DStructureConfig:
-    """Decode a CR15 register value into named dstructure fields."""
+    """Decode a CR register value into named dstructure fields."""
     word = int(value) & LR_CR_SCALAR_VALUE_MASK
     return DStructureConfig(
         valid_elements=word & DSTRUCTURE_VALID_ELEMENTS_MASK,

--- a/src/tools/ipu-emu-py/src/ipu_emu/ipu_state.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/ipu_state.py
@@ -14,14 +14,6 @@ from ipu_emu.stats import RunStats
 from ipu_emu.xmem import XMem
 from ipu_common import activations as _activations
 from ipu_emu.ipu_math import DType
-from ipu_emu.ipu_config import (
-    CR_DSTRUCTURE_REG_INDEX,
-    DEFAULT_DSTRUCTURE,
-    DStructureConfig,
-    Partition,
-    decode_dstructure,
-    encode_dstructure,
-)
 
 # Matches C: #define IPU__INST_MEM_SIZE 1024
 INST_MEM_SIZE = 1024
@@ -66,11 +58,6 @@ class IpuState:
         # Arithmetic data type — not stored in a CR register (emulator-only).
         self.dtype: DType = dtype
 
-        self.set_cr_dstructure(
-            valid_elements=DEFAULT_DSTRUCTURE.valid_elements,
-            partition=DEFAULT_DSTRUCTURE.partition,
-        )
-
         # --- Emulator-only wide-vector debug mode (GitHub issue #33) ------------
         self.wide_vector_debug: bool = wide_vector_debug
         self.wide_vector_arithmetic: WideVectorArithmetic = wide_vector_arithmetic
@@ -81,31 +68,6 @@ class IpuState:
         # --- Activation α (emulator-only; not mapped to CR) ----------------------
         self.elu_alpha: float = (
             float(elu_alpha) if elu_alpha is not None else float(_activations._ELU_ALPHA)
-        )
-
-    # -- CR dstructure convenience (CR15 = valid_elements[7:0] | partition[11:8]) --
-
-    def get_cr_dstructure(self) -> DStructureConfig:
-        """Read CR15 as decoded dstructure configuration fields."""
-        return decode_dstructure(self.regfile.get_cr(CR_DSTRUCTURE_REG_INDEX))
-
-    def get_config_valid_elements(self) -> int:
-        """Return the active lane count from the CR15 dstructure register."""
-        return self.get_cr_dstructure().valid_elements
-
-    def get_config_partition(self) -> int:
-        """Return the partition field from the CR15 dstructure register."""
-        return self.get_cr_dstructure().partition
-
-    def set_cr_dstructure(
-        self,
-        valid_elements: int = DEFAULT_DSTRUCTURE.valid_elements,
-        partition: Partition | int = DEFAULT_DSTRUCTURE.partition,
-    ) -> None:
-        """Write CR15 as dstructure configuration fields."""
-        self.regfile.set_cr(
-            CR_DSTRUCTURE_REG_INDEX,
-            encode_dstructure(valid_elements=valid_elements, partition=partition),
         )
 
     def set_activation_alphas(

--- a/src/tools/ipu-emu-py/test/test_execute.py
+++ b/src/tools/ipu-emu-py/test/test_execute.py
@@ -1570,13 +1570,17 @@ BKPT;;
             val = struct.unpack_from("<i", acc_raw, i * 4)[0]
             assert val == 6, f"acc word {i}: expected 6 (2×3), got {val}"
 
-    def test_mult_ve_cr_cr15_cr_idx_conflicts_with_explicit_cr15_dstructure(self):
-        """Assembler raises ValueError when cr_idx=CR15 and cr_dstructure=CR15 explicitly."""
-        import pytest
+    def test_mult_ve_cr_same_cr_idx_and_cr_dstructure_raises(self):
+        """Assembler raises ValueError when cr_idx and cr_dstructure are the same register."""
         from ipu_as.lark_tree import parse
         from ipu_as.compound_inst import CompoundInst
+        # CR15 as both
         ast = parse("MULT.VE.CR lr0 0 lr0 CR15 CR15;;\nBKPT;;")
         with pytest.raises(ValueError, match="conflicting roles"):
+            [CompoundInst(instr).encode() for instr in ast]
+        # Any other register — CR5 as both
+        ast = parse("MULT.VE.CR lr0 0 lr0 CR5 CR5;;\nBKPT;;")
+        with pytest.raises(ValueError, match="CR5.*conflicting roles"):
             [CompoundInst(instr).encode() for instr in ast]
 
 

--- a/src/tools/ipu-emu-py/test/test_execute.py
+++ b/src/tools/ipu-emu-py/test/test_execute.py
@@ -27,6 +27,7 @@ from ipu_as.lark_tree import assemble, parse
 from ipu_as.compound_inst import CompoundInst
 
 from ipu_common.activations import ACTIVATION_FN_NAMES, apply_activation
+from ipu_emu.ipu_config import encode_dstructure
 
 
 # ---------------------------------------------------------------------------
@@ -49,6 +50,7 @@ def _make_state(
     encoded = assemble(asm_code)
     decoded = [decode_instruction_word(w) for w in encoded]
     state = IpuState(elu_alpha=elu_alpha)
+    state.regfile.set_cr(15, encode_dstructure(valid_elements=128))
     if cr:
         for idx, val in cr.items():
             state.regfile.set_cr(idx, val)
@@ -340,7 +342,7 @@ SET lr14 cr9;;
 SET lr15 cr10;;
 LDR_CYCLIC_MULT_REG lr14 cr0 lr15;;
 RESET_ACC;;
-MULT.EE r1 lr0 0 lr0;
+MULT.EE r1 lr0 0 lr0 CR15;
 ACC;;
 SET lr0 cr11;;
 STR_ACC_REG lr0 cr0;;
@@ -427,7 +429,7 @@ LDR_MULT_MASK_REG lr3 cr0;;
 RESET_ACC;;
 SET lr5 cr10;;
 SET lr6 cr10;;
-MULT.EE r0 lr6 0 lr5;
+MULT.EE r0 lr6 0 lr5 CR15;
 ACC;;
 SET lr9 cr12;;
 STR_ACC_REG lr9 cr0;;
@@ -466,7 +468,7 @@ LDR_MULT_MASK_REG lr3 cr0;;
 RESET_ACC;;
 SET lr5 cr12;;
 SET lr6 cr10;;
-MULT.EE r0 lr6 1 lr5;
+MULT.EE r0 lr6 1 lr5 CR15;
 ACC;;
 SET lr9 cr13;;
 STR_ACC_REG lr9 cr0;;
@@ -818,12 +820,12 @@ BKPT;;
         """AGG.SUM.FIRST: sum all 128 lanes and write to R_ACC[dest] (clean init)."""
         state = _make_state(
             """\
-AGG.SUM.FIRST LR0;;
+AGG.SUM.FIRST LR0 CR15;;
 BKPT;;
 """
         )
         state.dtype = DType.INT8
-        state.set_cr_dstructure(128)
+        state.regfile.set_cr(15, encode_dstructure(valid_elements=128))
         state.regfile.set_lr(0, 127)  # dest = R_ACC[127]
         for i in range(128):
             state.regfile.set_r_acc_word(i, struct.unpack("<I", struct.pack("<i", 1))[0])
@@ -840,12 +842,12 @@ BKPT;;
         """
         state = _make_state(
             """\
-AGG.SUM.FIRST LR0;;
+AGG.SUM.FIRST LR0 CR15;;
 BKPT;;
 """
         )
         state.dtype = DType.INT8
-        state.set_cr_dstructure(4)  # only lanes 0..3 active
+        state.regfile.set_cr(15, encode_dstructure(valid_elements=4))  # only lanes 0..3 active
         state.regfile.set_lr(0, 127)  # dest = R_ACC[127], outside active range
         for i in range(128):
             state.regfile.set_r_acc_word(i, struct.unpack("<I", struct.pack("<i", 1))[0])
@@ -860,12 +862,12 @@ BKPT;;
         """AGG.SUM.FIRST: only active prefix contributes; tail is excluded."""
         state = _make_state(
             """\
-AGG.SUM.FIRST LR0;;
+AGG.SUM.FIRST LR0 CR15;;
 BKPT;;
 """
         )
         state.dtype = DType.INT8
-        state.set_cr_dstructure(4)
+        state.regfile.set_cr(15, encode_dstructure(valid_elements=4))
         state.regfile.set_lr(0, 127)
         for i in range(128):
             v = 10 if i < 4 else 1000
@@ -877,7 +879,6 @@ BKPT;;
 
     def test_agg_sum_first_non_default_cr_register(self):
         """AGG.SUM.FIRST uses the specified cr_dstructure register, not necessarily CR15."""
-        from ipu_emu.ipu_config import encode_dstructure
         state = _make_state(
             """\
 AGG.SUM.FIRST LR0 CR5;;
@@ -885,7 +886,7 @@ BKPT;;
 """
         )
         state.dtype = DType.INT8
-        state.set_cr_dstructure(valid_elements=4)  # CR15 = 4 active lanes
+        state.regfile.set_cr(15, encode_dstructure(valid_elements=4))  # CR15 = 4 active lanes
         state.regfile.set_cr(5, encode_dstructure(valid_elements=128))  # CR5 = 128
         state.regfile.set_lr(0, 127)
         for i in range(128):
@@ -903,12 +904,12 @@ BKPT;;
         """
         state = _make_state(
             """\
-AGG.SUM LR0;;
+AGG.SUM LR0 CR15;;
 BKPT;;
 """
         )
         state.dtype = DType.INT8
-        state.set_cr_dstructure(64)  # only lanes 0..63 active
+        state.regfile.set_cr(15, encode_dstructure(valid_elements=64))  # only lanes 0..63 active
         state.regfile.set_lr(0, 127)  # dest = R_ACC[127], outside active range
         for i in range(128):
             state.regfile.set_r_acc_word(i, struct.unpack("<I", struct.pack("<i", 1))[0])
@@ -923,12 +924,12 @@ BKPT;;
         """AGG.MAX.FIRST: max of all 128 lanes, no seed from dest."""
         state = _make_state(
             """\
-AGG.MAX.FIRST LR0;;
+AGG.MAX.FIRST LR0 CR15;;
 BKPT;;
 """
         )
         state.dtype = DType.INT8
-        state.set_cr_dstructure(128)
+        state.regfile.set_cr(15, encode_dstructure(valid_elements=128))
         state.regfile.set_lr(0, 127)
         for i in range(128):
             state.regfile.set_r_acc_word(i, struct.unpack("<I", struct.pack("<i", 5 + (i % 10)))[0])
@@ -947,12 +948,12 @@ BKPT;;
         """
         state = _make_state(
             """\
-AGG.MAX.FIRST LR0;;
+AGG.MAX.FIRST LR0 CR15;;
 BKPT;;
 """
         )
         state.dtype = DType.INT8
-        state.set_cr_dstructure(64)  # only lanes 0..63 active
+        state.regfile.set_cr(15, encode_dstructure(valid_elements=64))  # only lanes 0..63 active
         state.regfile.set_lr(0, 127)  # dest = R_ACC[127], outside active range
         for i in range(128):
             state.regfile.set_r_acc_word(i, struct.unpack("<I", struct.pack("<i", 5))[0])
@@ -966,12 +967,12 @@ BKPT;;
         """AGG.MAX.FIRST with valid_elements=0: dest gets the identity seed (INT32_MIN)."""
         state = _make_state(
             """\
-AGG.MAX.FIRST LR0;;
+AGG.MAX.FIRST LR0 CR15;;
 BKPT;;
 """
         )
         state.dtype = DType.INT8
-        state.set_cr_dstructure(0)  # no active lanes
+        state.regfile.set_cr(15, encode_dstructure(valid_elements=0))  # no active lanes
         state.regfile.set_lr(0, 7)
         state.regfile.set_r_acc_word(7, struct.unpack("<I", struct.pack("<i", 1234))[0])
         run_until_complete(state)
@@ -983,12 +984,12 @@ BKPT;;
         """AGG.MAX.FIRST: tail lanes beyond valid_elements are excluded."""
         state = _make_state(
             """\
-AGG.MAX.FIRST LR0;;
+AGG.MAX.FIRST LR0 CR15;;
 BKPT;;
 """
         )
         state.dtype = DType.INT8
-        state.set_cr_dstructure(50)
+        state.regfile.set_cr(15, encode_dstructure(valid_elements=50))
         state.regfile.set_lr(0, 127)
         for i in range(128):
             v = 3 if i < 50 else 9999
@@ -1003,12 +1004,12 @@ BKPT;;
         """AGG.MAX: existing dest value beats all active lanes — dest unchanged."""
         state = _make_state(
             """\
-AGG.MAX LR0;;
+AGG.MAX LR0 CR15;;
 BKPT;;
 """
         )
         state.dtype = DType.INT8
-        state.set_cr_dstructure(128)
+        state.regfile.set_cr(15, encode_dstructure(valid_elements=128))
         state.regfile.set_lr(0, 127)
         for i in range(128):
             state.regfile.set_r_acc_word(i, struct.unpack("<I", struct.pack("<i", 10))[0])
@@ -1022,12 +1023,12 @@ BKPT;;
         """AGG.MAX: an active lane beats the existing dest — dest updated."""
         state = _make_state(
             """\
-AGG.MAX LR0;;
+AGG.MAX LR0 CR15;;
 BKPT;;
 """
         )
         state.dtype = DType.INT8
-        state.set_cr_dstructure(100)
+        state.regfile.set_cr(15, encode_dstructure(valid_elements=100))
         state.regfile.set_lr(0, 127)
         for i in range(128):
             v = 5 if i < 100 else 1
@@ -1049,7 +1050,7 @@ BKPT;;
         """
         state = _make_state(
             """\
-AGG.SUM.FIRST LR0; ACTIVATE relu;;
+AGG.SUM.FIRST LR0 CR15; ACTIVATE relu CR15;;
 BKPT;;
 """
         )
@@ -1214,7 +1215,7 @@ LDR_CYCLIC_MULT_REG lr1 cr0 lr2;;
 RESET_ACC;;
 SET lr5 cr10;;
 SET lr6 cr10;;
-MULT.EE r0 lr6 0 lr5;
+MULT.EE r0 lr6 0 lr5 CR15;
 ACC;;
 BKPT;;
 """,
@@ -1256,7 +1257,7 @@ LDR_CYCLIC_MULT_REG lr0 cr0 lr1;;
 RESET_ACC;;
 SET lr2 cr9;;
 SET lr4 cr9;;
-MULT.VE.CR lr2 0 lr4 cr3;
+MULT.VE.CR lr2 0 lr4 cr3 CR15;
 ACC;;
 BKPT;;
 """,
@@ -1283,7 +1284,7 @@ LDR_CYCLIC_MULT_REG lr0 cr0 lr1;;
 RESET_ACC;;
 SET lr2 cr9;;
 SET lr4 cr9;;
-MULT.VE.CR lr2 0 lr4 cr2;
+MULT.VE.CR lr2 0 lr4 cr2 CR15;
 ACC;;
 BKPT;;
 """,
@@ -1309,7 +1310,7 @@ BKPT;;
 RESET_ACC;;
 SET lr2 cr8;;
 SET lr4 cr9;;
-MULT.VE.CR lr2 0 lr4 cr3;
+MULT.VE.CR lr2 0 lr4 cr3 CR15;
 ACC;;
 BKPT;;
 """,
@@ -1342,7 +1343,7 @@ LDR_CYCLIC_MULT_REG lr0 cr0 lr1;;
 RESET_ACC;;
 SET lr2 cr9;;
 SET lr4 cr9;;
-MULT.VE.CR lr2 0 lr4 cr5;
+MULT.VE.CR lr2 0 lr4 cr5 CR15;
 ACC;;
 BKPT;;
 """,
@@ -1368,7 +1369,7 @@ BKPT;;
 RESET_ACC;;
 SET lr2 cr8;;
 SET lr4 cr9;;
-MULT.VE.CR lr2 0 lr4 cr6;
+MULT.VE.CR lr2 0 lr4 cr6 CR15;
 ACC;;
 BKPT;;
 """,
@@ -1403,7 +1404,7 @@ SET lr1 cr9;;
 SET lr2 cr10;;
 LDR_CYCLIC_MULT_REG lr1 cr0 lr2;;
 RESET_ACC;;
-MULT.EE r0 lr2 0 lr2;
+MULT.EE r0 lr2 0 lr2 CR15;
 ACC;;
 BKPT;;
 """,
@@ -1432,7 +1433,7 @@ SET lr1 cr9;;
 SET lr2 cr10;;
 LDR_CYCLIC_MULT_REG lr1 cr0 lr2;;
 RESET_ACC;;
-MULT.VE.CYCLIC lr2 0 lr2 lr2;
+MULT.VE.CYCLIC lr2 0 lr2 lr2 CR15;
 ACC;;
 BKPT;;
 """,
@@ -1464,7 +1465,7 @@ RESET_ACC;;
 SET lr2 cr9;;
 SET lr4 cr10;;
 SET lr5 cr10;;
-MULT.VE.CYCLIC lr2 0 lr4 lr5;
+MULT.VE.CYCLIC lr2 0 lr4 lr5 CR15;
 ACC;;
 BKPT;;
 """,
@@ -1495,7 +1496,7 @@ RESET_ACC;;
 SET lr2 cr9;;
 SET lr4 cr10;;
 SET lr5 cr10;;
-MULT.VE.PADDED lr2 0 lr4 lr5;
+MULT.VE.PADDED lr2 0 lr4 lr5 CR15;
 ACC;;
 BKPT;;
 """,
@@ -1530,7 +1531,7 @@ SET lr2 cr11;;
 LDR_CYCLIC_MULT_REG lr1 cr0 lr2;;
 RESET_ACC;;
 SET lr3 cr12;;
-MULT.VE.CYCLIC lr2 0 lr2 lr3;
+MULT.VE.CYCLIC lr2 0 lr2 lr3 CR15;
 ACC;;
 BKPT;;
 """,
@@ -1578,15 +1579,6 @@ BKPT;;
         with pytest.raises(ValueError, match="conflicting roles"):
             [CompoundInst(instr).encode() for instr in ast]
 
-    def test_mult_ve_cr_cr15_cr_idx_conflicts_with_default_dstructure(self):
-        """Assembler raises ValueError when cr_idx=CR15 and cr_dstructure omitted (defaults to CR15)."""
-        import pytest
-        from ipu_as.lark_tree import parse
-        from ipu_as.compound_inst import CompoundInst
-        ast = parse("MULT.VE.CR lr0 0 lr0 CR15;;\nBKPT;;")
-        with pytest.raises(ValueError, match="conflicting roles"):
-            [CompoundInst(instr).encode() for instr in ast]
-
 
 class TestMultEeRr:
     """MULT.EE.RR — multi-element execution (MEE): r0-by-r0 or r1-by-r1."""
@@ -1600,7 +1592,7 @@ SET lr0 cr8;;
 LDR_MULT_REG r0 lr0 cr0;;
 RESET_ACC;;
 SET lr5 cr9;;
-MULT.EE.RR r0 0 lr5;
+MULT.EE.RR r0 0 lr5 CR15;
 ACC;;
 BKPT;;
 """,
@@ -1626,7 +1618,7 @@ SET lr1 cr9;;
 LDR_MULT_REG r1 lr1 cr0;;
 RESET_ACC;;
 SET lr5 cr10;;
-MULT.EE.RR r1 0 lr5;
+MULT.EE.RR r1 0 lr5 CR15;
 ACC;;
 BKPT;;
 """,
@@ -1655,7 +1647,7 @@ SET lr3 cr9;;
 LDR_MULT_MASK_REG lr3 cr0;;
 RESET_ACC;;
 SET lr5 cr10;;
-MULT.EE.RR r0 0 lr5;
+MULT.EE.RR r0 0 lr5 CR15;
 ACC;;
 BKPT;;
 """,
@@ -1703,7 +1695,7 @@ SET lr3 cr9;;
 LDR_MULT_MASK_REG lr3 cr0;;
 RESET_ACC;;
 SET lr5 cr2;;
-MULT.EE.RR r0 0 lr5;
+MULT.EE.RR r0 0 lr5 CR15;
 ACC;;
 BKPT;;
 """
@@ -1726,7 +1718,7 @@ BKPT;;
             },
         )
         state.dtype = DType.INT8
-        state.set_cr_dstructure(valid_elements=128, partition=partition)
+        state.regfile.set_cr(15, encode_dstructure(valid_elements=128, partition=partition))
         state.xmem.write_address(self._R0_ADDR, bytes([2] * 128))
         state.xmem.write_address(self._MASK_ADDR, mask_bytes)
         run_until_complete(state)
@@ -1880,10 +1872,11 @@ class TestAaqQuantize:
         """Direct clamp: values already in [-128, 127] pass through unchanged."""
         state = IpuState()
         state.dtype = DType.INT8
+        state.regfile.set_cr(15, encode_dstructure(valid_elements=128))
         # Lanes 0..127 hold the signed value (i - 64): -64..63, all in range.
         self._set_acc_words(state, [i - 64 for i in range(128)])
 
-        encoded = assemble("aaq;;\nBKPT;;")
+        encoded = assemble("aaq CR15;;\nBKPT;;")
         from ipu_emu.execute import decode_instruction_word
         from ipu_emu.emulator import load_program, run_until_complete
         decoded = [decode_instruction_word(w) for w in encoded]
@@ -1902,7 +1895,7 @@ class TestAaqQuantize:
         state.dtype = DType.INT8
         self._set_acc_words(state, [0] * 128)
 
-        encoded = assemble("aaq;;\nBKPT;;")
+        encoded = assemble("aaq CR15;;\nBKPT;;")
         from ipu_emu.execute import decode_instruction_word
         from ipu_emu.emulator import load_program, run_until_complete
         decoded = [decode_instruction_word(w) for w in encoded]
@@ -1915,11 +1908,12 @@ class TestAaqQuantize:
         """Direct clamp: values above 127 saturate to 127."""
         state = IpuState()
         state.dtype = DType.INT8
+        state.regfile.set_cr(15, encode_dstructure(valid_elements=128))
         # 127 stays 127; large positive int32 saturates to 127.
         values = [127] * 64 + [0x7FFFFFFF] * 64
         self._set_acc_words(state, values)
 
-        encoded = assemble("aaq;;\nBKPT;;")
+        encoded = assemble("aaq CR15;;\nBKPT;;")
         from ipu_emu.execute import decode_instruction_word
         from ipu_emu.emulator import load_program, run_until_complete
         decoded = [decode_instruction_word(w) for w in encoded]
@@ -1935,11 +1929,12 @@ class TestAaqQuantize:
         """Direct clamp: in-range negatives pass through; below -128 saturates to -128."""
         state = IpuState()
         state.dtype = DType.INT8
+        state.regfile.set_cr(15, encode_dstructure(valid_elements=128))
         # -1 stays -1 (0xFF); large negative int32 saturates to -128 (0x80).
         values = [-1] * 64 + [-(1 << 30)] * 64
         self._set_acc_words(state, values)
 
-        encoded = assemble("aaq;;\nBKPT;;")
+        encoded = assemble("aaq CR15;;\nBKPT;;")
         from ipu_emu.execute import decode_instruction_word
         from ipu_emu.emulator import load_program, run_until_complete
         decoded = [decode_instruction_word(w) for w in encoded]
@@ -1956,17 +1951,16 @@ class TestAaqQuantize:
     def test_aaq_requires_int8_mode(self):
         """aaq raises EmulatorError when not in INT8 mode."""
         from ipu_emu.ipu import EmulatorError
-        state = _make_state("aaq;;\nBKPT;;")
+        state = _make_state("aaq CR15;;\nBKPT;;")
         state.dtype = DType.E4
         with pytest.raises(EmulatorError, match="INT8 mode"):
             run_until_complete(state)
 
     def test_aaq_non_default_cr_register(self):
         """aaq reads valid_elements from the specified cr_dstructure, not necessarily CR15."""
-        from ipu_emu.ipu_config import encode_dstructure
         state = IpuState()
         state.dtype = DType.INT8
-        state.set_cr_dstructure(valid_elements=64)  # CR15 = 64 (would truncate to 64 lanes)
+        state.regfile.set_cr(15, encode_dstructure(valid_elements=64))  # CR15 = 64 (would truncate to 64 lanes)
         state.regfile.set_cr(5, encode_dstructure(valid_elements=128))  # CR5 = 128
         self._set_acc_words(state, [1] * 128)  # in-range; direct clamp leaves 1 -> 1
 
@@ -1985,10 +1979,10 @@ class TestAaqQuantize:
         """aaq CR15 quantizes only CR15.valid_elements lanes; rest are zeroed."""
         state = IpuState()
         state.dtype = DType.INT8
-        state.set_cr_dstructure(valid_elements=48)
+        state.regfile.set_cr(15, encode_dstructure(valid_elements=48))
         self._set_acc_words(state, [1] * 128)  # in-range; direct clamp leaves 1 -> 1
 
-        encoded = assemble("aaq;;\nBKPT;;")
+        encoded = assemble("aaq CR15;;\nBKPT;;")
         from ipu_emu.execute import decode_instruction_word
         from ipu_emu.emulator import load_program, run_until_complete
         decoded = [decode_instruction_word(w) for w in encoded]
@@ -2060,12 +2054,12 @@ class TestActivate:
     def test_activate_relu_int32(self):
         state = _make_state(
             """\
-ACTIVATE relu;;
+ACTIVATE relu CR15;;
 BKPT;;
 """
         )
         state.dtype = DType.INT8
-        state.set_cr_dstructure(128)
+        state.regfile.set_cr(15, encode_dstructure(valid_elements=128))
         state.regfile.set_r_acc_word(
             0, struct.unpack("<I", struct.pack("<i", -9))[0]
         )
@@ -2079,12 +2073,12 @@ BKPT;;
     def test_activate_masks_inactive_lanes(self):
         state = _make_state(
             """\
-ACTIVATE relu;;
+ACTIVATE relu CR15;;
 BKPT;;
 """
         )
         state.dtype = DType.INT8
-        state.set_cr_dstructure(2)
+        state.regfile.set_cr(15, encode_dstructure(valid_elements=2))
         state.regfile.set_r_acc_word(
             0, struct.unpack("<I", struct.pack("<i", -5))[0]
         )
@@ -2117,12 +2111,12 @@ BKPT;;
     def test_activate_identity_keyword_is_noop(self):
         state = _make_state(
             """\
-ACTIVATE identity;;
+ACTIVATE identity CR15;;
 BKPT;;
 """
         )
         state.dtype = DType.INT8
-        state.set_cr_dstructure(1)
+        state.regfile.set_cr(15, encode_dstructure(valid_elements=1))
         raw = struct.unpack("<I", struct.pack("<i", -42))[0]
         state.regfile.set_r_acc_word(0, raw)
         run_until_complete(state)
@@ -2132,12 +2126,12 @@ BKPT;;
     def test_activate_sigmoid_float_lane(self):
         state = _make_state(
             """\
-ACTIVATE sigmoid;;
+ACTIVATE sigmoid CR15;;
 BKPT;;
 """
         )
         state.dtype = DType.E4
-        state.set_cr_dstructure(1)
+        state.regfile.set_cr(15, encode_dstructure(valid_elements=1))
         state.regfile.set_r_acc_word(
             0, struct.unpack("<I", struct.pack("<f", 0.0))[0]
         )
@@ -2150,12 +2144,12 @@ BKPT;;
         for fid, name in enumerate(ACTIVATION_FN_NAMES):
             state = _make_state(
                 f"""\
-ACTIVATE {name};;
+ACTIVATE {name} CR15;;
 BKPT;;
 """
             )
             state.dtype = DType.E4
-            state.set_cr_dstructure(1)
+            state.regfile.set_cr(15, encode_dstructure(valid_elements=1))
             state.regfile.set_r_acc_word(
                 0, struct.unpack("<I", struct.pack("<f", x))[0]
             )
@@ -2167,12 +2161,12 @@ BKPT;;
     def test_activate_exp2_float(self):
         state = _make_state(
             """\
-ACTIVATE exp2;;
+ACTIVATE exp2 CR15;;
 BKPT;;
 """
         )
         state.dtype = DType.E4
-        state.set_cr_dstructure(1)
+        state.regfile.set_cr(15, encode_dstructure(valid_elements=1))
         state.regfile.set_r_acc_word(
             0, struct.unpack("<I", struct.pack("<f", 3.0))[0]
         )
@@ -2183,12 +2177,12 @@ BKPT;;
     def test_activate_gelu_float(self):
         state = _make_state(
             """\
-ACTIVATE gelu;;
+ACTIVATE gelu CR15;;
 BKPT;;
 """
         )
         state.dtype = DType.E4
-        state.set_cr_dstructure(1)
+        state.regfile.set_cr(15, encode_dstructure(valid_elements=1))
         x = 1.0
         state.regfile.set_r_acc_word(
             0, struct.unpack("<I", struct.pack("<f", x))[0]
@@ -2203,13 +2197,13 @@ BKPT;;
         alpha = 0.5
         state = _make_state(
             """\
-ACTIVATE elu;;
+ACTIVATE elu CR15;;
 BKPT;;
 """,
             elu_alpha=alpha,
         )
         state.dtype = DType.E4
-        state.set_cr_dstructure(1)
+        state.regfile.set_cr(15, encode_dstructure(valid_elements=1))
         state.regfile.set_r_acc_word(
             0, struct.unpack("<I", struct.pack("<f", x))[0]
         )
@@ -2223,13 +2217,13 @@ BKPT;;
         alpha = 0.125
         state = _make_state(
             """\
-ACTIVATE elu;;
+ACTIVATE elu CR15;;
 BKPT;;
 """
         )
         state.set_activation_alphas(elu_alpha=alpha)
         state.dtype = DType.E4
-        state.set_cr_dstructure(1)
+        state.regfile.set_cr(15, encode_dstructure(valid_elements=1))
         state.regfile.set_r_acc_word(
             0, struct.unpack("<I", struct.pack("<f", x))[0]
         )
@@ -2241,12 +2235,12 @@ BKPT;;
     def test_activate_valid_elements_from_cr15(self):
         state = _make_state(
             """\
-ACTIVATE relu;;
+ACTIVATE relu CR15;;
 BKPT;;
 """
         )
         state.dtype = DType.INT8
-        state.set_cr_dstructure(1)
+        state.regfile.set_cr(15, encode_dstructure(valid_elements=1))
         state.regfile.set_r_acc_word(
             0, struct.unpack("<I", struct.pack("<i", -8))[0]
         )
@@ -2264,12 +2258,12 @@ BKPT;;
     def test_activate_reciprocal_float(self):
         state = _make_state(
             """\
-ACTIVATE reciprocal;;
+ACTIVATE reciprocal CR15;;
 BKPT;;
 """
         )
         state.dtype = DType.E4
-        state.set_cr_dstructure(1)
+        state.regfile.set_cr(15, encode_dstructure(valid_elements=1))
         x = 4.0
         state.regfile.set_r_acc_word(
             0, struct.unpack("<I", struct.pack("<f", x))[0]
@@ -2281,12 +2275,12 @@ BKPT;;
     def test_activate_reciprocal_zero_input(self):
         state = _make_state(
             """\
-ACTIVATE reciprocal;;
+ACTIVATE reciprocal CR15;;
 BKPT;;
 """
         )
         state.dtype = DType.E4
-        state.set_cr_dstructure(1)
+        state.regfile.set_cr(15, encode_dstructure(valid_elements=1))
         state.regfile.set_r_acc_word(
             0, struct.unpack("<I", struct.pack("<f", 0.0))[0]
         )
@@ -2297,12 +2291,12 @@ BKPT;;
     def test_activate_rsqrt_float(self):
         state = _make_state(
             """\
-ACTIVATE rsqrt;;
+ACTIVATE rsqrt CR15;;
 BKPT;;
 """
         )
         state.dtype = DType.E4
-        state.set_cr_dstructure(1)
+        state.regfile.set_cr(15, encode_dstructure(valid_elements=1))
         x = 4.0
         state.regfile.set_r_acc_word(
             0, struct.unpack("<I", struct.pack("<f", x))[0]
@@ -2314,12 +2308,12 @@ BKPT;;
     def test_activate_rsqrt_nonpositive_input(self):
         state = _make_state(
             """\
-ACTIVATE rsqrt;;
+ACTIVATE rsqrt CR15;;
 BKPT;;
 """
         )
         state.dtype = DType.E4
-        state.set_cr_dstructure(1)
+        state.regfile.set_cr(15, encode_dstructure(valid_elements=1))
         state.regfile.set_r_acc_word(
             0, struct.unpack("<I", struct.pack("<f", 0.0))[0]
         )
@@ -2329,7 +2323,6 @@ BKPT;;
 
     def test_activate_non_default_cr_register(self):
         """ACTIVATE uses the specified cr_dstructure register, not necessarily CR15."""
-        from ipu_emu.ipu_config import encode_dstructure
         state = _make_state(
             """\
 ACTIVATE relu CR5;;
@@ -2337,7 +2330,7 @@ BKPT;;
 """
         )
         state.dtype = DType.INT8
-        state.set_cr_dstructure(valid_elements=4)  # CR15 = 4 (would only activate 4 lanes)
+        state.regfile.set_cr(15, encode_dstructure(valid_elements=4))  # CR15 = 4 (would only activate 4 lanes)
         state.regfile.set_cr(5, encode_dstructure(valid_elements=128))  # CR5 = 128
         for i in range(128):
             state.regfile.set_r_acc_word(i, struct.unpack("<I", struct.pack("<i", i + 1))[0])
@@ -2349,12 +2342,12 @@ BKPT;;
         """ACTIVATE CR15 activates only CR15.valid_elements lanes; rest unchanged."""
         state = _make_state(
             """\
-ACTIVATE relu;;
+ACTIVATE relu CR15;;
 BKPT;;
 """
         )
         state.dtype = DType.INT8
-        state.set_cr_dstructure(valid_elements=4)
+        state.regfile.set_cr(15, encode_dstructure(valid_elements=4))
         for i in range(128):
             state.regfile.set_r_acc_word(i, struct.unpack("<I", struct.pack("<i", i + 1))[0])
         run_until_complete(state)

--- a/src/tools/ipu-emu-py/test/test_execute.py
+++ b/src/tools/ipu-emu-py/test/test_execute.py
@@ -818,7 +818,7 @@ BKPT;;
         """AGG.SUM.FIRST: sum all 128 lanes and write to R_ACC[dest] (clean init)."""
         state = _make_state(
             """\
-AGG.SUM.FIRST LR0 1;;
+AGG.SUM.FIRST LR0;;
 BKPT;;
 """
         )
@@ -840,7 +840,7 @@ BKPT;;
         """
         state = _make_state(
             """\
-AGG.SUM.FIRST LR0 0;;
+AGG.SUM.FIRST LR0;;
 BKPT;;
 """
         )
@@ -860,7 +860,7 @@ BKPT;;
         """AGG.SUM.FIRST: only active prefix contributes; tail is excluded."""
         state = _make_state(
             """\
-AGG.SUM.FIRST LR0 0;;
+AGG.SUM.FIRST LR0;;
 BKPT;;
 """
         )
@@ -875,23 +875,25 @@ BKPT;;
         result = struct.unpack("<i", struct.pack("<I", raw))[0]
         assert result == 40, f"expected sum of 4 tens = 40, got {result}"
 
-    def test_agg_sum_first_full_xmem_row_overrides_valid_elements(self):
-        """AGG.SUM.FIRST with full_xmem_row=1 uses all 128 lanes regardless of CR15."""
+    def test_agg_sum_first_non_default_cr_register(self):
+        """AGG.SUM.FIRST uses the specified cr_dstructure register, not necessarily CR15."""
+        from ipu_emu.ipu_config import encode_dstructure
         state = _make_state(
             """\
-AGG.SUM.FIRST LR0 1;;
+AGG.SUM.FIRST LR0 CR5;;
 BKPT;;
 """
         )
         state.dtype = DType.INT8
-        state.set_cr_dstructure(valid_elements=4)
+        state.set_cr_dstructure(valid_elements=4)  # CR15 = 4 active lanes
+        state.regfile.set_cr(5, encode_dstructure(valid_elements=128))  # CR5 = 128
         state.regfile.set_lr(0, 127)
         for i in range(128):
             state.regfile.set_r_acc_word(i, struct.unpack("<I", struct.pack("<i", 1))[0])
         run_until_complete(state)
         raw = state.regfile.get_r_acc_word(127)
         result = struct.unpack("<i", struct.pack("<I", raw))[0]
-        assert result == 128, f"expected sum of all 128 lanes = 128, got {result}"
+        assert result == 128, f"expected sum of all 128 lanes (from CR5) = 128, got {result}"
 
     def test_agg_sum_accumulates(self):
         """AGG.SUM: sum of active lanes is ADDED to existing R_ACC[dest] (running accumulation).
@@ -901,7 +903,7 @@ BKPT;;
         """
         state = _make_state(
             """\
-AGG.SUM LR0 0;;
+AGG.SUM LR0;;
 BKPT;;
 """
         )
@@ -921,7 +923,7 @@ BKPT;;
         """AGG.MAX.FIRST: max of all 128 lanes, no seed from dest."""
         state = _make_state(
             """\
-AGG.MAX.FIRST LR0 1;;
+AGG.MAX.FIRST LR0;;
 BKPT;;
 """
         )
@@ -945,7 +947,7 @@ BKPT;;
         """
         state = _make_state(
             """\
-AGG.MAX.FIRST LR0 0;;
+AGG.MAX.FIRST LR0;;
 BKPT;;
 """
         )
@@ -964,7 +966,7 @@ BKPT;;
         """AGG.MAX.FIRST with valid_elements=0: dest gets the identity seed (INT32_MIN)."""
         state = _make_state(
             """\
-AGG.MAX.FIRST LR0 0;;
+AGG.MAX.FIRST LR0;;
 BKPT;;
 """
         )
@@ -981,7 +983,7 @@ BKPT;;
         """AGG.MAX.FIRST: tail lanes beyond valid_elements are excluded."""
         state = _make_state(
             """\
-AGG.MAX.FIRST LR0 0;;
+AGG.MAX.FIRST LR0;;
 BKPT;;
 """
         )
@@ -1001,7 +1003,7 @@ BKPT;;
         """AGG.MAX: existing dest value beats all active lanes — dest unchanged."""
         state = _make_state(
             """\
-AGG.MAX LR0 1;;
+AGG.MAX LR0;;
 BKPT;;
 """
         )
@@ -1020,7 +1022,7 @@ BKPT;;
         """AGG.MAX: an active lane beats the existing dest — dest updated."""
         state = _make_state(
             """\
-AGG.MAX LR0 0;;
+AGG.MAX LR0;;
 BKPT;;
 """
         )
@@ -1047,7 +1049,7 @@ BKPT;;
         """
         state = _make_state(
             """\
-AGG.SUM.FIRST LR0 1; ACTIVATE relu 1;;
+AGG.SUM.FIRST LR0; ACTIVATE relu;;
 BKPT;;
 """
         )
@@ -1544,6 +1546,47 @@ BKPT;;
             val = struct.unpack_from("<i", acc_raw, i * 4)[0]
             assert val == 28, f"acc word {i}: expected 28 (r1[0]=7 × cyclic[i]=4), got {val}"
 
+    def test_mult_ve_cr_cr15_as_cr_idx_with_explicit_dstructure(self):
+        """CR15 is valid as cr_idx when cr_dstructure is a different register (e.g. CR0)."""
+        import pytest
+        from ipu_as.lark_tree import assemble
+        # Scalar = 2 stored in CR15, dstructure taken from CR0 (128 elements)
+        asm = """\
+RESET_ACC;;
+SET lr2 cr9;;
+SET lr4 cr9;;
+MULT.VE.CR lr2 0 lr4 CR15 CR0;
+ACC;;
+BKPT;;
+"""
+        state = _make_state(asm, cr={9: 0})
+        state.dtype = DType.INT8
+        state.regfile.set_cr(15, 2)  # CR15 used as scalar source
+        state.regfile.set_r_cyclic_at(0, bytes([3] * 512))
+        run_until_complete(state)
+        acc_raw = state.regfile.raw("r_acc")
+        for i in range(128):
+            val = struct.unpack_from("<i", acc_raw, i * 4)[0]
+            assert val == 6, f"acc word {i}: expected 6 (2×3), got {val}"
+
+    def test_mult_ve_cr_cr15_cr_idx_conflicts_with_explicit_cr15_dstructure(self):
+        """Assembler raises ValueError when cr_idx=CR15 and cr_dstructure=CR15 explicitly."""
+        import pytest
+        from ipu_as.lark_tree import parse
+        from ipu_as.compound_inst import CompoundInst
+        ast = parse("MULT.VE.CR lr0 0 lr0 CR15 CR15;;\nBKPT;;")
+        with pytest.raises(ValueError, match="conflicting roles"):
+            [CompoundInst(instr).encode() for instr in ast]
+
+    def test_mult_ve_cr_cr15_cr_idx_conflicts_with_default_dstructure(self):
+        """Assembler raises ValueError when cr_idx=CR15 and cr_dstructure omitted (defaults to CR15)."""
+        import pytest
+        from ipu_as.lark_tree import parse
+        from ipu_as.compound_inst import CompoundInst
+        ast = parse("MULT.VE.CR lr0 0 lr0 CR15;;\nBKPT;;")
+        with pytest.raises(ValueError, match="conflicting roles"):
+            [CompoundInst(instr).encode() for instr in ast]
+
 
 class TestMultEeRr:
     """MULT.EE.RR — multi-element execution (MEE): r0-by-r0 or r1-by-r1."""
@@ -1840,7 +1883,7 @@ class TestAaqQuantize:
         # Lanes 0..127 hold the signed value (i - 64): -64..63, all in range.
         self._set_acc_words(state, [i - 64 for i in range(128)])
 
-        encoded = assemble("aaq 0;;\nBKPT;;")
+        encoded = assemble("aaq;;\nBKPT;;")
         from ipu_emu.execute import decode_instruction_word
         from ipu_emu.emulator import load_program, run_until_complete
         decoded = [decode_instruction_word(w) for w in encoded]
@@ -1859,7 +1902,7 @@ class TestAaqQuantize:
         state.dtype = DType.INT8
         self._set_acc_words(state, [0] * 128)
 
-        encoded = assemble("aaq 0;;\nBKPT;;")
+        encoded = assemble("aaq;;\nBKPT;;")
         from ipu_emu.execute import decode_instruction_word
         from ipu_emu.emulator import load_program, run_until_complete
         decoded = [decode_instruction_word(w) for w in encoded]
@@ -1876,7 +1919,7 @@ class TestAaqQuantize:
         values = [127] * 64 + [0x7FFFFFFF] * 64
         self._set_acc_words(state, values)
 
-        encoded = assemble("aaq 0;;\nBKPT;;")
+        encoded = assemble("aaq;;\nBKPT;;")
         from ipu_emu.execute import decode_instruction_word
         from ipu_emu.emulator import load_program, run_until_complete
         decoded = [decode_instruction_word(w) for w in encoded]
@@ -1896,7 +1939,7 @@ class TestAaqQuantize:
         values = [-1] * 64 + [-(1 << 30)] * 64
         self._set_acc_words(state, values)
 
-        encoded = assemble("aaq 0;;\nBKPT;;")
+        encoded = assemble("aaq;;\nBKPT;;")
         from ipu_emu.execute import decode_instruction_word
         from ipu_emu.emulator import load_program, run_until_complete
         decoded = [decode_instruction_word(w) for w in encoded]
@@ -1913,19 +1956,21 @@ class TestAaqQuantize:
     def test_aaq_requires_int8_mode(self):
         """aaq raises EmulatorError when not in INT8 mode."""
         from ipu_emu.ipu import EmulatorError
-        state = _make_state("aaq 0;;\nBKPT;;")
+        state = _make_state("aaq;;\nBKPT;;")
         state.dtype = DType.E4
         with pytest.raises(EmulatorError, match="INT8 mode"):
             run_until_complete(state)
 
-    def test_aaq_full_xmem_row_1_ignores_valid_elements(self):
-        """full_xmem_row=1 always quantizes all 128 lanes even if CR15.valid_elements < 128."""
+    def test_aaq_non_default_cr_register(self):
+        """aaq reads valid_elements from the specified cr_dstructure, not necessarily CR15."""
+        from ipu_emu.ipu_config import encode_dstructure
         state = IpuState()
         state.dtype = DType.INT8
-        state.set_cr_dstructure(valid_elements=64)
+        state.set_cr_dstructure(valid_elements=64)  # CR15 = 64 (would truncate to 64 lanes)
+        state.regfile.set_cr(5, encode_dstructure(valid_elements=128))  # CR5 = 128
         self._set_acc_words(state, [1] * 128)  # in-range; direct clamp leaves 1 -> 1
 
-        encoded = assemble("aaq 1;;\nBKPT;;")
+        encoded = assemble("aaq CR5;;\nBKPT;;")
         from ipu_emu.execute import decode_instruction_word
         from ipu_emu.emulator import load_program, run_until_complete
         decoded = [decode_instruction_word(w) for w in encoded]
@@ -1933,17 +1978,17 @@ class TestAaqQuantize:
         run_until_complete(state)
 
         result = state.regfile.get_post_aaq_reg()
-        assert result[:128] == bytearray([1] * 128), "all 128 lanes should be quantized"
+        assert result[:128] == bytearray([1] * 128), "all 128 lanes should be quantized (from CR5)"
         assert result[128:] == bytearray(384)
 
-    def test_aaq_full_xmem_row_0_uses_valid_elements(self):
-        """full_xmem_row=0 quantizes only CR15.valid_elements lanes; rest are zeroed."""
+    def test_aaq_cr15_uses_valid_elements(self):
+        """aaq CR15 quantizes only CR15.valid_elements lanes; rest are zeroed."""
         state = IpuState()
         state.dtype = DType.INT8
         state.set_cr_dstructure(valid_elements=48)
         self._set_acc_words(state, [1] * 128)  # in-range; direct clamp leaves 1 -> 1
 
-        encoded = assemble("aaq 0;;\nBKPT;;")
+        encoded = assemble("aaq;;\nBKPT;;")
         from ipu_emu.execute import decode_instruction_word
         from ipu_emu.emulator import load_program, run_until_complete
         decoded = [decode_instruction_word(w) for w in encoded]
@@ -2015,7 +2060,7 @@ class TestActivate:
     def test_activate_relu_int32(self):
         state = _make_state(
             """\
-ACTIVATE relu 0;;
+ACTIVATE relu;;
 BKPT;;
 """
         )
@@ -2034,7 +2079,7 @@ BKPT;;
     def test_activate_masks_inactive_lanes(self):
         state = _make_state(
             """\
-ACTIVATE relu 0;;
+ACTIVATE relu;;
 BKPT;;
 """
         )
@@ -2072,7 +2117,7 @@ BKPT;;
     def test_activate_identity_keyword_is_noop(self):
         state = _make_state(
             """\
-ACTIVATE identity 0;;
+ACTIVATE identity;;
 BKPT;;
 """
         )
@@ -2087,7 +2132,7 @@ BKPT;;
     def test_activate_sigmoid_float_lane(self):
         state = _make_state(
             """\
-ACTIVATE sigmoid 0;;
+ACTIVATE sigmoid;;
 BKPT;;
 """
         )
@@ -2105,7 +2150,7 @@ BKPT;;
         for fid, name in enumerate(ACTIVATION_FN_NAMES):
             state = _make_state(
                 f"""\
-ACTIVATE {name} 0;;
+ACTIVATE {name};;
 BKPT;;
 """
             )
@@ -2122,7 +2167,7 @@ BKPT;;
     def test_activate_exp2_float(self):
         state = _make_state(
             """\
-ACTIVATE exp2 0;;
+ACTIVATE exp2;;
 BKPT;;
 """
         )
@@ -2138,7 +2183,7 @@ BKPT;;
     def test_activate_gelu_float(self):
         state = _make_state(
             """\
-ACTIVATE gelu 0;;
+ACTIVATE gelu;;
 BKPT;;
 """
         )
@@ -2158,7 +2203,7 @@ BKPT;;
         alpha = 0.5
         state = _make_state(
             """\
-ACTIVATE elu 0;;
+ACTIVATE elu;;
 BKPT;;
 """,
             elu_alpha=alpha,
@@ -2178,7 +2223,7 @@ BKPT;;
         alpha = 0.125
         state = _make_state(
             """\
-ACTIVATE elu 0;;
+ACTIVATE elu;;
 BKPT;;
 """
         )
@@ -2196,7 +2241,7 @@ BKPT;;
     def test_activate_valid_elements_from_cr15(self):
         state = _make_state(
             """\
-ACTIVATE relu 0;;
+ACTIVATE relu;;
 BKPT;;
 """
         )
@@ -2219,7 +2264,7 @@ BKPT;;
     def test_activate_reciprocal_float(self):
         state = _make_state(
             """\
-ACTIVATE reciprocal 0;;
+ACTIVATE reciprocal;;
 BKPT;;
 """
         )
@@ -2236,7 +2281,7 @@ BKPT;;
     def test_activate_reciprocal_zero_input(self):
         state = _make_state(
             """\
-ACTIVATE reciprocal 0;;
+ACTIVATE reciprocal;;
 BKPT;;
 """
         )
@@ -2252,7 +2297,7 @@ BKPT;;
     def test_activate_rsqrt_float(self):
         state = _make_state(
             """\
-ACTIVATE rsqrt 0;;
+ACTIVATE rsqrt;;
 BKPT;;
 """
         )
@@ -2269,7 +2314,7 @@ BKPT;;
     def test_activate_rsqrt_nonpositive_input(self):
         state = _make_state(
             """\
-ACTIVATE rsqrt 0;;
+ACTIVATE rsqrt;;
 BKPT;;
 """
         )
@@ -2282,27 +2327,29 @@ BKPT;;
         out = _post_aaq_lane_f32(state, 0)
         assert out == 0.0
 
-    def test_activate_full_xmem_row_1_ignores_valid_elements(self):
-        """ACTIVATE full_xmem_row=1: activates all 128 lanes even when CR15.valid_elements < 128."""
+    def test_activate_non_default_cr_register(self):
+        """ACTIVATE uses the specified cr_dstructure register, not necessarily CR15."""
+        from ipu_emu.ipu_config import encode_dstructure
         state = _make_state(
             """\
-ACTIVATE relu 1;;
+ACTIVATE relu CR5;;
 BKPT;;
 """
         )
         state.dtype = DType.INT8
-        state.set_cr_dstructure(valid_elements=4)
+        state.set_cr_dstructure(valid_elements=4)  # CR15 = 4 (would only activate 4 lanes)
+        state.regfile.set_cr(5, encode_dstructure(valid_elements=128))  # CR5 = 128
         for i in range(128):
             state.regfile.set_r_acc_word(i, struct.unpack("<I", struct.pack("<i", i + 1))[0])
         run_until_complete(state)
         for i in range(128):
-            assert _post_aaq_lane_i32(state, i) == i + 1, f"lane {i} should be activated"
+            assert _post_aaq_lane_i32(state, i) == i + 1, f"lane {i} should be activated (from CR5)"
 
-    def test_activate_full_xmem_row_0_uses_valid_elements(self):
-        """ACTIVATE full_xmem_row=0: activates only CR15.valid_elements lanes; rest unchanged."""
+    def test_activate_cr15_uses_valid_elements(self):
+        """ACTIVATE CR15 activates only CR15.valid_elements lanes; rest unchanged."""
         state = _make_state(
             """\
-ACTIVATE relu 0;;
+ACTIVATE relu;;
 BKPT;;
 """
         )

--- a/src/tools/ipu-emu-py/test/test_regfile.py
+++ b/src/tools/ipu-emu-py/test/test_regfile.py
@@ -9,7 +9,6 @@ import pytest
 from ipu_emu.descriptors import REGFILE_SCHEMA, RegDescriptor, RegDtype, RegKind
 from ipu_emu.regfile import RegFile
 from ipu_emu.ipu_config import (
-    CR_DSTRUCTURE_REG_INDEX,
     DSTRUCTURE_PARTITION_MASK,
     DSTRUCTURE_VALID_ELEMENTS_MASK,
     LR_CR_SCALAR_VALUE_MASK,
@@ -293,25 +292,21 @@ class TestIpuState:
         state.dtype = DType.E4
         assert state.dtype == DType.E4
 
-    def test_cr15_default_dstructure(self):
+    def test_cr15_no_special_initialization(self):
         state = IpuState()
-        valid_elements, partition = state.get_cr_dstructure()
-        assert valid_elements == 128
-        assert partition == 0
+        assert state.regfile.get_cr(15) == 0  # no auto-init; caller must configure
 
     def test_set_cr_dstructure(self):
         state = IpuState()
-        state.set_cr_dstructure(64, 2)
-        config = state.get_cr_dstructure()
+        state.regfile.set_cr(15, encode_dstructure(valid_elements=64, partition=2))
+        config = decode_dstructure(state.regfile.get_cr(15))
         assert config.valid_elements == 64
         assert config.partition == 2
-        assert state.get_config_valid_elements() == 64
-        assert state.get_config_partition() == 2
 
     def test_cr_dstructure_masks_valid_elements(self):
         state = IpuState()
-        state.set_cr_dstructure(valid_elements=DSTRUCTURE_VALID_ELEMENTS_MASK + 1)
-        assert state.get_cr_dstructure().valid_elements == 0
+        state.regfile.set_cr(15, encode_dstructure(valid_elements=DSTRUCTURE_VALID_ELEMENTS_MASK + 1))
+        assert decode_dstructure(state.regfile.get_cr(15)).valid_elements == 0
 
     def test_cr_dstructure_invalid_partition_raises(self):
         with pytest.raises(ValueError, match="not a valid Partition"):
@@ -323,13 +318,11 @@ class TestIpuState:
         assert decoded.valid_elements == 17
         assert decoded.partition == 4
 
-    def test_cr_dstructure_uses_config_register(self):
+    def test_cr_dstructure_encode_decode(self):
         state = IpuState()
-        state.set_cr_dstructure(7, 4)
-        assert state.regfile.get_cr(CR_DSTRUCTURE_REG_INDEX) == encode_dstructure(
-            valid_elements=7,
-            partition=4,
-        )
+        expected = encode_dstructure(valid_elements=7, partition=4)
+        state.regfile.set_cr(15, expected)
+        assert state.regfile.get_cr(15) == expected
 
     def test_load_store_r_reg_xmem(self):
         """Load data into XMEM, then load into R register, verify."""

--- a/src/tools/ipu-emu-py/test/test_stats.py
+++ b/src/tools/ipu-emu-py/test/test_stats.py
@@ -88,7 +88,7 @@ class TestStatsCountedDuringExecution:
         # MULT.EE syntax: ra, cyclic_offset(LR), mask_offset(imm), mask_shift(LR)
         asm = """\
 SET lr0 cr0;;
-LDR_MULT_REG r0 lr0 cr0;MULT.EE r0 lr0 0 lr0;;
+LDR_MULT_REG r0 lr0 cr0;MULT.EE r0 lr0 0 lr0 CR15;;
 BKPT;;
 """
         state = IpuState()

--- a/src/tools/ipu-emu-py/test/test_wide_vector_debug.py
+++ b/src/tools/ipu-emu-py/test/test_wide_vector_debug.py
@@ -86,8 +86,8 @@ RESET_ACC;;
 MULT.EE r0 lr2 0 lr2;;
 acc.first;;
 SET lr0 cr9;;
-ACTIVATE identity 0;;
-aaq 0;;
+ACTIVATE identity;;
+aaq;;
 BKPT;;
 """,
             cr={6: 0x1000, 7: 0x2000, 8: 0, 9: 128},
@@ -116,8 +116,8 @@ RESET_ACC;;
 MULT.EE r0 lr2 0 lr2;;
 acc.first;;
 SET lr0 cr9;;
-ACTIVATE identity 0;;
-aaq 0;;
+ACTIVATE identity;;
+aaq;;
 BKPT;;
 """
         state.regfile.set_cr(6, 0x1000)
@@ -372,7 +372,7 @@ class TestWideVectorAgg:
         acc = bytearray(512)
         struct.pack_into("<128i", acc, 0, *([4] * 128))
         st = self._run_agg(
-            "AGG.SUM.FIRST LR0 0;;\nBKPT;;\n", WideVectorArithmetic.INT32, acc
+            "AGG.SUM.FIRST LR0;;\nBKPT;;\n", WideVectorArithmetic.INT32, acc
         )
         raw = st.regfile.raw("r_acc")
         assert struct.unpack_from("<i", raw, 127 * 4)[0] == 512
@@ -382,7 +382,7 @@ class TestWideVectorAgg:
         acc = bytearray(512)
         struct.pack_into("<128f", acc, 0, *([0.5] * 128))
         st = self._run_agg(
-            "AGG.SUM.FIRST LR0 0;;\nBKPT;;\n", WideVectorArithmetic.FP32, acc
+            "AGG.SUM.FIRST LR0;;\nBKPT;;\n", WideVectorArithmetic.FP32, acc
         )
         raw = st.regfile.raw("r_acc")
         assert struct.unpack_from("<f", raw, 127 * 4)[0] == pytest.approx(64.0)
@@ -393,7 +393,7 @@ class TestWideVectorAgg:
         struct.pack_into("<128f", acc, 0, *([1.0] * 128))
         struct.pack_into("<f", acc, 3 * 4, 7.5)
         st = self._run_agg(
-            "AGG.MAX.FIRST LR0 0;;\nBKPT;;\n", WideVectorArithmetic.FP32, acc
+            "AGG.MAX.FIRST LR0;;\nBKPT;;\n", WideVectorArithmetic.FP32, acc
         )
         raw = st.regfile.raw("r_acc")
         assert struct.unpack_from("<f", raw, 127 * 4)[0] == pytest.approx(7.5)

--- a/src/tools/ipu-emu-py/test/test_wide_vector_debug.py
+++ b/src/tools/ipu-emu-py/test/test_wide_vector_debug.py
@@ -14,6 +14,7 @@ import pytest
 from ipu_emu.emulator import load_program, run_until_complete
 from ipu_emu.execute import decode_instruction_word
 from ipu_emu.ipu import EmulatorError
+from ipu_emu.ipu_config import encode_dstructure
 from ipu_emu.ipu_math import DType
 from ipu_emu.ipu_state import IpuState, WideVectorArithmetic
 
@@ -59,7 +60,7 @@ SET lr2 cr8;;
 LDR_MULT_REG r0 lr0 cr0;;
 LDR_CYCLIC_MULT_REG lr1 cr0 lr2;;
 RESET_ACC;;
-MULT.EE r0 lr2 0 lr2;;
+MULT.EE r0 lr2 0 lr2 CR15;;
 acc.first;;
 BKPT;;
 """
@@ -83,11 +84,11 @@ SET lr2 cr8;;
 LDR_MULT_REG r0 lr0 cr0;;
 LDR_CYCLIC_MULT_REG lr1 cr0 lr2;;
 RESET_ACC;;
-MULT.EE r0 lr2 0 lr2;;
+MULT.EE r0 lr2 0 lr2 CR15;;
 acc.first;;
 SET lr0 cr9;;
-ACTIVATE identity;;
-aaq;;
+ACTIVATE identity CR15;;
+aaq CR15;;
 BKPT;;
 """,
             cr={6: 0x1000, 7: 0x2000, 8: 0, 9: 128},
@@ -104,6 +105,7 @@ BKPT;;
             wide_vector_quantize_output=True,
         )
         state.dtype = DType.INT8
+        state.regfile.set_cr(15, encode_dstructure(valid_elements=128))
         state.xmem.write_address(0x1000, r0)
         state.xmem.write_address(0x2000, rc)
         asm = """\
@@ -113,11 +115,11 @@ SET lr2 cr8;;
 LDR_MULT_REG r0 lr0 cr0;;
 LDR_CYCLIC_MULT_REG lr1 cr0 lr2;;
 RESET_ACC;;
-MULT.EE r0 lr2 0 lr2;;
+MULT.EE r0 lr2 0 lr2 CR15;;
 acc.first;;
 SET lr0 cr9;;
-ACTIVATE identity;;
-aaq;;
+ACTIVATE identity CR15;;
+aaq CR15;;
 BKPT;;
 """
         state.regfile.set_cr(6, 0x1000)
@@ -147,7 +149,7 @@ SET lr2 cr8;;
 LDR_MULT_REG r0 lr0 cr0;;
 LDR_CYCLIC_MULT_REG lr1 cr0 lr2;;
 RESET_ACC;;
-MULT.EE r0 lr2 0 lr2;;
+MULT.EE r0 lr2 0 lr2 CR15;;
 acc.first;;
 BKPT;;
 """
@@ -193,7 +195,7 @@ LDR_MULT_REG r0 lr0 cr0;;
 LDR_MULT_REG r1 lr1 cr0;;
 LDR_CYCLIC_MULT_REG lr2 cr0 lr3;;
 RESET_ACC;;
-MULT.EE {which} lr3 0 lr3;;
+MULT.EE {which} lr3 0 lr3 CR15;;
 acc.first;;
 BKPT;;
 """
@@ -235,7 +237,7 @@ SET lr4 cr10;;
 LDR_MULT_REG r0 lr4 cr0;;
 SET lr5 cr11;;
 RESET_ACC;;
-MULT.EE r0 lr5 0 lr5;;
+MULT.EE r0 lr5 0 lr5 CR15;;
 acc.first;;
 BKPT;;
 """
@@ -264,7 +266,7 @@ class TestWideVectorPadding:
         asm = """\
 SET lr0 cr6;;
 SET lr2 cr7;;
-MULT.VE.CR lr0 0 lr2 cr2;;
+MULT.VE.CR lr0 0 lr2 cr2 CR15;;
 RESET_ACC;;
 acc.first;;
 BKPT;;
@@ -300,7 +302,7 @@ LDR_MULT_REG r0 lr4 cr0;;
 SET lr0 cr6;;
 SET lr2 cr7;;
 SET lr3 cr8;;
-MULT.VE.CYCLIC lr0 0 lr2 lr3;;
+MULT.VE.CYCLIC lr0 0 lr2 lr3 CR15;;
 RESET_ACC;;
 acc.first;;
 BKPT;;
@@ -336,7 +338,7 @@ LDR_MULT_REG r0 lr4 cr0;;
 SET lr0 cr6;;
 SET lr2 cr7;;
 SET lr3 cr8;;
-MULT.VE.PADDED lr0 0 lr2 lr3;;
+MULT.VE.PADDED lr0 0 lr2 lr3 CR15;;
 RESET_ACC;;
 acc.first;;
 BKPT;;
@@ -360,7 +362,7 @@ class TestWideVectorAgg:
         st = IpuState(wide_vector_debug=True, wide_vector_arithmetic=arithmetic)
         st.dtype = DType.INT8
         st.regfile.set_r_acc_bytes(acc)
-        st.set_cr_dstructure(128)
+        st.regfile.set_cr(15, encode_dstructure(valid_elements=128))
         st.regfile.set_lr(0, 127)  # dest = r_acc lane 127
         encoded = assemble(asm)
         load_program(st, [decode_instruction_word(w) for w in encoded])
@@ -372,7 +374,7 @@ class TestWideVectorAgg:
         acc = bytearray(512)
         struct.pack_into("<128i", acc, 0, *([4] * 128))
         st = self._run_agg(
-            "AGG.SUM.FIRST LR0;;\nBKPT;;\n", WideVectorArithmetic.INT32, acc
+            "AGG.SUM.FIRST LR0 CR15;;\nBKPT;;\n", WideVectorArithmetic.INT32, acc
         )
         raw = st.regfile.raw("r_acc")
         assert struct.unpack_from("<i", raw, 127 * 4)[0] == 512
@@ -382,7 +384,7 @@ class TestWideVectorAgg:
         acc = bytearray(512)
         struct.pack_into("<128f", acc, 0, *([0.5] * 128))
         st = self._run_agg(
-            "AGG.SUM.FIRST LR0;;\nBKPT;;\n", WideVectorArithmetic.FP32, acc
+            "AGG.SUM.FIRST LR0 CR15;;\nBKPT;;\n", WideVectorArithmetic.FP32, acc
         )
         raw = st.regfile.raw("r_acc")
         assert struct.unpack_from("<f", raw, 127 * 4)[0] == pytest.approx(64.0)
@@ -393,7 +395,7 @@ class TestWideVectorAgg:
         struct.pack_into("<128f", acc, 0, *([1.0] * 128))
         struct.pack_into("<f", acc, 3 * 4, 7.5)
         st = self._run_agg(
-            "AGG.MAX.FIRST LR0;;\nBKPT;;\n", WideVectorArithmetic.FP32, acc
+            "AGG.MAX.FIRST LR0 CR15;;\nBKPT;;\n", WideVectorArithmetic.FP32, acc
         )
         raw = st.regfile.raw("r_acc")
         assert struct.unpack_from("<f", raw, 127 * 4)[0] == pytest.approx(7.5)
@@ -417,7 +419,7 @@ LDR_MULT_REG r0 lr0 cr0;;
 LDR_CYCLIC_MULT_REG lr1 cr0 lr2;;
 SET lr3 cr9;;
 RESET_ACC;;
-MULT.EE r0 lr3 0 lr3;;
+MULT.EE r0 lr3 0 lr3 CR15;;
 BKPT;;
 """
         encoded = assemble(asm)


### PR DESCRIPTION
## What Changed

### 1. `full_xmem_row` → `cr_dstructure` (core change)

The old `full_xmem_row` was a 1-bit flag: `1` = always use 128 lanes, `0` = read `valid_elements` from a hardcoded CR15. The new `cr_dstructure` is a **4-bit CR register index** that points to any CR register (CR0–CR15) whose encoded dstructure value supplies `valid_elements` (active lane count) and `partition` (mask-shift group boundary).

Affected instructions: `MULT.VE.*`, `MULT.EE`, `MULT.EE.RR`, `AGG.SUM`, `AGG.SUM.FIRST`, `AGG.MAX`, `AGG.MAX.FIRST`, `AAQ`, `ACTIVATE`.

Files changed:
- **`instruction_spec.py`** — removed `full_xmem_row`; added `cr_dstructure: CrDstructureIdx` as the last operand on all affected instructions.
- **`union_layout.py`** — updated slot union field from 1-bit `FullXmemRow` to 4-bit `CrDstructureIdx`.
- **`ipu.py`** — all `execute_*` handlers updated to accept and use `cr_dstructure`.
- **`reg.py`** — added `CrDstructureIdxField` class (extends `_CrRegFieldBase`, accepts CR0–CR15, `default()` returns CR15).
- **`inst.py`** — added `"CrDstructureIdx": reg.CrDstructureIdxField` to `OPERAND_TYPE_MAP`.

### 2. `cr_dstructure` is an optional trailing operand

When `cr_dstructure` is omitted from an instruction, the assembler automatically defaults it to **CR15** (which `IpuState.__init__` always sets to `valid_elements=128, partition=0`). This means existing programs that don't need a non-default dstructure register require no changes — the common case is zero extra tokens.

```asm
; Both of these are equivalent:
ACTIVATE relu;;
ACTIVATE relu CR15;;

; Use a different CR register explicitly:
ACTIVATE relu CR5;;