### PR TITLE
Add INC/DEC to LR slot; remove AddSubSrcB from ADD/SUB (fixes #132)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -97,13 +97,13 @@ LDR_MULT_REG R0, LR0, CR0; MULT.EE R0, LR1, 0, LR3; ACC; ADD LR0, LR0, 1; BNE LR
 | MULT | `MULT.EE`, `MULT.VE.CYCLIC`, `MULT.VE.PADDED`, `MULT.VE.CR`, `MULT.EE.RR` | 8-bit vector multiply |
 | ACC | `ACC`, `ACC.FIRST`, `ACC.STRIDE`, `RESET_ACC`, `AGG.SUM`, `AGG.SUM.FIRST`, `AGG.MAX`, `AGG.MAX.FIRST` | Accumulate into `R_ACC`; in-place aggregation (sum/max) writing a single slot of `R_ACC` |
 | AAQ | `AAQ`, `ACTIVATE` | **`ACTIVATE`** reads **`R_ACC`** and writes activated **32b** lanes into **`POST_AAQ_REG`** (512 B staging). **`AAQ`** (INT8) quantizes wide lanes in **`POST_AAQ_REG`** into the leading **128 B**; **`STR_POST_AAQ_REG`** stores the full **512 B** register to XMEM. See `docs/content/building-applications.md#activations-emulator`. |
-| LR (×3) | `SET`, `ADD`, `SUB`, `INCR_MOD_POW2` | Scalar loop register ops (`SET` copies from a **`CR`** register) |
+| LR (×3) | `SET`, `ADD`, `SUB`, `INCR_MOD_POW2`, `INC`, `DEC` | Scalar loop register ops (`SET` copies from a **`CR`** register; `INC`/`DEC` read-modify-write with union-derived immediate) |
 | COND | `BEQ`, `BNE`, `BLT`, `BNZ`, `BZ`, `B`, `BR`, `BKPT` | Branches |
 | BREAK | `BREAK`, `BREAK.IFEQ` | Debug breakpoints |
 
 ### Operand Types (defined in instruction_spec)
 
-`MultStageReg`, `LrIdx`, `CrIdx`, `LcrIdx`, `AddSubSrcB`, `FullXmemRow`, `ActivationFn`, `ElementsInRow`, `HorizontalStride`, `VerticalStride`, `LrModPow2KImmediate`, `MultMaskOffsetImmediate`, `BreakImmediate`, `Label`
+`MultStageReg`, `LrIdx`, `CrIdx`, `LcrIdx`, `LrIncDecImmediate`, `FullXmemRow`, `ActivationFn`, `ElementsInRow`, `HorizontalStride`, `VerticalStride`, `LrModPow2KImmediate`, `MultMaskOffsetImmediate`, `BreakImmediate`, `Label`
 
 ---
 

--- a/docs/content/specs/stage-control.md
+++ b/docs/content/specs/stage-control.md
@@ -175,7 +175,7 @@ XMEM read-address port, and the APB slave.
 | `LR_REG_COUNT` | `16` | `LR0`–`LR15`. |
 | `CR_REG_COUNT` | `16` | `CR0`–`CR15` per bank. |
 | `BRANCH_COND_COUNT` | `7` | `BEQ`, `BNE`, `BLT`, `BNZ`, `BZ`, `B`, `BR`. |
-| `LR_OP_COUNT` | `4` | `SET`, `ADD`, `SUB`, `INCR_MOD_POW2`. |
+| `LR_OP_COUNT` | `6` | `SET`, `ADD`, `SUB`, `INCR_MOD_POW2`, `INC`, `DEC`. |
 | `SET_IMM_BITS` | `5` | Combined `src5` operand: bit 4 selects mode; bits [3:0] are a CR index *or* a signed 4-bit immediate. |
 | `XMEM_ADDR_W` | *impl* | Width of `xmem_read_addr`. Sized to address the external XMEM address space (= log2 of XMEM word count). |
 | `APB_ADDR_W` | `32` | APB byte-address width on `apb_paddr`. |
@@ -190,7 +190,7 @@ XMEM read-address port, and the APB slave.
 - For each instruction in the MULT, ACC, AAQ, and STORE stages, **CTRL** resolves the CR/LR operand value(s) from the register files (by the indices carried in that stage's slot fields) and **forwards** them on the dispatch bus. The downstream stages **never** read the register files and CR/LR are **not visible** to them — the operand value(s) arrive already resolved. CTRL evaluates its three LR-ALU lanes before forwarding, so a downstream stage sees this cycle's **post-LR-write** value (it reflects any LR write this same VLIW performs).
 - **XMEM is not a pipeline stage** and is **read-only**. CTRL pre-resolves the XMEM address from CR + LR and forwards only the computed **read address** to XMEM (there is no XMEM opcode; every XMEM access is a memory load). XMEM accesses external memory and **writes the returned data directly into the MULT stage's input registers** (e.g. `R0`/`R1`/`R_CYCLIC`/`R_MASK`). It has no CR/LR read port and does not appear on the MULT → ACC → AAQ → STORE chain. Writes back to external memory are the responsibility of the STORE stage.
 - The **prior-cycle snapshot** (read-before-write) applies **only to CTRL's own register reads**: the three LR-ALU lane source operands and the branch/COND operands. These see the values committed at end of cycle N−1 — an LR write generated in cycle N is **not** visible to CTRL's own reads in cycle N (it becomes visible to them only starting cycle N+1). The CR/LR operand values CTRL **forwards** to MULT/ACC/AAQ/STORE/XMEM are **not** the snapshot: CTRL evaluates its LR-ALU lanes first, then forwards the resulting **post-write** values for this cycle. So a downstream stage sees this cycle's LR writes, while CTRL's own LR-ALU/branch reads do not.
-- `LR0`–`LR15` are **20-bit** local registers. They are written **only** by the LR-slot ops (`SET`, `ADD`, `SUB`, `INCR_MOD_POW2`). The RISC-V host cannot write LR.
+- `LR0`–`LR15` are **20-bit** local registers. They are written **only** by the LR-slot ops (`SET`, `ADD`, `SUB`, `INCR_MOD_POW2`, `INC`, `DEC`). The RISC-V host cannot write LR.
 - `CR0`–`CR15` are **20-bit** configuration registers, read-only to the program. The RISC-V host populates the inactive bank and triggers a swap externally; there is no ISA instruction for the swap.
 - **`CR0` is hard-wired to `0` (zero register)** and **`CR1` is hard-wired to `1` (one register)**. These two values are guaranteed by hardware and are the canonical operands for clearing or incrementing an LR via `ADD`/`SUB`.
 - `CR15` is reserved for the dstructure register (`valid_elements` and `partition`) and must not be used for application data. It is not a valid operand to any ISA instruction.
@@ -435,12 +435,12 @@ destination LR from two lanes in the same VLIW word (see §10).
 - **Operands:**
   - `dest` — destination, `LR0`–`LR15`.
   - `src_a` — first source, `LR0`–`LR15`.
-  - `src_b` — second source: `LR0`–`LR15`, `CR0`–`CR15`, or a 5-bit unsigned immediate `0`–`31`.
+  - `src_b` — second source: `LR0`–`LR15` or `CR0`–`CR14` (`LcrIdx`).
 - **Operation:**
   ```text
   dest = (src_a + src_b)[19:0]                 // 20-bit two's complement add (wrap on overflow)
   ```
-- **Examples:** `ADD LR0 LR1 LR2;;`, `ADD LR3 LR1 CR5;;`, `ADD LR4 LR1 7;;`.
+- **Examples:** `ADD LR0 LR1 LR2;;`, `ADD LR3 LR1 CR5;;`.
 
 #### 10.1.3 `SUB` — Subtract
 
@@ -451,7 +451,7 @@ destination LR from two lanes in the same VLIW word (see §10).
   ```text
   dest = (src_a - src_b)[19:0]                 // 20-bit two's complement subtract (wrap on underflow)
   ```
-- **Examples:** `SUB LR0 LR1 LR2;;`, `SUB LR3 LR1 CR5;;`, `SUB LR4 LR1 7;;`.
+- **Examples:** `SUB LR0 LR1 LR2;;`, `SUB LR3 LR1 CR5;;`.
 
 #### 10.1.4 `INCR_MOD_POW2` — Increment Local Register Modulo Power of Two
 
@@ -466,6 +466,30 @@ destination LR from two lanes in the same VLIW word (see §10).
   dst = (dst + step) & ((1 << k) - 1)          // mask to k low bits (mod 2^k)
   ```
 - **Example:** `INCR_MOD_POW2 LR2 LR3 4;;` — advance `LR2` by `LR3` and wrap modulo 16.
+
+#### 10.1.5 `INC` — Increment by Immediate
+
+- **Summary:** Add an unsigned immediate to the destination LR (read-modify-write).
+- **Syntax:** `INC dest imm`
+- **Operands:**
+  - `dest` — destination local register, `LR0`–`LR15` (also the implicit source).
+  - `imm` — unsigned immediate; range `0` to `2^W − 1` where `W` is derived from the LR slot union layout (5 bits in the current encoding).
+- **Operation:**
+  ```text
+  dest = (dest + imm)[19:0]
+  ```
+- **Example:** `INC LR0 7;;`
+
+#### 10.1.6 `DEC` — Decrement by Immediate
+
+- **Summary:** Subtract an unsigned immediate from the destination LR (read-modify-write).
+- **Syntax:** `DEC dest imm`
+- **Operands:** identical to `INC`.
+- **Operation:**
+  ```text
+  dest = (dest - imm)[19:0]
+  ```
+- **Example:** `DEC LR0 3;;`
 
 ### 10.2 COND Slot (one per VLIW word)
 
@@ -565,6 +589,8 @@ assembler.
 | LR   | `ADD`            | `dest src_a src_b`       | `dest = (src_a + src_b)[19:0]` |
 | LR   | `SUB`            | `dest src_a src_b`       | `dest = (src_a - src_b)[19:0]` |
 | LR   | `INCR_MOD_POW2`  | `dst step k`             | `dst = (dst + step) & ((1<<k) - 1)` |
+| LR   | `INC`            | `dest imm`               | `dest = (dest + imm)[19:0]` |
+| LR   | `DEC`            | `dest imm`               | `dest = (dest - imm)[19:0]` |
 | COND | `BEQ`            | `reg1 reg2 label`        | branch if `reg1 == reg2` |
 | COND | `BNE`            | `reg1 reg2 label`        | branch if `reg1 != reg2` |
 | COND | `BLT`            | `reg1 reg2 label`        | branch if `signed(reg1) < signed(reg2)` |

--- a/src/tools/ipu-as-py/src/ipu_as/gen_docs.py
+++ b/src/tools/ipu-as-py/src/ipu_as/gen_docs.py
@@ -30,13 +30,13 @@ OPERAND_TYPE_DETAILS: dict[str, str] = {
     "LcrIdx": (
         "LR **or** CR index in one field: lower indices map to **`lr0`–`lr15`**, higher indices to "
         "`**cr0`–`cr14`** in the usual combined ordering used by the assembler. `cr15` is reserved "
-        "and is not a valid operand."
+        "and is not a valid operand. Used as **`src_b`** on **`ADD`**/**`SUB`** and as **`step`** on "
+        "**`INCR_MOD_POW2`**."
     ),
-    "AddSubSrcB": (
-        "Second source for **`ADD`** / **`SUB`** in the LR slot: **`lr0`–`lr15`**, **`cr0`–`cr14`**, "
-        "or an **unsigned 5-bit immediate** (`0`–`31`). Encoded in **6 bits**: **`0`–`31`** use the "
-        "same ordering as **`LcrIdx`**; **`32`–`63`** encode immediates as **`32 + imm`**. `cr15` is "
-        "reserved and is not a valid operand."
+    "LrIncDecImmediate": (
+        "Unsigned immediate for **`INC`** / **`DEC`** in the LR slot. The bit width **W** is not "
+        "hardcoded — it is derived from the LR slot union layout so the total slot width stays "
+        "constant. Valid range: **`0`** to **`2^W − 1`**."
     ),
     "ElementsInRow": (
         "ACC-slot immediate: encoded **elements-per-row** selector (see `acc_stride_enums` in "
@@ -143,7 +143,7 @@ label:                          # Labels end with a colon
     LDR_MULT_REG r0 lr0 cr0;     # LOAD: load into mult stage r0
     MULT.EE r0 lr1 0 lr3;        # MULT: element-wise multiply
     ACC;                         # ACC: accumulate
-    ADD lr0 lr0 1;               # LR: bump address (increment via ADD)
+    INC lr0 1;               # LR: bump address (increment via INC)
     BNE lr0 lr1 next;            # COND: branch
     ;;
 ```
@@ -170,7 +170,7 @@ load_inst; mult_inst; acc_inst; aaq_inst; store_inst; acc_store_inst; lr_inst_a;
 **Example (parallel slots):**
 
 ```asm
-LDR_MULT_REG r0 lr0 cr0; MULT.EE r0 lr1 0 lr3; ACC; ADD lr0 lr0 1; BNE lr0 lr1 loop;;
+LDR_MULT_REG r0 lr0 cr0; MULT.EE r0 lr1 0 lr3; ACC; INC lr0 1; BNE lr0 lr1 loop;;
 ```
 
 ## Register names
@@ -194,7 +194,7 @@ The **`mem_bypass`** vector may still exist in the **emulator regfile** for debu
 start:
     SET lr0 cr0;;
 loop:
-    ADD lr0 lr0 1;;
+    INC lr0 1;;
     BNE lr0 lr1 loop;;
     BKPT;;
 ```

--- a/src/tools/ipu-as-py/src/ipu_as/immediate.py
+++ b/src/tools/ipu-as-py/src/ipu_as/immediate.py
@@ -6,6 +6,10 @@ from ipu_common.incr_mod_pow2_k import (
     LR_MOD_POW2_K_MAX,
     LR_MOD_POW2_K_MIN,
 )
+from ipu_common.lr_inc_dec_imm import (
+    LR_INC_DEC_IMM_FIELD_BITS,
+    lr_inc_dec_imm_max,
+)
 from ipu_common.mult_mask_offset import (
     MULT_MASK_OFFSET_FIELD_BITS,
     MULT_MASK_SLOT_COUNT,
@@ -106,56 +110,40 @@ class ActivationFnField(ipu_token.EnumToken):
         return list(ACTIVATION_FN_NAMES)
 
 
-# Encoding matches LcrIdx for register indices 0–31; values ≥32 encode IMM5 (payload in low 5 bits).
-_ADD_SUB_SRC_B_REGS: tuple[str, ...] = tuple(
-    [f"lr{i}" for i in range(16)] + [f"cr{i}" for i in range(16)]
-)
-_ADD_SUB_SRC_B_IMM_BASE = 32
+class LrIncDecImmediate(ipu_token.IpuToken):
+    """Unsigned immediate for ``INC`` / ``DEC`` in the LR slot.
 
-
-class AddSubSrcBField(ipu_token.IpuToken):
-    """Second source for ``add`` / ``sub``: lr0–lr15, cr0–cr15, or unsigned IMM5 (0–31).
-
-    Encoded in 6 bits: register indices use the same mapping as ``LcrIdx`` (0–31);
-    immediates use ``32 + imm``.
+    Bit width is derived from the LR slot union layout (see ``lr_inc_dec_imm``).
     """
 
     @classmethod
     def bits(cls) -> int:
-        return 6
+        return LR_INC_DEC_IMM_FIELD_BITS
 
     @classmethod
     def default(cls) -> "ipu_token.IpuToken":
-        return cls(ipu_token.AnnotatedToken(lark.Token("TOKEN", "lr0"), 0))
+        return cls(ipu_token.AnnotatedToken(lark.Token("NUMBER", "0"), 0))
 
     def __init__(self, token: ipu_token.AnnotatedToken):
         super().__init__(token)
-        raw = self.token.value.lower()
-        if raw == "cr15":
-            self._raise_error(
-                "CR15 is reserved for dstructure configuration and cannot be used as an ISA operand"
-            )
-        if raw in _ADD_SUB_SRC_B_REGS:
-            self._encoded = _ADD_SUB_SRC_B_REGS.index(raw)
-            return
         try:
-            imm = int(self.token.value, 0)
+            self.int = int(token.token.value, 0)
         except ValueError:
+            self._raise_error(f"Value {self.token.value} is not a valid integer")
+        imm_max = lr_inc_dec_imm_max()
+        if not (0 <= self.int <= imm_max):
             self._raise_error(
-                "Expected lr0–lr15, cr0–cr14, or an unsigned 5-bit immediate (0–31)"
+                f"Value {self.int} out of range [0, {imm_max}] "
+                "for INC/DEC immediate operand"
             )
-        if not (0 <= imm <= 31):
-            self._raise_error(f"Immediate operand must be in range [0, 31], got {imm}")
-        self._encoded = _ADD_SUB_SRC_B_IMM_BASE + imm
 
     def encode(self) -> int:
-        return self._encoded
+        return self.int
 
     @classmethod
     def decode(cls, value: int) -> str:
-        if value >= _ADD_SUB_SRC_B_IMM_BASE:
-            return str(value & 31)
-        return _ADD_SUB_SRC_B_REGS[value]
+        mask = (1 << LR_INC_DEC_IMM_FIELD_BITS) - 1
+        return str(value & mask)
 
 
 # ---------------------------------------------------------------------------

--- a/src/tools/ipu-as-py/src/ipu_as/inst.py
+++ b/src/tools/ipu-as-py/src/ipu_as/inst.py
@@ -35,7 +35,7 @@ OPERAND_TYPE_MAP: dict[str, type[ipu_token.IpuToken]] = {
     "LrIdx": reg.LrRegField,
     "CrIdx": reg.CrRegField,
     "LcrIdx": reg.LcrRegField,
-    "AddSubSrcB": immediate.AddSubSrcBField,
+    "LrIncDecImmediate": immediate.LrIncDecImmediate,
     "ElementsInRow": immediate.ElementsInRowField,
     "HorizontalStride": immediate.HorizontalStrideField,
     "VerticalStride": immediate.VerticalStrideField,
@@ -596,14 +596,10 @@ class LrInst(Inst):
         return LrInst(
             {
                 "opcode": ipu_token.AnnotatedToken(
-                    token=lark.Token("TOKEN", "ADD", line=0, column=0),
+                    token=lark.Token("TOKEN", "INC", line=0, column=0),
                     instr_id=addr,
                 ),
                 "operands": [
-                    ipu_token.AnnotatedToken(
-                        token=lark.Token("TOKEN", "lr0", line=0, column=0),
-                        instr_id=addr,
-                    ),
                     ipu_token.AnnotatedToken(
                         token=lark.Token("TOKEN", "lr0", line=0, column=0),
                         instr_id=addr,

--- a/src/tools/ipu-common/src/ipu_common/instruction_spec.py
+++ b/src/tools/ipu-common/src/ipu_common/instruction_spec.py
@@ -26,7 +26,7 @@ OPERAND TYPE NAMES (resolved by ipu_as into actual token classes):
   - "LrIdx": LR0–LR15 (LrRegField)  
   - "CrIdx": CR0–CR14 (CrRegField)
   - "LcrIdx": LR0–LR15 or CR0–CR14 (LcrRegField)
-  - "AddSubSrcB": second operand for ADD/SUB — LR, CR, or unsigned IMM5 (AddSubSrcBField; 6-bit encoding)
+  - "LrIncDecImmediate": unsigned immediate for INC/DEC; bit width derived from LR slot union layout
   - "LrModPow2KImmediate": k operand for INCR_MOD_POW2 (semantic k ∈ [1, 9]; encoded as k−1 in 4 bits)
   - "MultMaskOffsetImmediate": mask slot index for mult masking (0–7; eight 128-bit slots in R_MASK)
   - "ActivationFn": keyword on `ACTIVATE` (see ``ACTIVATION_FN_NAMES`` in ``activations.py``)
@@ -332,7 +332,7 @@ INSTRUCTION_SPEC = {
     
     # =========================================================================
     # LR Slot (Loop Register Instructions)
-    # Opcode = position: SET=0, ADD=1, SUB=2, INCR_MOD_POW2=3
+    # Opcode = position: SET=0, ADD=1, SUB=2, INCR_MOD_POW2=3, INC=4, DEC=5
     # =========================================================================
     "lr": {
         "SET": {
@@ -357,22 +357,21 @@ INSTRUCTION_SPEC = {
             "operands": [
                 {"name": "dest", "type": "LrIdx"},
                 {"name": "src_a", "type": "LrIdx", "read": "snapshot"},
-                {"name": "src_b", "type": "AddSubSrcB", "read": "snapshot"},
+                {"name": "src_b", "type": "LcrIdx", "read": "snapshot"},
             ],
             "doc": InstructionDoc(
                 title="Add",
                 summary=(
-                    "Add two sources (second source may be an LR, CR, or 5-bit unsigned immediate) "
-                    "and store the result in the destination LR."
+                    "Add two register sources and store the result in the destination LR."
                 ),
                 syntax="ADD dest, src_a, src_b",
                 operands=[
                     "dest: Destination local register (LR0–LR15)",
                     "src_a: First source local register (LR0–LR15)",
-                    "src_b: Second source — LR0–LR15, CR0–CR14, or unsigned immediate 0–31",
+                    "src_b: Second source — LR0–LR15 or CR0–CR14",
                 ],
                 operation="dest = src_a + src_b",
-                example="ADD LR0, LR1, LR2;;\nADD LR3, LR1, CR5;;\nADD LR4, LR1, 7;;",
+                example="ADD LR0, LR1, LR2;;\nADD LR3, LR1, CR5;;",
             ),
             "execute_fn": "execute_lr_add",
         },
@@ -380,22 +379,22 @@ INSTRUCTION_SPEC = {
             "operands": [
                 {"name": "dest", "type": "LrIdx"},
                 {"name": "src_a", "type": "LrIdx", "read": "snapshot"},
-                {"name": "src_b", "type": "AddSubSrcB", "read": "snapshot"},
+                {"name": "src_b", "type": "LcrIdx", "read": "snapshot"},
             ],
             "doc": InstructionDoc(
                 title="Subtract",
                 summary=(
-                    "Subtract the second source from the first (second source may be an LR, CR, "
-                    "or 5-bit unsigned immediate) and store the result in the destination LR."
+                    "Subtract the second source from the first and store the result "
+                    "in the destination LR."
                 ),
                 syntax="SUB dest, src_a, src_b",
                 operands=[
                     "dest: Destination local register (LR0–LR15)",
                     "src_a: First source local register (LR0–LR15)",
-                    "src_b: Second source — LR0–LR15, CR0–CR14, or unsigned immediate 0–31",
+                    "src_b: Second source — LR0–LR15 or CR0–CR14",
                 ],
                 operation="dest = src_a - src_b",
-                example="SUB LR0, LR1, LR2;;\nSUB LR3, LR1, CR5;;\nSUB LR4, LR1, 7;;",
+                example="SUB LR0, LR1, LR2;;\nSUB LR3, LR1, CR5;;",
             ),
             "execute_fn": "execute_lr_sub",
         },
@@ -421,6 +420,46 @@ INSTRUCTION_SPEC = {
                 example="INCR_MOD_POW2 LR2, LR3, 4;;",
             ),
             "execute_fn": "execute_lr_incr_mod_pow2",
+        },
+        "INC": {
+            "operands": [
+                {"name": "dest", "type": "LrIdx"},
+                {"name": "imm", "type": "LrIncDecImmediate"},
+            ],
+            "doc": InstructionDoc(
+                title="Increment",
+                summary=(
+                    "Add an unsigned immediate to the destination LR (read-modify-write)."
+                ),
+                syntax="INC dest, imm",
+                operands=[
+                    "dest: Destination local register (LR0–LR15); also the implicit source",
+                    "imm: Unsigned immediate; range 0 to 2^W − 1 where W is derived from the LR slot union layout",
+                ],
+                operation="dest = dest + imm",
+                example="INC LR0, 7;;",
+            ),
+            "execute_fn": "execute_lr_inc",
+        },
+        "DEC": {
+            "operands": [
+                {"name": "dest", "type": "LrIdx"},
+                {"name": "imm", "type": "LrIncDecImmediate"},
+            ],
+            "doc": InstructionDoc(
+                title="Decrement",
+                summary=(
+                    "Subtract an unsigned immediate from the destination LR (read-modify-write)."
+                ),
+                syntax="DEC dest, imm",
+                operands=[
+                    "dest: Destination local register (LR0–LR15); also the implicit source",
+                    "imm: Unsigned immediate; range 0 to 2^W − 1 where W is derived from the LR slot union layout",
+                ],
+                operation="dest = dest - imm",
+                example="DEC LR0, 3;;",
+            ),
+            "execute_fn": "execute_lr_dec",
         },
     },
     
@@ -1068,7 +1107,7 @@ def extract_opcodes() -> Dict[str, List[str]]:
     Example:
         {
             "load": ["LDR_MULT_REG", "LDR_CYCLIC_MULT_REG", ...],
-            "lr": ["SET", "ADD", "SUB", "INCR_MOD_POW2"],
+            "lr": ["SET", "ADD", "SUB", "INCR_MOD_POW2", "INC", "DEC"],
             ...
         }
     """
@@ -1241,11 +1280,11 @@ VALID_OPERAND_TYPES: frozenset[str] = frozenset(
         "HorizontalStride",
         "VerticalStride",
         "LrModPow2KImmediate",
+        "LrIncDecImmediate",
         "MultMaskOffsetImmediate",
         "ActivationFn",
         "BreakImmediate",
         "Label",
-        "AddSubSrcB",
         "FullXmemRow",
     }
 )

--- a/src/tools/ipu-common/src/ipu_common/lr_inc_dec_imm.py
+++ b/src/tools/ipu-common/src/ipu_common/lr_inc_dec_imm.py
@@ -1,0 +1,20 @@
+"""INC/DEC immediate operand — bit width derived from the LR slot union layout.
+
+The field width is not hardcoded here.  After ``compute_slot_layouts`` runs, the
+union solver writes ``LR_INC_DEC_IMM_FIELD_BITS`` from the shared union field
+that carries the ``LrIncDecImmediate`` operand (same bin as ``LcrIdx`` for
+``ADD``/``SUB`` ``src_b`` and ``INCR_MOD_POW2`` ``step``).
+
+Valid immediates are unsigned: ``0`` .. ``(1 << LR_INC_DEC_IMM_FIELD_BITS) - 1``.
+"""
+
+LR_INC_DEC_IMM_FIELD_BITS: int = 0
+
+
+def lr_inc_dec_imm_max() -> int:
+    """Return the maximum unsigned immediate value (inclusive)."""
+    if LR_INC_DEC_IMM_FIELD_BITS <= 0:
+        raise RuntimeError(
+            "LR_INC_DEC_IMM_FIELD_BITS is unset; union layout must be computed first"
+        )
+    return (1 << LR_INC_DEC_IMM_FIELD_BITS) - 1

--- a/src/tools/ipu-common/src/ipu_common/union_layout.py
+++ b/src/tools/ipu-common/src/ipu_common/union_layout.py
@@ -31,7 +31,17 @@ from ipu_common.acc_stride_enums import (
 from ipu_common.activations import ACTIVATION_FN_NAMES
 from ipu_common.incr_mod_pow2_k import LR_MOD_POW2_K_FIELD_BITS
 from ipu_common.mult_mask_offset import MULT_MASK_OFFSET_FIELD_BITS
+from ipu_common import lr_inc_dec_imm
 from ipu_common.registers import REGISTER_DEFINITIONS
+
+# Operand types whose bit-width is determined by union packing, not a fixed constant.
+_DERIVED_OPERAND_TYPES: frozenset[str] = frozenset({"LrIncDecImmediate"})
+
+# Per-slot target widths (bits).  Padding is applied after union packing when the
+# solver's natural width is narrower — keeps encoded LR sub-instructions stable.
+_SLOT_TARGET_BITS: dict[str, int] = {
+    "lr": 17,
+}
 
 
 def _enum_bits(names: tuple) -> int:
@@ -48,7 +58,9 @@ def get_operand_type_bits() -> dict[str, int]:
         "LrIdx": (lr_count - 1).bit_length(),
         "CrIdx": (cr_count - 1).bit_length(),
         "LcrIdx": (lr_count + cr_count - 1).bit_length(),
-        "AddSubSrcB": 6,  # 6-bit: 0-31 register codes, 32-63 IMM5
+        # Width 0 at layout time — the shared union field width is set in
+        # finalize_derived_operand_bits() after packing.
+        "LrIncDecImmediate": 0,
         "LrModPow2KImmediate": LR_MOD_POW2_K_FIELD_BITS,
         "MultMaskOffsetImmediate": MULT_MASK_OFFSET_FIELD_BITS,
         "BreakImmediate": 16,
@@ -212,10 +224,51 @@ def compute_slot_layout(
     )
 
 
+def _pad_slot_to_target(su: SlotUnion) -> None:
+    """Grow union fields when packing is narrower than the hardware slot width."""
+    target = _SLOT_TARGET_BITS.get(su.slot)
+    if target is None:
+        return
+    total = su.opcode_bits + sum(f.bits for f in su.fields)
+    deficit = target - total
+    if deficit <= 0:
+        return
+    # Prefer padding the field that carries LrModPow2K (k); the extra bit is unused.
+    for field in su.fields:
+        if any(
+            actual_type == "LrModPow2KImmediate"
+            for _opcode, (_operand_name, actual_type) in field.users.items()
+        ):
+            field.bits += deficit
+            return
+    raise ValueError(
+        f"Cannot pad {su.slot} slot to {target} bits (currently {total})"
+    )
+
+
+def finalize_derived_operand_bits(slot_unions: dict[str, SlotUnion]) -> None:
+    """Populate module-level constants for operand types with derived bit-widths."""
+    su = slot_unions.get("lr")
+    if su is None:
+        return
+    for field in su.fields:
+        for _opcode, (_operand_name, actual_type) in field.users.items():
+            if actual_type == "LrIncDecImmediate":
+                lr_inc_dec_imm.LR_INC_DEC_IMM_FIELD_BITS = field.bits
+                return
+    raise ValueError(
+        "LrIncDecImmediate not found in LR slot union layout"
+    )
+
+
 def compute_slot_layouts(instruction_spec: dict) -> dict[str, SlotUnion]:
     """Compute union layouts for all slots in *instruction_spec*."""
     type_bits = get_operand_type_bits()
-    return {
+    slot_unions = {
         slot: compute_slot_layout(slot, instructions, type_bits)
         for slot, instructions in instruction_spec.items()
     }
+    for su in slot_unions.values():
+        _pad_slot_to_target(su)
+    finalize_derived_operand_bits(slot_unions)
+    return slot_unions

--- a/src/tools/ipu-common/test/test_union_layout.py
+++ b/src/tools/ipu-common/test/test_union_layout.py
@@ -76,6 +76,25 @@ def test_lr_slot_sharing():
     )
 
 
+def test_lr_slot_opcode_bits():
+    """Six LR opcodes require a 3-bit opcode field."""
+    assert SLOT_UNIONS["lr"].opcode_bits == 3
+
+
+def test_lr_slot_total_width_unchanged():
+    """LR sub-instruction stays 17 bits after INC/DEC and opcode growth."""
+    su = SLOT_UNIONS["lr"]
+    total = su.opcode_bits + sum(f.bits for f in su.fields)
+    assert total == 17, f"Expected 17-bit LR slot, got {total}"
+
+
+def test_lr_inc_dec_imm_width_derived():
+    """INC/DEC immediate width is derived from the union layout (5 bits)."""
+    from ipu_common.lr_inc_dec_imm import LR_INC_DEC_IMM_FIELD_BITS
+
+    assert LR_INC_DEC_IMM_FIELD_BITS == 5
+
+
 def test_all_slots_present():
     """All expected slots are computed."""
     expected = {"load", "store", "acc_store", "lr", "mult", "acc", "aaq", "cond", "break"}

--- a/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
@@ -79,7 +79,7 @@ _TYPE_FIELD_SUFFIX = {
     "LrIdx": "lr_reg_field",
     "CrIdx": "cr_reg_field",
     "LcrIdx": "lcr_reg_field",
-    "AddSubSrcB": "add_sub_src_b_field",
+    "LrIncDecImmediate": "lr_inc_dec_immediate",
     "ElementsInRow": "elements_in_row_field",
     "HorizontalStride": "horizontal_stride_field",
     "VerticalStride": "vertical_stride_field",
@@ -278,7 +278,6 @@ class Ipu:
         - LrIdx → source.get_lr(idx) → uint32 value
         - CrIdx → source.get_cr(idx) → uint32 value
         - LcrIdx → LR if idx < LR_REG_COUNT, else CR → uint32 value
-        - AddSubSrcB → like LcrIdx for codes 0–31; codes ≥ 32 → unsigned IMM5 (low 5 bits)
         - MultStageReg → register bytes via _MULT_STAGE_MAP → bytearray
 
         Args:
@@ -295,13 +294,6 @@ class Ipu:
                 return source.get_lr(raw_value)
             else:
                 return source.get_cr(raw_value - LR_REG_COUNT)
-        elif op_type == "AddSubSrcB":
-            # 6-bit encoding: 0–31 same as LcrIdx; 32–63 → unsigned IMM5 (low 5 bits).
-            if raw_value >= 32:
-                return raw_value & 31
-            if raw_value < LR_REG_COUNT:
-                return source.get_lr(raw_value)
-            return source.get_cr(raw_value - LR_REG_COUNT)
         elif op_type == "MultStageReg":
             if raw_value > 1:
                 raise EmulatorError(
@@ -492,12 +484,24 @@ class Ipu:
         self.state.regfile.set_lr(reg, src & 0xFFFFFFFF)
 
     def execute_lr_add(self, *, dest: int, src_a: int, src_b: int) -> None:
-        """Execute ADD: uint32 ``dest = src_a + src_b`` (``src_b`` may be an immediate)."""
+        """Execute ADD: uint32 ``dest = src_a + src_b``."""
         self.state.regfile.set_lr(dest, (src_a + src_b) & 0xFFFFFFFF)
 
     def execute_lr_sub(self, *, dest: int, src_a: int, src_b: int) -> None:
-        """Execute SUB: uint32 ``dest = src_a - src_b`` (``src_b`` may be an immediate)."""
+        """Execute SUB: uint32 ``dest = src_a - src_b``."""
         self.state.regfile.set_lr(dest, (src_a - src_b) & 0xFFFFFFFF)
+
+    def execute_lr_inc(self, *, dest: int, imm: int) -> None:
+        """Execute INC: uint32 ``dest = dest + imm`` (read-modify-write)."""
+        assert self.snapshot is not None
+        cur = self.snapshot.get_lr(dest)
+        self.state.regfile.set_lr(dest, (cur + imm) & 0xFFFFFFFF)
+
+    def execute_lr_dec(self, *, dest: int, imm: int) -> None:
+        """Execute DEC: uint32 ``dest = dest - imm`` (read-modify-write)."""
+        assert self.snapshot is not None
+        cur = self.snapshot.get_lr(dest)
+        self.state.regfile.set_lr(dest, (cur - imm) & 0xFFFFFFFF)
 
     def execute_lr_incr_mod_pow2(self, *, dest: int, step: int, k: int) -> None:
         """INCR_MOD_POW2: dest <- (dest + step) mod 2^k.
@@ -535,16 +539,9 @@ class Ipu:
             field_map = _INSTRUCTION_FIELD_MAP[("lr", inst_name, slot_idx)]
             kwargs = {name: inst[field_key] for name, field_key in field_map.items()}
 
-            # Unfilled LR slots encode ``ADD lrX lrX 0`` (IMM5 0 → encoding 32): identity, no write.
-            if inst_name == "ADD":
-                sb = kwargs.get("src_b")
-                if (
-                    kwargs.get("dest") == kwargs.get("src_a")
-                    and isinstance(sb, int)
-                    and sb >= 32
-                    and (sb & 31) == 0
-                ):
-                    continue
+            # Unfilled LR slots encode ``INC lrX 0``: identity, no write.
+            if inst_name in ("INC", "DEC") and kwargs.get("imm") == 0:
+                continue
 
             # Auto-resolve 'read' operands to register values.
             read_types = _INSTRUCTION_READ_TYPES.get(("lr", inst_name), {})

--- a/src/tools/ipu-emu-py/test/test_execute.py
+++ b/src/tools/ipu-emu-py/test/test_execute.py
@@ -86,8 +86,8 @@ class TestRegisterOperations:
     def test_add_imm_accumulates_lr(self):
         state = _run("""\
 SET lr11 cr8;;
-ADD lr11 lr11 5;;
-ADD lr11 lr11 3;;
+INC lr11 5;;
+INC lr11 3;;
 BKPT;;
 """,
             cr={8: 10})
@@ -130,10 +130,11 @@ BKPT;;
     def test_add_lr_lr_imm5(self):
         state = _run("""\
 SET lr1 cr8;;
-ADD lr4 lr1 11;;
+SET lr2 cr9;;
+ADD lr4 lr1 lr2;;
 BKPT;;
 """,
-            cr={8: 200})
+            cr={8: 200, 9: 11})
         assert state.regfile.get_lr(4) == 211
 
     def test_sub_lr_lr(self):
@@ -160,10 +161,11 @@ BKPT;;
     def test_sub_lr_lr_imm5(self):
         state = _run("""\
 SET lr2 cr8;;
-SUB lr3 lr2 30;;
+SET lr4 cr9;;
+SUB lr3 lr2 lr4;;
 BKPT;;
 """,
-            cr={8: 100})
+            cr={8: 100, 9: 30})
         assert state.regfile.get_lr(3) == 70
 
 
@@ -254,6 +256,46 @@ BKPT;;
         assert state.regfile.get_lr(6) == 128
 
 
+class TestIncDec:
+    def test_inc_dest(self):
+        state = _run("""\
+SET lr5 cr8;;
+INC lr5 7;;
+BKPT;;
+""",
+            cr={8: 100})
+        assert state.regfile.get_lr(5) == 107
+
+    def test_dec_dest(self):
+        state = _run("""\
+SET lr5 cr8;;
+DEC lr5 30;;
+BKPT;;
+""",
+            cr={8: 100})
+        assert state.regfile.get_lr(5) == 70
+
+    def test_inc_dec_same_cycle(self):
+        state = _run("""\
+SET lr0 cr8;;
+SET lr1 cr9;;
+INC lr0 5;;
+DEC lr1 2;;
+BKPT;;
+""",
+            cr={8: 10, 9: 20})
+        assert state.regfile.get_lr(0) == 15
+        assert state.regfile.get_lr(1) == 18
+
+    def test_decode_inc_imm_operand_field(self):
+        """``INC`` immediate uses the union-derived LrIncDecImmediate field."""
+        encoded = assemble("INC lr2 7;; BKPT;;")
+        d = decode_instruction_word(encoded[0])
+        assert d["lr_inst_0_token_0_lr_inst_opcode"] == 4  # inc
+        assert d["lr_inst_0_token_2_lr_reg_field"] == 2
+        assert d["lr_inst_0_token_1_lcr_reg_field"] == 7  # imm in shared lcr field
+
+
 # ============================================================================
 # Three LR sub-slots per VLIW (SLOT_COUNT["lr"] == 3)
 # ============================================================================
@@ -288,23 +330,23 @@ BKPT;;
         d = decode_instruction_word(encoded[0])
         assert d["lr_inst_0_token_0_lr_inst_opcode"] == 0  # set
         assert d["lr_inst_0_token_2_lr_reg_field"] == 4   # reg = lr4
-        assert d["lr_inst_0_token_1_add_sub_src_b_field"] == 8  # src = cr8
+        assert d["lr_inst_0_token_1_lcr_reg_field"] == 8  # src = cr8
         assert d["lr_inst_0_token_3_lr_reg_field"] == 0   # unused field (default lr0)
         assert d["lr_inst_1_token_2_lr_reg_field"] == 5   # reg = lr5
-        assert d["lr_inst_1_token_1_add_sub_src_b_field"] == 9   # src = cr9
+        assert d["lr_inst_1_token_1_lcr_reg_field"] == 9   # src = cr9
         assert d["lr_inst_1_token_3_lr_reg_field"] == 0   # unused field (default lr0)
         assert d["lr_inst_2_token_2_lr_reg_field"] == 6   # reg = lr6
-        assert d["lr_inst_2_token_1_add_sub_src_b_field"] == 10  # src = cr10
+        assert d["lr_inst_2_token_1_lcr_reg_field"] == 10  # src = cr10
         assert d["lr_inst_2_token_3_lr_reg_field"] == 0   # unused field (default lr0)
 
-    def test_decode_add_imm_operand_field(self):
-        """``add`` third operand uses AddSubSrcBField; IMM5 encodes as 32 + value."""
-        encoded = assemble("ADD lr2 lr1 7;; BKPT;;")
+    def test_decode_add_lcr_operand_field(self):
+        """``ADD`` third operand uses LcrRegField (register-only)."""
+        encoded = assemble("ADD lr2 lr1 cr7;; BKPT;;")
         d = decode_instruction_word(encoded[0])
         assert d["lr_inst_0_token_0_lr_inst_opcode"] == 1  # add
         assert d["lr_inst_0_token_2_lr_reg_field"] == 2   # dest = lr2
         assert d["lr_inst_0_token_3_lr_reg_field"] == 1   # src_a = lr1
-        assert d["lr_inst_0_token_1_add_sub_src_b_field"] == 32 + 7  # src_b = IMM5(7)
+        assert d["lr_inst_0_token_1_lcr_reg_field"] == 16 + 7  # src_b = cr7
 
 
 # ============================================================================
@@ -658,7 +700,7 @@ BKPT;;
         state = _make_state("""\
 SET lr0 cr8;;
 cr_loop_start:
-ADD lr0 lr0 1;;
+INC lr0 1;;
 BNE lr0 cr5 cr_loop_start;;
 BKPT;;
 """,
@@ -673,7 +715,7 @@ SET lr0 cr8;;
 SET lr1 cr9;;
 SET lr2 cr8;;
 loop_start:
-ADD lr0 lr0 1;;
+INC lr0 1;;
 BNE lr0 lr1 loop_start;;
 BKPT;;
 """,
@@ -1184,7 +1226,7 @@ class TestDecodeRoundtrip:
         # LR opcode should be 'set' = index 0
         assert d["lr_inst_0_token_0_lr_inst_opcode"] == 0  # set
         assert d["lr_inst_0_token_2_lr_reg_field"] == 13  # reg = lr13
-        assert d["lr_inst_0_token_1_add_sub_src_b_field"] == 8  # src = cr8
+        assert d["lr_inst_0_token_1_lcr_reg_field"] == 8  # src = cr8
 
 
 # ============================================================================

--- a/src/tools/ipu-emu-py/test/test_stats.py
+++ b/src/tools/ipu-emu-py/test/test_stats.py
@@ -167,8 +167,8 @@ BKPT;;
         # Three pure-LR instructions: no mult/acc/xmem
         asm = """\
 SET lr0 cr0;;
-ADD lr1 lr0 1;;
-ADD lr2 lr1 1;;
+ADD lr1 lr0 cr1;;
+ADD lr2 lr1 cr1;;
 BKPT;;
 """
         state = _run(asm)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements [#132](https://github.com/rechefe/ipu-emulator/issues/132): extend the LR slot with `INC`/`DEC`, remove the hybrid `AddSubSrcB` operand, and wire the union layout so the LR sub-instruction stays **17 bits** wide.

## Changes

### ISA / spec (`instruction_spec.py`)
- **Deleted** `AddSubSrcB` operand type
- **Changed** `ADD` / `SUB` `src_b` → `LcrIdx` (register-only: LR0–LR15, CR0–CR14)
- **Added** `INC dest, imm` and `DEC dest, imm` (read-modify-write on `dest`)
- LR opcode field grows **2 → 3 bits** (6 opcodes: SET, ADD, SUB, INCR_MOD_POW2, INC, DEC)

### Union layout (first real use of cross-opcode field sharing)
- New `LrIncDecImmediate` operand type with **derived** bit width from union packing
- INC/DEC `imm` shares the **5-bit** union field with `LcrIdx` (`ADD`/`SUB` `src_b`, `INCR_MOD_POW2` `step`)
- `LR_INC_DEC_IMM_FIELD_BITS` is set automatically after layout (currently **5** → range 0–31)
- LR slot padded to **17 bits** total (3-bit opcode + 5 + 4 + 5 fields) to match pre-change width

### Emulator (`ipu.py`)
- `execute_lr_inc` / `execute_lr_dec` handlers
- Removed `AddSubSrcB` operand resolution
- LR NOP encoding: `INC lr0 0` (identity, skipped at dispatch)

### Assembler
- Removed `AddSubSrcBField`; added `LrIncDecImmediate`
- `LrInst.nop_inst()` uses `INC lr0 0`

### Docs / tests
- Updated `SKILL.md`, `stage-control.md`, generated operand/instruction docs
- New INC/DEC emulator tests; union layout tests for 3-bit opcode, 17-bit width, derived imm width
- Migrated tests that used `ADD lrX lrX <imm>` to `INC` or register-only `ADD`

## Verification

```
bazel test //...   # 286 tests, all pass
bazel build //docs:build_docs   # site.tar built for review
```

## Union layout (LR slot)

| Field | Width | Canonical type | Used by |
|-------|-------|----------------|---------|
| opcode | 3 | — | all |
| field 0 | 5 | LcrIdx | SET `src`, ADD/SUB `src_b`, INCR `step`, INC/DEC `imm` |
| field 1 | 4 | LrIdx | dest/reg |
| field 2 | 5 | LrIdx | ADD/SUB `src_a`, INCR `k` (+1 pad bit) |

**Total: 17 bits** (unchanged from before this change)

Closes #132
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-683495de-8f4a-4293-85c7-4bf0842f0528"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-683495de-8f4a-4293-85c7-4bf0842f0528"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

