### PR TITLE
Validate LDR_CYCLIC_MULT_REG index instead of silently wrapping mod 512

### DIFF
--- a/docs/content/wide-vector-debug-mode.md
+++ b/docs/content/wide-vector-debug-mode.md
@@ -49,7 +49,7 @@ The high-level helper [`run_test`](https://github.com/rechefe/ipu-emulator/blob/
 While **addresses are still byte addresses**, wide mode changes how much data some loads consume per instruction:
 
 - **`LDR_MULT_REG`** reads **512 elements** from XMEM (128×FP32 or 128×INT32, depending on `wide_vector_arithmetic`) into internal staging for **`R0` or `R1` only**. The architectural 128-element `r` register in the regfile is not the source for mult operands in this mode.
-- **`LDR_CYCLIC_MULT_REG`** reads **512 elements** into `r_cyclic` at the given **`index`**, which must be **aligned to 512** (same rule as 128-element alignment in normal mode, scaled to the wide chunk).
+- **`LDR_CYCLIC_MULT_REG`** reads **512 elements** into `r_cyclic` at the given **`index`**, which loads the entire register in one shot, so **`index` must be `0`**. (In normal mode `index` must be one of the four 128-element slot boundaries — `0`, `128`, `256`, `384`; any other value raises an error.)
 
 Prepare XMEM accordingly (e.g. raw `float32` or `int32` little-endian blobs).
 

--- a/src/tools/ipu-common/src/ipu_common/instruction_spec.py
+++ b/src/tools/ipu-common/src/ipu_common/instruction_spec.py
@@ -220,9 +220,9 @@ INSTRUCTION_SPEC = {
                 operands=[
                     "offset: Offset register (LR0–LR15)",
                     "base: Base address register (CR0–CR14)",
-                    "index: Index inside cyclic register (LR0–LR15)",
+                    "index: Index inside cyclic register (LR0–LR15); must hold 0, 128, 256, or 384 — the four R_CYCLIC slot boundaries. Any other value raises an error.",
                 ],
-                operation="R_CYCLIC[index % 512:128] = Memory[offset + base]",
+                operation="R_CYCLIC[index .. index+127] = Memory[offset + base]   # index ∈ {0, 128, 256, 384}",
             ),
             "execute_fn": "execute_ldr_cyclic_mult_reg",
         },

--- a/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
@@ -67,6 +67,10 @@ R_REG_SIZE = _reg_sizes["r"]["size_bytes"]
 R_CYCLIC_SIZE = _reg_sizes["r_cyclic"]["size_bytes"]
 R_ACC_SIZE = _reg_sizes["r_acc"]["size_bytes"]
 
+# R_CYCLIC is divided into four 128-byte slots; LDR_CYCLIC_MULT_REG's index
+# must land exactly on a slot boundary — no implicit wraparound.
+R_CYCLIC_VALID_INDICES = tuple(range(0, R_CYCLIC_SIZE, R_REG_SIZE))
+
 
 # ---------------------------------------------------------------------------
 # Operand extraction: maps instruction_spec operand names → inst dict field keys
@@ -454,18 +458,21 @@ class Ipu:
     def execute_ldr_cyclic_mult_reg(self, *, offset: int, base: int, index: int) -> None:
         """Execute LDR_CYCLIC_MULT_REG: Load with cyclic addressing into r_cyclic."""
         addr = offset + base
-        assert index % R_REG_SIZE == 0, (
-            f"LR index for cyclic load must be aligned to {R_REG_SIZE}: got {index}"
-        )
         if self._wide_vector_active():
-            assert index % R_CYCLIC_SIZE == 0, (
-                f"Wide-vector debug: cyclic load index must be aligned to {R_CYCLIC_SIZE}, "
-                f"got {index}"
-            )
+            if index != 0:
+                raise EmulatorError(
+                    f"LDR_CYCLIC_MULT_REG: wide-vector debug mode loads the full "
+                    f"{R_CYCLIC_SIZE}-byte r_cyclic register, so index must be 0; got {index}"
+                )
             data = self.state.xmem.read_address(addr, R_CYCLIC_SIZE)
             self.state.regfile.set_r_cyclic_at(index, data)
             return
 
+        if index not in R_CYCLIC_VALID_INDICES:
+            raise EmulatorError(
+                f"LDR_CYCLIC_MULT_REG: index must be one of {R_CYCLIC_VALID_INDICES} "
+                f"(R_CYCLIC slot boundaries); got {index}"
+            )
         data = self.state.xmem.read_address(addr, R_REG_SIZE)
         self.state.regfile.set_r_cyclic_at(index, data)
 

