### PR TITLE
remove MULT.VE.PADDED and RESET_ACC instructions

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -94,8 +94,8 @@ LDR_MULT_REG R0, LR0, CR0; MULT.EE R0, LR1, 0, LR3; ACC; ADD LR0, LR0, 1; BNE LR
 | LOAD | `LDR_MULT_REG`, `LDR_CYCLIC_MULT_REG`, `LDR_MULT_MASK_REG` | First-stage memory loads (feeds multiply) |
 | STORE | `STR_POST_AAQ_REG` | Last-stage memory store (drains `POST_AAQ_REG`) |
 | ACC_STORE | `STR_ACC_REG` | **Simulation-only** — store `R_ACC` to external memory |
-| MULT | `MULT.EE`, `MULT.VE.CYCLIC`, `MULT.VE.PADDED`, `MULT.VE.CR`, `MULT.EE.RR` | 8-bit vector multiply |
-| ACC | `ACC`, `ACC.FIRST`, `ACC.STRIDE`, `RESET_ACC`, `AGG.SUM`, `AGG.SUM.FIRST`, `AGG.MAX`, `AGG.MAX.FIRST` | Accumulate into `R_ACC`; in-place aggregation (sum/max) writing a single slot of `R_ACC` |
+| MULT | `MULT.EE`, `MULT.VE.CYCLIC`, `MULT.VE.CR`, `MULT.EE.RR` | 8-bit vector multiply |
+| ACC | `ACC`, `ACC.FIRST`, `ACC.STRIDE`, `AGG.SUM`, `AGG.SUM.FIRST`, `AGG.MAX`, `AGG.MAX.FIRST` | Accumulate into `R_ACC`; in-place aggregation (sum/max) writing a single slot of `R_ACC` |
 | AAQ | `AAQ`, `ACTIVATE` | **`ACTIVATE`** reads **`R_ACC`** and writes activated **32b** lanes into **`POST_AAQ_REG`** (512 B staging). **`AAQ`** (INT8) quantizes wide lanes in **`POST_AAQ_REG`** into the leading **128 B**; **`STR_POST_AAQ_REG`** stores the full **512 B** register to XMEM. See `docs/content/building-applications.md#activations-emulator`. |
 | LR (×3) | `SET`, `ADD`, `SUB`, `INCR_MOD_POW2` | Scalar loop register ops (`SET` copies from a **`CR`** register) |
 | COND | `BEQ`, `BNE`, `BLT`, `BNZ`, `BZ`, `B`, `BR`, `BKPT` | Branches |

--- a/docs/content/building-applications.md
+++ b/docs/content/building-applications.md
@@ -417,8 +417,6 @@ The IPU assembly implements the core computation: activations for the current sa
     SET                 lr2 cr8 ;;
 
 input_loop:
-    RESET_ACC;;
-
     LDR_MULT_REG        r0 lr0 cr0;;
 
     SET                 lr4 cr9 ;;
@@ -426,6 +424,12 @@ input_loop:
     SET                 lr6 cr11 ;;
     SET                 lr15 cr12 ;;
 
+    LDR_CYCLIC_MULT_REG lr4 cr1 lr15;
+    ADD                 lr4 lr4 cr3;
+    ADD                 lr5 lr5 cr4;
+    MULT.VE.CYCLIC      lr15 0 lr15 lr5;
+    ACC.FIRST;
+    BEQ                 lr5 lr6 done_acc;;
 
 element_loop:
     LDR_CYCLIC_MULT_REG lr4 cr1 lr15;
@@ -433,8 +437,9 @@ element_loop:
     ADD                 lr5 lr5 cr4;
     MULT.VE.CYCLIC      lr15 0 lr15 lr5;
     ACC;
-    BLT                 lr5 lr6 element_loop;;
+    BNE                 lr5 lr6 element_loop;;
 
+done_acc:
     STR_ACC_REG         lr7 cr2;;
     ADD                 lr7 lr7 cr5;
     ADD                 lr0 lr0 cr3;;

--- a/docs/content/debugging.md
+++ b/docs/content/debugging.md
@@ -11,7 +11,6 @@ Add `BREAK` instructions where you want execution to pause:
 ```asm
 main_loop:
     BREAK ;;              # Unconditional break
-    RESET_ACC;;
     LDR_CYCLIC_MULT_REG lr0 cr0 lr15;;
 ```
 
