### PR TITLE
LR instruction slot documented three times

### DIFF
--- a/src/tools/ipu-as-py/src/ipu_as/inst.py
+++ b/src/tools/ipu-as-py/src/ipu_as/inst.py
@@ -9,7 +9,6 @@ from ipu_common.instruction_spec import (
     INSTRUCTION_SPEC,
     COMPOUND_LAYOUT_SLOT_ORDER,
     InstructionDoc,
-    SLOT_COUNT,
     SLOT_UNIONS,
     is_hardware_slot,
 )
@@ -252,7 +251,7 @@ class Inst:
             inst_class = slot_to_class.get(slot)
             if inst_class is None:
                 continue
-            seen.extend([inst_class] * SLOT_COUNT.get(slot, 1))
+            seen.append(inst_class)
         # Any subclasses not in COMPOUND_LAYOUT_SLOT_ORDER (should not happen).
         for subclass in cls.__subclasses__():
             if subclass not in seen:


### PR DESCRIPTION
## Bug: LR instruction slot documented three times

### Root cause

`Inst.get_all_instruction_classes()` in `inst.py` used `SLOT_COUNT` to
multiply each instruction class into the returned list — so
`LrInst` appeared **three times** because `SLOT_COUNT["lr"] == 3`
(the LR slot occupies three positions in each VLIW word).

`gen_docs.py` iterates that list and calls `inst_class.description()`
for every entry, causing the entire LR instruction block (SET, ADD,
SUB, INCR_MOD_POW2) to be rendered three times in `instructions.md`.

### Fix

Changed `seen.extend([inst_class] * SLOT_COUNT.get(slot, 1))` to
`seen.append(inst_class)` in `get_all_instruction_classes()`, and
removed the now-unused `SLOT_COUNT` import from `inst.py`.

The `SLOT_COUNT` multiplication still lives in `compound_inst.py`
where it correctly builds the binary VLIW layout with 3 physical LR
slots. `get_all_instruction_classes()` only needs one representative
per instruction type, so the multiplication was always wrong there.

After the fix, `instructions.md` was regenerated via
`bazel run //docs:gen_docs`.

### Files changed

- `src/tools/ipu-as-py/src/ipu_as/inst.py` — removed duplicate
  entries from `get_all_instruction_classes()`
- `docs/content/instructions.md` — regenerated (LR block now appears
  once)