--- a/src/tools/ipu-emu-py/test/test_execute.py
+++ b/src/tools/ipu-emu-py/test/test_execute.py
@@ -414,6 +414,20 @@ BKPT;;
         loaded = state.regfile.get_r_cyclic_at(0, 128)
         assert loaded == bytearray(cyclic_data)
 
+    def test_cyclic_register_load_invalid_index_raises(self):
+        """index must be one of the four R_CYCLIC slot boundaries — no implicit wrap."""
+        from ipu_emu.ipu import EmulatorError
+
+        state = _make_state("""\
+SET lr0 cr8;;
+SET lr1 cr9;;
+LDR_CYCLIC_MULT_REG lr0 cr0 lr1;;
+BKPT;;
+""",
+            cr={8: 20480, 9: 64})
+        with pytest.raises(EmulatorError, match="index must be one of"):
+            run_until_complete(state)
+
     def test_mask_register_load(self):
         mask_data = bytes([(i + 1) & 0xFF for i in range(128)])
         state = _make_state("""\

--- a/src/tools/ipu-emu-py/test/test_wide_vector_debug.py
+++ b/src/tools/ipu-emu-py/test/test_wide_vector_debug.py
@@ -207,44 +207,26 @@ BKPT;;
 
 
 class TestWideVectorCyclicIndex:
-    """``LDR_CYCLIC_MULT_REG`` must honour ``index`` in wide mode (512-byte chunk)."""
+    """``LDR_CYCLIC_MULT_REG`` loads the full 512-byte chunk in wide mode, so
+    ``index`` must be 0 — any other value must raise, not silently wrap."""
 
-    def test_ldr_cyclic_nonzero_index_fp32(self) -> None:
-        zeros = struct.pack("<128f", *([0.0] * 128))
-        nines = struct.pack("<128f", *([9.0] * 128))
+    def test_ldr_cyclic_nonzero_index_raises_fp32(self) -> None:
         twos = struct.pack("<128f", *([2.0] * 128))
         st = IpuState(wide_vector_debug=True, wide_vector_arithmetic=WideVectorArithmetic.FP32)
         st.dtype = DType.INT8
-        st.xmem.write_address(0x2000, zeros)
-        st.xmem.write_address(0x2200, nines)
         st.xmem.write_address(0x1000, twos)
-        st.regfile.set_cr(6, 0x2000)
-        st.regfile.set_cr(7, 0)
-        st.regfile.set_cr(8, 0x2200)
-        st.regfile.set_cr(9, 512)
-        st.regfile.set_cr(10, 0x1000)
-        st.regfile.set_cr(11, 512)
+        st.regfile.set_cr(6, 0x1000)
+        st.regfile.set_cr(7, 512)
         asm = """\
 SET lr0 cr6;;
 SET lr1 cr7;;
 LDR_CYCLIC_MULT_REG lr0 cr0 lr1;;
-SET lr2 cr8;;
-SET lr3 cr9;;
-LDR_CYCLIC_MULT_REG lr2 cr0 lr3;;
-SET lr4 cr10;;
-LDR_MULT_REG r0 lr4 cr0;;
-SET lr5 cr11;;
-RESET_ACC;;
-MULT.EE r0 lr5 0 lr5;;
-acc.first;;
 BKPT;;
 """
         encoded = assemble(asm)
         load_program(st, [decode_instruction_word(w) for w in encoded])
-        run_until_complete(st)
-        acc = st.regfile.raw("r_acc")
-        for i in range(128):
-            assert struct.unpack_from("<f", acc, i * 4)[0] == pytest.approx(18.0), f"lane {i}"
+        with pytest.raises(EmulatorError, match="index must be 0"):
+            run_until_complete(st)
 
 
 class TestWideVectorPadding:


### PR DESCRIPTION
R_CYCLIC has four 128-byte slots at indices 0, 128, 256, and 384.
execute_ldr_cyclic_mult_reg previously only checked 128-byte alignment,
letting out-of-range index values fall through to RegFile's generic
wraparound accessor and silently land on the wrong slot. Raise
EmulatorError for any index outside {0, 128, 256, 384} (narrow mode) or
nonzero index in wide-vector debug mode, where the full 512-byte register
is loaded in one shot. MULT.VE.CYCLIC's read-side wraparound is untouched.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013B5xEXJ2rGW9narj4KdVCQ