@@ -230,7 +229,7 @@ IPU Debug - Break at PC=3
   ...
 
 === Current Instruction ===
-  BREAK.IFEQ lr0 0; RESET_ACC; MULT_NOP; ACC_NOP; B lr0 lr0 @4;;
+  BREAK.IFEQ lr0 0; ACC_NOP; MULT_NOP; ACC_NOP; B lr0 lr0 @4;;
 
 debug >>> get lr1
 lr1 = 1280 (0x500)

--- a/src/tools/ipu-apps/src/ipu_apps/fully_connected/fully_connected.asm
+++ b/src/tools/ipu-apps/src/ipu_apps/fully_connected/fully_connected.asm
@@ -3,8 +3,6 @@
     SET                 lr2 cr8 ;;
 
 input_loop:
-    RESET_ACC;;
-
     LDR_MULT_REG        r0 lr0 cr0;;
 
     SET                 lr4 cr9 ;;
@@ -12,6 +10,12 @@ input_loop:
     SET                 lr6 cr11 ;;
     SET                 lr15 cr12 ;;
 
+    LDR_CYCLIC_MULT_REG lr4 cr13 lr15;
+    ADD                 lr4 lr4 cr3;
+    ADD                 lr5 lr5 cr4;
+    MULT.VE.CYCLIC      lr15 0 lr15 lr5;
+    ACC.FIRST;
+    BEQ                 lr5 lr6 done_acc;;
 
 element_loop:
     LDR_CYCLIC_MULT_REG lr4 cr13 lr15;
@@ -21,6 +25,7 @@ element_loop:
     ACC;
     BNE                 lr5 lr6 element_loop;;
 
+done_acc:
     STR_ACC_REG         lr7 cr2;;
     ADD                 lr7 lr7 cr5;
     ADD                 lr0 lr0 cr3;;

--- a/src/tools/ipu-as-py/src/ipu_as/gen_docs.py
+++ b/src/tools/ipu-as-py/src/ipu_as/gen_docs.py
@@ -210,7 +210,7 @@ Relative labels such as `B +5` / `B -2` are supported where the grammar accepts 
     masking_section = """
 ## Masking
 
-Multiply instructions (`MULT.EE`, `MULT.EE.RR`, `MULT.VE.CYCLIC`, `MULT.VE.PADDED`, `MULT.VE.CR`) support **lane masking**: after the multiply, lanes in `MULT_RES` whose
+Multiply instructions (`MULT.EE`, `MULT.EE.RR`, `MULT.VE.CYCLIC`, `MULT.VE.CR`) support **lane masking**: after the multiply, lanes in `MULT_RES` whose
 corresponding mask bit is **1** are **active** and pass through to accumulation; lanes whose bit is
 **0** are **zeroed** (deactivated). A mask of all-ones leaves every lane active (the reset default);
 a mask of all-zeros deactivates every lane.

--- a/src/tools/ipu-common/src/ipu_common/instruction_spec.py
+++ b/src/tools/ipu-common/src/ipu_common/instruction_spec.py
@@ -426,8 +426,7 @@ INSTRUCTION_SPEC = {
     
     # =========================================================================
     # MULT Slot (Multiply Instructions)
-    # Opcode = position: MULT.EE=0, MULT.VE.CYCLIC=1, MULT.VE.PADDED=2, MULT_NOP=3,
-    #          MULT.VE.CR=4, MULT.EE.RR=5
+    # Opcode = position: MULT.EE=0, MULT.VE.CYCLIC=1, MULT_NOP=2, MULT.VE.CR=3, MULT.EE.RR=4
     # =========================================================================
     "mult": {
         "MULT.EE": {
@@ -479,32 +478,6 @@ INSTRUCTION_SPEC = {
                 notes="Lane masking via `mask_offset` and `mask_shift` zeroes lanes whose derived mask bit is **0** (deactivated) in `MULT_RES` before accumulation; lanes with bit **1** pass through. See [Masking](assembly-syntax.md#masking) for the full algorithm.",
             ),
             "execute_fn": "execute_mult_ve_cyclic",
-        },
-        "MULT.VE.PADDED": {
-            "operands": [
-                {"name": "cyclic_offset", "type": "LrIdx", "read": "live"},
-                {"name": "mask_offset", "type": "MultMaskOffsetImmediate"},
-                {"name": "mask_shift", "type": "LrIdx", "read": "live"},
-                {"name": "fixed_idx", "type": "LrIdx", "read": "live"},
-            ],
-            "doc": InstructionDoc(
-                title="Vector-Element Multiply (padded RC)",
-                summary=(
-                    "Same scalar × RC row as `MULT.VE.CYCLIC`, but indices at or past the 512-byte RC "
-                    "boundary within the 128-element window use a dtype-specific 1 instead of wrapping."
-                ),
-                syntax="MULT.VE.PADDED cyclic_offset, mask_offset, mask_shift, fixed_idx",
-                operands=[
-                    "`cyclic_offset`: **`LR0`**…**`LR15`** — base byte offset into `R_CYCLIC`; out-of-range lanes use dtype 1.",
-                    "`mask_offset`: immediate mask slot **`0`**…**`7`** — selects one of eight 128-bit masks in `R_MASK`.",
-                    "`mask_shift`: **`LR0`**…**`LR15`** — index ∈ [−3, +3] (values >3 clamp to 3, values <−3 clamp to −3) selecting one of seven masks via sequential shift-and-AND: positive indices use partition_vector (0 at group start), negative indices use inverse_partition_vector (0 at group end).",
-                    "`fixed_idx`: **`LR0`**…**`LR15`** (value read live) — scalar index into **`R0`**/**`R1`**.",
-                ],
-                operation="For i in [0, 128): rb = R_CYCLIC[cyclic_offset + i] if in bounds else dtype_one; scalar from R0/R1; MULT_RES[i] = scalar * rb (then mask/shift).",
-                example="MULT.VE.PADDED LR0, 0, LR2, LR3;;",
-                notes="Lane masking via `mask_offset` and `mask_shift` zeroes lanes whose derived mask bit is **0** (deactivated) in `MULT_RES` before accumulation; lanes with bit **1** pass through. See [Masking](assembly-syntax.md#masking) for the full algorithm.",
-            ),
-            "execute_fn": "execute_mult_ve_padded",
         },
         "MULT_NOP": {
             "operands": [],
@@ -568,7 +541,7 @@ INSTRUCTION_SPEC = {
 
     # =========================================================================
     # ACC Slot (Accumulator Instructions)
-    # Opcode = position: ACC=0, ACC.FIRST=1, RESET_ACC=2, ACC_NOP=3, ACC.STRIDE=4, AGG.SUM.FIRST=5, AGG.SUM=6, AGG.MAX.FIRST=7, AGG.MAX=8
+    # Opcode = position: ACC=0, ACC.FIRST=1, ACC_NOP=2, ACC.STRIDE=3, AGG.SUM.FIRST=4, AGG.SUM=5, AGG.MAX.FIRST=6, AGG.MAX=7
     # =========================================================================
     "acc": {
         "ACC": {
@@ -593,17 +566,6 @@ INSTRUCTION_SPEC = {
                 example="ACC.FIRST;;",
             ),
             "execute_fn": "execute_acc_first",
-        },
-        "RESET_ACC": {
-            "operands": [],
-            "doc": InstructionDoc(
-                title="Reset Accumulator",
-                summary="Reset accumulator to zero.",
-                syntax="RESET_ACC",
-                operands=[],
-                operation="R_ACC = 0",
-            ),
-            "execute_fn": "execute_reset_acc",
         },
         "ACC_NOP": {
             "operands": [],

--- a/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
@@ -719,16 +719,6 @@ class Ipu:
             fixed_idx=fixed_idx,
         )
 
-    def execute_mult_ve_padded(self, *, cyclic_offset: int,
-                               mask_offset: int, mask_shift: int, fixed_idx: int) -> None:
-        """Execute MULT.VE.PADDED: fixed r0/r1 element × r_cyclic row with boundary padding."""
-        self._execute_mult_ve_variant(
-            pad_128_ones=True,
-            cyclic_offset=cyclic_offset,
-            mask_offset=mask_offset,
-            mask_shift=mask_shift,
-            fixed_idx=fixed_idx,
-        )
 
     def execute_mult_ve_cr(self, *, cyclic_offset: int, mask_offset: int,
                            mask_shift: int, cr_idx: int) -> None:
@@ -784,10 +774,6 @@ class Ipu:
     def execute_acc_nop(self) -> None:
         """Execute ACC_NOP: No operation."""
         pass
-
-    def execute_reset_acc(self) -> None:
-        """Execute RESET_ACC: Reset accumulator to zero."""
-        self.state.regfile.set_r_acc_bytes(bytearray(R_ACC_SIZE))
 
     def execute_acc(self) -> None:
         """Execute ACC: Accumulate mult_res into accumulator."""

--- a/src/tools/ipu-emu-py/test/test_execute.py
+++ b/src/tools/ipu-emu-py/test/test_execute.py
@@ -339,7 +339,6 @@ LDR_MULT_REG r1 lr13 cr0;;
 SET lr14 cr9;;
 SET lr15 cr10;;
 LDR_CYCLIC_MULT_REG lr14 cr0 lr15;;
-RESET_ACC;;
 MULT.EE r1 lr0 0 lr0;
 ACC;;
 SET lr0 cr11;;
@@ -424,7 +423,6 @@ SET lr2 cr10;;
 LDR_CYCLIC_MULT_REG lr1 cr0 lr2;;
 SET lr3 cr11;;
 LDR_MULT_MASK_REG lr3 cr0;;
-RESET_ACC;;
 SET lr5 cr10;;
 SET lr6 cr10;;
 MULT.EE r0 lr6 0 lr5;
@@ -463,7 +461,6 @@ SET lr2 cr10;;
 LDR_CYCLIC_MULT_REG lr1 cr0 lr2;;
 SET lr3 cr11;;
 LDR_MULT_MASK_REG lr3 cr0;;
-RESET_ACC;;
 SET lr5 cr12;;
 SET lr6 cr10;;
 MULT.EE r0 lr6 1 lr5;
@@ -719,15 +716,6 @@ BKPT;;
 
 
 class TestAccumulator:
-    def test_reset(self):
-        state = _make_state("RESET_ACC;;\nBKPT;;")
-        # Pre-fill acc words with non-zero
-        for i in range(128):
-            state.regfile.set_r_acc_word(i, 12345)
-        run_until_complete(state)
-        for i in range(128):
-            assert state.regfile.get_r_acc_word(i) == 0
-
     def test_acc_first(self):
         """ACC.FIRST sets r_acc to mult_res without adding previous r_acc."""
         state = _make_state(
@@ -1209,7 +1197,6 @@ LDR_MULT_REG r0 lr0 cr0;;
 SET lr1 cr9;;
 SET lr2 cr10;;
 LDR_CYCLIC_MULT_REG lr1 cr0 lr2;;
-RESET_ACC;;
 SET lr5 cr10;;
 SET lr6 cr10;;
 MULT.EE r0 lr6 0 lr5;
@@ -1251,7 +1238,6 @@ class TestMultVeCr:
 SET lr0 cr8;;
 SET lr1 cr9;;
 LDR_CYCLIC_MULT_REG lr0 cr0 lr1;;
-RESET_ACC;;
 SET lr2 cr9;;
 SET lr4 cr9;;
 MULT.VE.CR lr2 0 lr4 cr3;
@@ -1278,7 +1264,6 @@ BKPT;;
 SET lr0 cr8;;
 SET lr1 cr9;;
 LDR_CYCLIC_MULT_REG lr0 cr0 lr1;;
-RESET_ACC;;
 SET lr2 cr9;;
 SET lr4 cr9;;
 MULT.VE.CR lr2 0 lr4 cr2;
@@ -1304,7 +1289,6 @@ BKPT;;
         pad_start = 62  # 512 - 450 = 62 elements in bounds
 
         state = _make_state("""\
-RESET_ACC;;
 SET lr2 cr8;;
 SET lr4 cr9;;
 MULT.VE.CR lr2 0 lr4 cr3;
@@ -1337,7 +1321,6 @@ BKPT;;
 SET lr0 cr8;;
 SET lr1 cr9;;
 LDR_CYCLIC_MULT_REG lr0 cr0 lr1;;
-RESET_ACC;;
 SET lr2 cr9;;
 SET lr4 cr9;;
 MULT.VE.CR lr2 0 lr4 cr5;
@@ -1363,7 +1346,6 @@ BKPT;;
         scalar_fp8 = _float32_to_fp8_scalar(3.0, 5)
 
         state = _make_state("""\
-RESET_ACC;;
 SET lr2 cr8;;
 SET lr4 cr9;;
 MULT.VE.CR lr2 0 lr4 cr6;
@@ -1400,7 +1382,6 @@ LDR_MULT_REG r0 lr0 cr0;;
 SET lr1 cr9;;
 SET lr2 cr10;;
 LDR_CYCLIC_MULT_REG lr1 cr0 lr2;;
-RESET_ACC;;
 MULT.EE r0 lr2 0 lr2;
 ACC;;
 BKPT;;
@@ -1429,7 +1410,6 @@ LDR_MULT_REG r0 lr0 cr0;;
 SET lr1 cr9;;
 SET lr2 cr10;;
 LDR_CYCLIC_MULT_REG lr1 cr0 lr2;;
-RESET_ACC;;
 MULT.VE.CYCLIC lr2 0 lr2 lr2;
 ACC;;
 BKPT;;
@@ -1458,7 +1438,6 @@ BKPT;;
         state = _make_state("""\
 SET lr0 cr8;;
 LDR_MULT_REG r0 lr0 cr0;;
-RESET_ACC;;
 SET lr2 cr9;;
 SET lr4 cr10;;
 SET lr5 cr10;;
@@ -1477,40 +1456,6 @@ BKPT;;
             val = struct.unpack_from("<i", acc_raw, i * 4)[0]
             assert val == scalar * rc_fill, f"word {i}: expected {scalar * rc_fill}, got {val}"
 
-    def test_mult_ve_padded_boundary(self):
-        """MULT.VE.PADDED: elements past RC byte 511 use dtype 1."""
-        rc_fill = 4
-        scalar = 5
-        pad_start = 62  # 512 - 450 = 62 elements in bounds before padding
-
-        r0_data = bytearray(128)
-        r0_data[0] = scalar
-
-        state = _make_state("""\
-SET lr0 cr8;;
-LDR_MULT_REG r0 lr0 cr0;;
-RESET_ACC;;
-SET lr2 cr9;;
-SET lr4 cr10;;
-SET lr5 cr10;;
-MULT.VE.PADDED lr2 0 lr4 lr5;
-ACC;;
-BKPT;;
-""",
-            cr={8: 4096, 9: 450, 10: 0})
-        state.dtype = DType.INT8
-        state.xmem.write_address(0x1000, bytes(r0_data))
-        state.regfile.set_r_cyclic_at(0, bytes([rc_fill] * 512))
-        run_until_complete(state)
-
-        acc_raw = state.regfile.raw("r_acc")
-        for i in range(pad_start):
-            val = struct.unpack_from("<i", acc_raw, i * 4)[0]
-            assert val == scalar * rc_fill, f"word {i}: expected {scalar * rc_fill}, got {val}"
-        for i in range(pad_start, 128):
-            val = struct.unpack_from("<i", acc_raw, i * 4)[0]
-            assert val == scalar * 1, f"word {i} (padded): expected {scalar}, got {val}"
-
     def test_mult_ve_r1_scalar(self):
         """MULT.VE.CYCLIC: fixed_idx in [128, 255] addresses R1[fixed_idx - 128] instead of R0."""
         r0_data = bytearray(128)  # all zeros — must not be picked
@@ -1526,7 +1471,6 @@ LDR_MULT_REG r1 lr0 cr0;;
 SET lr1 cr10;;
 SET lr2 cr11;;
 LDR_CYCLIC_MULT_REG lr1 cr0 lr2;;
-RESET_ACC;;
 SET lr3 cr12;;
 MULT.VE.CYCLIC lr2 0 lr2 lr3;
 ACC;;
@@ -1555,7 +1499,6 @@ class TestMultEeRr:
         state = _make_state("""\
 SET lr0 cr8;;
 LDR_MULT_REG r0 lr0 cr0;;
-RESET_ACC;;
 SET lr5 cr9;;
 MULT.EE.RR r0 0 lr5;
 ACC;;
@@ -1581,7 +1524,6 @@ SET lr0 cr8;;
 LDR_MULT_REG r0 lr0 cr0;;
 SET lr1 cr9;;
 LDR_MULT_REG r1 lr1 cr0;;
-RESET_ACC;;
 SET lr5 cr10;;
 MULT.EE.RR r1 0 lr5;
 ACC;;
@@ -1610,7 +1552,6 @@ SET lr0 cr8;;
 LDR_MULT_REG r0 lr0 cr0;;
 SET lr3 cr9;;
 LDR_MULT_MASK_REG lr3 cr0;;
-RESET_ACC;;
 SET lr5 cr10;;
 MULT.EE.RR r0 0 lr5;
 ACC;;
@@ -1658,7 +1599,6 @@ SET lr0 cr8;;
 LDR_MULT_REG r0 lr0 cr0;;
 SET lr3 cr9;;
 LDR_MULT_MASK_REG lr3 cr0;;
-RESET_ACC;;
 SET lr5 cr2;;
 MULT.EE.RR r0 0 lr5;
 ACC;;

--- a/src/tools/ipu-emu-py/test/test_stats.py
+++ b/src/tools/ipu-emu-py/test/test_stats.py
@@ -102,15 +102,10 @@ BKPT;;
 
     def test_acc_active_counted(self):
         asm = """\
-RESET_ACC;;
-ACC;;
+ACC.FIRST;;
 BKPT;;
 """
         state = _run(asm)
-        assert state.stats.acc_active_cycles >= 1
-
-    def test_reset_acc_is_active(self):
-        state = _run("RESET_ACC;;BKPT;;")
         assert state.stats.acc_active_cycles >= 1
 
     def test_xmem_read_counted(self):
@@ -134,7 +129,6 @@ BKPT;;
     def test_xmem_write_counted(self):
         # STR_ACC_REG writes to xmem
         asm = """\
-RESET_ACC;;
 STR_ACC_REG lr0 cr1;;
 BKPT;;
 """
@@ -152,11 +146,11 @@ BKPT;;
         assert state.stats.xmem_reads == 0
 
     def test_multiple_cycles_accumulate(self):
-        # 3 independent RESET_ACC cycles, then BKPT
+        # 3 independent acc cycles (ACC.FIRST, ACC, ACC), then BKPT
         asm = """\
-RESET_ACC;;
-RESET_ACC;;
-RESET_ACC;;
+ACC.FIRST;;
+ACC;;
+ACC;;
 BKPT;;
 """
         state = _run(asm)

--- a/src/tools/ipu-emu-py/test/test_wide_vector_debug.py
+++ b/src/tools/ipu-emu-py/test/test_wide_vector_debug.py
@@ -58,7 +58,6 @@ SET lr1 cr7;;
 SET lr2 cr8;;
 LDR_MULT_REG r0 lr0 cr0;;
 LDR_CYCLIC_MULT_REG lr1 cr0 lr2;;
-RESET_ACC;;
 MULT.EE r0 lr2 0 lr2;;
 acc.first;;
 BKPT;;
@@ -82,7 +81,6 @@ SET lr1 cr7;;
 SET lr2 cr8;;
 LDR_MULT_REG r0 lr0 cr0;;
 LDR_CYCLIC_MULT_REG lr1 cr0 lr2;;
-RESET_ACC;;
 MULT.EE r0 lr2 0 lr2;;
 acc.first;;
 SET lr0 cr9;;
@@ -112,7 +110,6 @@ SET lr1 cr7;;
 SET lr2 cr8;;
 LDR_MULT_REG r0 lr0 cr0;;
 LDR_CYCLIC_MULT_REG lr1 cr0 lr2;;
-RESET_ACC;;
 MULT.EE r0 lr2 0 lr2;;
 acc.first;;
 SET lr0 cr9;;
@@ -146,7 +143,6 @@ SET lr1 cr7;;
 SET lr2 cr8;;
 LDR_MULT_REG r0 lr0 cr0;;
 LDR_CYCLIC_MULT_REG lr1 cr0 lr2;;
-RESET_ACC;;
 MULT.EE r0 lr2 0 lr2;;
 acc.first;;
 BKPT;;
@@ -192,7 +188,6 @@ SET lr3 cr9;;
 LDR_MULT_REG r0 lr0 cr0;;
 LDR_MULT_REG r1 lr1 cr0;;
 LDR_CYCLIC_MULT_REG lr2 cr0 lr3;;
-RESET_ACC;;
 MULT.EE {which} lr3 0 lr3;;
 acc.first;;
 BKPT;;
@@ -234,7 +229,6 @@ LDR_CYCLIC_MULT_REG lr2 cr0 lr3;;
 SET lr4 cr10;;
 LDR_MULT_REG r0 lr4 cr0;;
 SET lr5 cr11;;
-RESET_ACC;;
 MULT.EE r0 lr5 0 lr5;;
 acc.first;;
 BKPT;;
@@ -265,7 +259,6 @@ class TestWideVectorPadding:
 SET lr0 cr6;;
 SET lr2 cr7;;
 MULT.VE.CR lr0 0 lr2 cr2;;
-RESET_ACC;;
 acc.first;;
 BKPT;;
 """
@@ -301,7 +294,6 @@ SET lr0 cr6;;
 SET lr2 cr7;;
 SET lr3 cr8;;
 MULT.VE.CYCLIC lr0 0 lr2 lr3;;
-RESET_ACC;;
 acc.first;;
 BKPT;;
 """
@@ -313,42 +305,6 @@ BKPT;;
             assert struct.unpack_from("<f", mult_res, i * 4)[0] == pytest.approx(6.0), f"lane {i}"
         for i in range(32, 128):
             assert struct.unpack_from("<f", mult_res, i * 4)[0] == pytest.approx(10.0), f"lane {i}"
-
-    def test_mult_ve_fp32_wide_padded_past_boundary(self) -> None:
-        """MULT.VE.PADDED (wide FP32): lanes past byte 511 use ×1."""
-        buf = bytearray(512)
-        for k in range(32):
-            struct.pack_into("<f", buf, 384 + k * 4, 3.0)
-        for k in range(96):
-            struct.pack_into("<f", buf, k * 4, 5.0)
-        st = IpuState(wide_vector_debug=True, wide_vector_arithmetic=WideVectorArithmetic.FP32)
-        st.dtype = DType.INT8
-        st.regfile.set_cr(0, 0)
-        st.regfile.set_r_cyclic_at(0, buf)
-        st.xmem.write_address(0x1000, struct.pack("<128f", *([2.0] * 128)))
-        st.regfile.set_cr(10, 0x1000)
-        st.regfile.set_cr(6, 384)
-        st.regfile.set_cr(7, 0)
-        st.regfile.set_cr(8, 0)
-        asm = """\
-SET lr4 cr10;;
-LDR_MULT_REG r0 lr4 cr0;;
-SET lr0 cr6;;
-SET lr2 cr7;;
-SET lr3 cr8;;
-MULT.VE.PADDED lr0 0 lr2 lr3;;
-RESET_ACC;;
-acc.first;;
-BKPT;;
-"""
-        encoded = assemble(asm)
-        load_program(st, [decode_instruction_word(w) for w in encoded])
-        run_until_complete(st)
-        mult_res = st.regfile.raw("mult_res")
-        for i in range(32):
-            assert struct.unpack_from("<f", mult_res, i * 4)[0] == pytest.approx(6.0), f"lane {i}"
-        for i in range(32, 128):
-            assert struct.unpack_from("<f", mult_res, i * 4)[0] == pytest.approx(2.0), f"lane {i}"
 
 
 class TestWideVectorAgg:
@@ -416,7 +372,6 @@ SET lr2 cr8;;
 LDR_MULT_REG r0 lr0 cr0;;
 LDR_CYCLIC_MULT_REG lr1 cr0 lr2;;
 SET lr3 cr9;;
-RESET_ACC;;
 MULT.EE r0 lr3 0 lr3;;
 BKPT;;
 """


### PR DESCRIPTION

## Changes

- **`instruction_spec.py`** — removed `MULT.VE.PADDED` and `RESET_ACC` entries; updated opcode-position comments
- **`ipu.py`** — deleted `execute_mult_ve_padded` and `execute_reset_acc` handlers
- **`test_execute.py`** — removed `TestAccumulator::test_reset`, `TestMult::test_mult_ve_padded_boundary`, and all `RESET_ACC;;` init lines (safe: `R_ACC` is zero at program start)
- **`test_stats.py`** — removed `test_reset_acc_is_active`; rewrote `test_acc_active_counted` and `test_multiple_cycles_accumulate` using `ACC.FIRST`/`ACC`; removed `RESET_ACC;;` init line from `test_xmem_write_counted`
- **`test_wide_vector_debug.py`** — removed `test_mult_ve_fp32_wide_padded_past_boundary` and all `RESET_ACC;;` init lines
- **`fully_connected.asm`** — unrolled first element-loop iteration to use `ACC.FIRST` (see above)
- **`docs/`** — regenerated `instructions.md`; updated `assembly-syntax.md`, `building-applications.md`, `debugging.md`, `gen_docs.py`, and `SKILL.md`


