### PR TITLE
Refactor multiply instructions: consolidate MULT.EE/VE variants into RC-based API

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -66,7 +66,7 @@ Same principle applies to **`registers.py`** for register definitions.
 Every cycle executes one **compound instruction** — multiple independent slots in parallel:
 
 ```asm
-LDR_MULT_REG R0, LR0, CR0; MULT.EE R0, LR1, 0, LR3; ACC; ADD LR0, LR0, 1; BNE LR0, LR1, next;;
+LDR_MULT_REG R0, LR0, CR0; MULT.RC.VV LR1, R0, 0, LR3; ACC; ADD LR0, LR0, 1; BNE LR0, LR1, next;;
 ```
 
 - Binary layout (MSB → LSB): `cond`, `lr` (×3), `load`, `mult`, `acc`, `aaq`, `store`, `acc_store`, `break`
@@ -94,7 +94,7 @@ LDR_MULT_REG R0, LR0, CR0; MULT.EE R0, LR1, 0, LR3; ACC; ADD LR0, LR0, 1; BNE LR
 | LOAD | `LDR_MULT_REG`, `LDR_CYCLIC_MULT_REG`, `LDR_MULT_MASK_REG` | First-stage memory loads (feeds multiply) |
 | STORE | `STR_POST_AAQ_REG` | Last-stage memory store (drains `POST_AAQ_REG`) |
 | ACC_STORE | `STR_ACC_REG` | **Simulation-only** — store `R_ACC` to external memory |
-| MULT | `MULT.EE`, `MULT.VE.CYCLIC`, `MULT.VE.PADDED`, `MULT.VE.CR`, `MULT.EE.RR` | 8-bit vector multiply |
+| MULT | `MULT.RC.VV`, `MULT.RC.VE`, `MULT.RC.VS`, `MULT.VE`, `MULT.EE` | 8-bit vector multiply |
 | ACC | `ACC`, `ACC.FIRST`, `ACC.STRIDE`, `RESET_ACC`, `AGG.SUM`, `AGG.SUM.FIRST`, `AGG.MAX`, `AGG.MAX.FIRST` | Accumulate into `R_ACC`; in-place aggregation (sum/max) writing a single slot of `R_ACC` |
 | AAQ | `AAQ`, `ACTIVATE` | **`ACTIVATE`** reads **`R_ACC`** and writes activated **32b** lanes into **`POST_AAQ_REG`** (512 B staging). **`AAQ`** (INT8) quantizes wide lanes in **`POST_AAQ_REG`** into the leading **128 B**; **`STR_POST_AAQ_REG`** stores the full **512 B** register to XMEM. See `docs/content/building-applications.md#activations-emulator`. |
 | LR (×3) | `SET`, `ADD`, `SUB`, `INCR_MOD_POW2`, `INC`, `DEC` | Scalar loop register ops (`SET` copies from a **`CR`** register; `INC`/`DEC` read-modify-write with union-derived immediate) |

--- a/docs/content/building-applications.md
+++ b/docs/content/building-applications.md
@@ -409,7 +409,7 @@ This section walks through a complete real-world implementation: a fully-connect
 
 ### Assembly Program
 
-The IPU assembly implements the core computation: activations for the current sample live in **`r0`** (loaded once per sample). Each inner-loop iteration loads a 128-byte **weight row** into the cyclic register (**`r_cyclic`**) and issues **`MULT.VE.CYCLIC`**, which multiplies that row by the scalar **`r0[lr5]`** (loop counter advanced via **`ADD`**), then accumulates. The harness initializes **`cr3`**, **`cr4`**, and **`cr5`** with stride constants **128**, **1**, and **256** so the program can add large steps without the removed **`incr`** mnemonic.
+The IPU assembly implements the core computation: activations for the current sample live in **`r0`** (loaded once per sample). Each inner-loop iteration loads a 128-byte **weight row** into the cyclic register (**`r_cyclic`**) and issues **`MULT.RC.VE`**, which multiplies that row by the scalar **`r0[lr5]`** (loop counter advanced via **`ADD`**), then accumulates. The harness initializes **`cr3`**, **`cr4`**, and **`cr5`** with stride constants **128**, **1**, and **256** so the program can add large steps without the removed **`incr`** mnemonic.
 
 ```asm
     SET                 lr0 cr6 ;;
@@ -431,7 +431,7 @@ element_loop:
     LDR_CYCLIC_MULT_REG lr4 cr1 lr15;
     ADD                 lr4 lr4 cr3;
     ADD                 lr5 lr5 cr4;
-    MULT.VE.CYCLIC      lr15 0 lr15 lr5;
+    MULT.RC.VE          lr15 lr5 0 lr15;
     ACC;
     BLT                 lr5 lr6 element_loop;;
 

--- a/docs/content/wide-vector-debug-mode.md
+++ b/docs/content/wide-vector-debug-mode.md
@@ -57,13 +57,13 @@ Prepare XMEM accordingly (e.g. raw `float32` or `int32` little-endian blobs).
 
 Wide mode unpacks `r_cyclic` as 128 consecutive 32-bit lanes starting at a **byte offset**:
 
-- **`cyclic_offset`** and **`fixed_cyclic_idx`** passed to mult instructions must be **4-byte aligned**. Unaligned values raise `EmulatorError` so you do not silently mis-read lane boundaries.
+- **`rc_idx`** (and any LR-encoded `src`/`ra_idx` used to further index into Ra) passed to mult instructions must be **4-byte aligned**. Unaligned values raise `EmulatorError` so you do not silently mis-read lane boundaries.
 
 ## Semantics that differ from normal mode
 
 - **Multiply masks** (`mask_offset` immediate slot 0–7 / `mask_shift` LR): mask-and-shift on `mult_res` is **disabled** in wide mode, because the 128-bit mask layout does not map to 128 FP32/INT32 lanes.
 - **`AAQ`**: unless `wide_vector_quantize_output=True`, **`AAQ` is a no-op** in wide mode; full lane results remain in **`R_ACC`**. Use the existing debug-only **`STR_ACC_REG`** instruction (or read `R_ACC` in Python) to dump 512 elements of accumulator data.
-- **LR and CR** are **not** widened; scalars such as **`MULT.VE.CR`** still use the **low byte** of a CR as a signed value in the wide path.
+- **LR and CR** are **not** widened; scalars such as **`MULT.RC.VE`**'s CR-encoded `src` still use the **low byte** of a CR as a signed value in the wide path.
 
 ## INT32 vs FP32
 

--- a/src/tools/ipu-apps/src/ipu_apps/fully_connected/fully_connected.asm
+++ b/src/tools/ipu-apps/src/ipu_apps/fully_connected/fully_connected.asm
@@ -17,7 +17,7 @@ element_loop:
     LDR_CYCLIC_MULT_REG lr4 cr13 lr15;
     ADD                 lr4 lr4 cr3;
     ADD                 lr5 lr5 cr4;
-    MULT.VE.CYCLIC      lr15 0 lr15 lr5;
+    MULT.RC.VE          lr15 lr5 0 lr15;
     ACC;
     BNE                 lr5 lr6 element_loop;;
 

--- a/src/tools/ipu-as-py/src/ipu_as/gen_docs.py
+++ b/src/tools/ipu-as-py/src/ipu_as/gen_docs.py
@@ -14,7 +14,7 @@ OPERAND_TYPE_DETAILS: dict[str, str] = {
     "MultStageReg": (
         "Multiply-stage field in the VLIW encoding. Assembly accepts **`r0`** and **`r1`** only; "
         "the field is **two bits** wide (encoding `2` is reserved). Used as the destination of "
-        "`LDR_MULT_REG` and as the **`ra`** operand of `MULT.EE`."
+        "`LDR_MULT_REG` and as the **`ra`** operand of `MULT.RC.VV`."
     ),
     "LrIdx": (
         "Loop register index: resolves to **`lr0`** … **`lr15`**. Often used for addresses, strides, "
@@ -30,8 +30,9 @@ OPERAND_TYPE_DETAILS: dict[str, str] = {
     "LcrIdx": (
         "LR **or** CR index in one field: lower indices map to **`lr0`–`lr15`**, higher indices to "
         "`**cr0`–`cr14`** in the usual combined ordering used by the assembler. `cr15` is reserved "
-        "and is not a valid operand. Used as **`src_b`** on **`ADD`**/**`SUB`** and as **`step`** on "
-        "**`INCR_MOD_POW2`**."
+        "and is not a valid operand. Used as **`src_b`** on **`ADD`**/**`SUB`**, as **`step`** on "
+        "**`INCR_MOD_POW2`**, and as **`src`** on **`MULT.RC.VE`** (an LR's stored value selects an "
+        "element from `R0`/`R1`; a CR's low byte is the scalar directly)."
     ),
     "LrIncDecImmediate": (
         "Unsigned immediate for **`INC`** / **`DEC`** in the LR slot. The bit width **W** is not "
@@ -141,14 +142,14 @@ Assembly is line-oriented. One **compound instruction** may contain several **sl
 # Comments start with # or //
 label:                          # Labels end with a colon
     LDR_MULT_REG r0 lr0 cr0;     # LOAD: load into mult stage r0
-    MULT.EE r0 lr1 0 lr3;        # MULT: element-wise multiply
+    MULT.RC.VV lr1 r0 0 lr3;     # MULT: element-wise multiply
     ACC;                         # ACC: accumulate
     INC lr0 1;               # LR: bump address (increment via INC)
     BNE lr0 lr1 next;            # COND: branch
     ;;
 ```
 
-By convention, **instruction mnemonics are written in upper case** in documentation and examples (e.g. `MULT.EE`, `LDR_MULT_REG`). **Operand tokens** use **lower case** (`lr0`, `r0`, `cr0`). The assembler accepts **any case** for mnemonics and register tokens.
+By convention, **instruction mnemonics are written in upper case** in documentation and examples (e.g. `MULT.RC.VV`, `LDR_MULT_REG`). **Operand tokens** use **lower case** (`lr0`, `r0`, `cr0`). The assembler accepts **any case** for mnemonics and register tokens.
 
 ## Compound instructions
 
@@ -170,7 +171,7 @@ load_inst; mult_inst; acc_inst; aaq_inst; store_inst; acc_store_inst; lr_inst_a;
 **Example (parallel slots):**
 
 ```asm
-LDR_MULT_REG r0 lr0 cr0; MULT.EE r0 lr1 0 lr3; ACC; INC lr0 1; BNE lr0 lr1 loop;;
+LDR_MULT_REG r0 lr0 cr0; MULT.RC.VV lr1 r0 0 lr3; ACC; INC lr0 1; BNE lr0 lr1 loop;;
 ```
 
 ## Register names
@@ -210,7 +211,7 @@ Relative labels such as `B +5` / `B -2` are supported where the grammar accepts 
     masking_section = """
 ## Masking
 
-Multiply instructions (`MULT.EE`, `MULT.EE.RR`, `MULT.VE.CYCLIC`, `MULT.VE.PADDED`, `MULT.VE.CR`) support **lane masking**: after the multiply, lanes in `MULT_RES` whose
+Multiply instructions (`MULT.RC.VV`, `MULT.RC.VE`, `MULT.RC.VS`, `MULT.VE`, `MULT.EE`) support **lane masking**: after the multiply, lanes in `MULT_RES` whose
 corresponding mask bit is **1** are **active** and pass through to accumulation; lanes whose bit is
 **0** are **zeroed** (deactivated). A mask of all-ones leaves every lane active (the reset default);
 a mask of all-zeros deactivates every lane.
@@ -292,7 +293,7 @@ LDR_MULT_REG R0, LR0, CR0;;
 LDR_CYCLIC_MULT_REG LR2, CR0, LR5;;
 
 # Multiply R0 element-wise vs R_CYCLIC using slot 3, shift index in LR4, accumulate
-MULT.EE R0, LR2, 3, LR4; ACC;;
+MULT.RC.VV LR2, R0, 3, LR4; ACC;;
 ```
 
 `3` is the `mask_offset` (slot 3 of `R_MASK`); `LR4` holds the `mask_shift` index.

--- a/src/tools/ipu-common/src/ipu_common/instruction_spec.py
+++ b/src/tools/ipu-common/src/ipu_common/instruction_spec.py
@@ -468,85 +468,79 @@ INSTRUCTION_SPEC = {
     
     # =========================================================================
     # MULT Slot (Multiply Instructions)
-    # Opcode = position: MULT.EE=0, MULT.VE.CYCLIC=1, MULT.VE.PADDED=2, MULT_NOP=3,
-    #          MULT.VE.CR=4, MULT.EE.RR=5
+    # Opcode = position: MULT.RC.VV=0, MULT.RC.VE=1, MULT.RC.VS=2, MULT_NOP=3,
+    #          MULT.VE=4, MULT.EE=5
     # =========================================================================
     "mult": {
-        "MULT.EE": {
+        "MULT.RC.VV": {
             "operands": [
+                {"name": "rc_idx", "type": "LrIdx", "read": "live"},
                 {"name": "ra", "type": "MultStageReg", "read": "live"},
-                {"name": "cyclic_offset", "type": "LrIdx", "read": "live"},
                 {"name": "mask_offset", "type": "MultMaskOffsetImmediate"},
                 {"name": "mask_shift", "type": "LrIdx", "read": "live"},
             ],
             "doc": InstructionDoc(
-                title="Element-wise Multiply",
-                summary="Multiply elements of two registers element by element.",
-                syntax="MULT.EE ra, cyclic_offset, mask_offset, mask_shift",
+                title="RC Vector × Ra Vector Multiply",
+                summary="Multiply R_CYCLIC[rc_idx:rc_idx+128] by Ra (R0 or R1) element-wise.",
+                syntax="MULT.RC.VV rc_idx, ra, mask_offset, mask_shift",
                 operands=[
+                    "`rc_idx`: **`LR0`**…**`LR15`** — base byte offset into **`R_CYCLIC`** (cyclic, mod 512).",
                     "`ra`: **`R0`** | **`R1`** — multiplicand mult-stage register (same cycle as `LDR_MULT_REG` into **`R0`**/**`R1`** is allowed).",
-                    "`cyclic_offset`: **`LR0`**…**`LR15`** — base byte offset into **`R_CYCLIC`**.",
                     "`mask_offset`: immediate mask slot **`0`**…**`7`** — selects one of eight 128-bit masks in **`R_MASK`**.",
                     "`mask_shift`: **`LR0`**…**`LR15`** — index ∈ [−3, +3] (values >3 clamp to 3, values <−3 clamp to −3) selecting one of seven masks via sequential shift-and-AND: positive indices use partition_vector (0 at group start), negative indices use inverse_partition_vector (0 at group end).",
                 ],
-                operation="For each lane i: MULT_RES[i] = ipu_mult(ra[i], R_CYCLIC[cyclic_offset + i]); then apply mask and shift.",
-                example="MULT.EE R0, LR0, 0, LR2;;",
+                operation="For each lane i: MULT_RES[i] = ipu_mult(R_CYCLIC[(rc_idx + i) % 512], ra[i]); then apply mask and shift.",
+                example="MULT.RC.VV LR0, R0, 0, LR2;;",
                 notes="Lane masking via `mask_offset` and `mask_shift` zeroes lanes whose derived mask bit is **0** (deactivated) in `MULT_RES` before accumulation; lanes with bit **1** pass through. See [Masking](assembly-syntax.md#masking) for the full algorithm.",
             ),
-            "execute_fn": "execute_mult_ee",
+            "execute_fn": "execute_mult_rc_vv",
         },
-        "MULT.VE.CYCLIC": {
+        "MULT.RC.VE": {
             "operands": [
-                {"name": "cyclic_offset", "type": "LrIdx", "read": "live"},
+                {"name": "rc_idx", "type": "LrIdx", "read": "live"},
+                {"name": "src", "type": "LcrIdx"},
                 {"name": "mask_offset", "type": "MultMaskOffsetImmediate"},
                 {"name": "mask_shift", "type": "LrIdx", "read": "live"},
-                {"name": "fixed_idx", "type": "LrIdx", "read": "live"},
             ],
             "doc": InstructionDoc(
-                title="Vector-Element Multiply (cyclic RC)",
+                title="RC Vector × Scalar Multiply",
                 summary=(
-                    "Multiply a fixed element from R0 or R1 against R_CYCLIC[cyclic_offset:cyclic_offset+128]. "
-                    "`fixed_idx` 0..127 selects `R0[fixed_idx]`, 128..255 selects `R1[fixed_idx - 128]`. "
-                    "R_CYCLIC is addressed cyclically modulo 512 elements (no padding with 1 past the boundary)."
+                    "Multiply R_CYCLIC[rc_idx:rc_idx+128] by a scalar, element-wise. The scalar is "
+                    "either a single element of R0/R1 (selected by an LR value) or a CR register value."
                 ),
-                syntax="MULT.VE.CYCLIC cyclic_offset, mask_offset, mask_shift, fixed_idx",
+                syntax="MULT.RC.VE rc_idx, src, mask_offset, mask_shift",
                 operands=[
-                    "`cyclic_offset`: **`LR0`**…**`LR15`** — base byte offset into **`R_CYCLIC`** (reduced mod 512).",
+                    "`rc_idx`: **`LR0`**…**`LR15`** — base byte offset into **`R_CYCLIC`** (cyclic, mod 512).",
+                    "`src`: **`LR0`**…**`LR15`** | **`CR0`**…**`CR14`** — if an LR, its stored value selects the scalar from R0/R1 (0..127 → `R0[idx]`, 128..255 → `R1[idx - 128]`); if a CR, its low byte supplies the scalar directly.",
                     "`mask_offset`: immediate mask slot **`0`**…**`7`** — selects one of eight 128-bit masks in **`R_MASK`**.",
                     "`mask_shift`: **`LR0`**…**`LR15`** — index ∈ [−3, +3] (values >3 clamp to 3, values <−3 clamp to −3) selecting one of seven masks via sequential shift-and-AND: positive indices use partition_vector (0 at group start), negative indices use inverse_partition_vector (0 at group end).",
-                    "`fixed_idx`: **`LR0`**…**`LR15`** (value read live) — scalar index into **`R0`**/**`R1`**.",
                 ],
-                operation="For i in [0, 128): rb = R_CYCLIC[(cyclic_offset + i) % 512]; scalar from R0/R1 via fixed_idx; MULT_RES[i] = scalar * rb (then mask/shift).",
-                example="MULT.VE.CYCLIC LR0, 0, LR2, LR3;;",
+                operation="For each lane i: MULT_RES[i] = ipu_mult(R_CYCLIC[(rc_idx + i) % 512], src_value); then apply mask and shift.",
+                example="MULT.RC.VE LR0, LR3, 0, LR2;;",
                 notes="Lane masking via `mask_offset` and `mask_shift` zeroes lanes whose derived mask bit is **0** (deactivated) in `MULT_RES` before accumulation; lanes with bit **1** pass through. See [Masking](assembly-syntax.md#masking) for the full algorithm.",
             ),
-            "execute_fn": "execute_mult_ve_cyclic",
+            "execute_fn": "execute_mult_rc_ve",
         },
-        "MULT.VE.PADDED": {
+        "MULT.RC.VS": {
             "operands": [
-                {"name": "cyclic_offset", "type": "LrIdx", "read": "live"},
+                {"name": "rc_idx", "type": "LrIdx", "read": "live"},
                 {"name": "mask_offset", "type": "MultMaskOffsetImmediate"},
                 {"name": "mask_shift", "type": "LrIdx", "read": "live"},
-                {"name": "fixed_idx", "type": "LrIdx", "read": "live"},
             ],
             "doc": InstructionDoc(
-                title="Vector-Element Multiply (padded RC)",
-                summary=(
-                    "Same scalar × RC row as `MULT.VE.CYCLIC`, but indices at or past the 512-byte RC "
-                    "boundary within the 128-element window use a dtype-specific 1 instead of wrapping."
-                ),
-                syntax="MULT.VE.PADDED cyclic_offset, mask_offset, mask_shift, fixed_idx",
+                title="RC Vector Self-Multiply (Square)",
+                summary="Square R_CYCLIC[rc_idx:rc_idx+128] element-wise.",
+                syntax="MULT.RC.VS rc_idx, mask_offset, mask_shift",
                 operands=[
-                    "`cyclic_offset`: **`LR0`**…**`LR15`** — base byte offset into `R_CYCLIC`; out-of-range lanes use dtype 1.",
-                    "`mask_offset`: immediate mask slot **`0`**…**`7`** — selects one of eight 128-bit masks in `R_MASK`.",
+                    "`rc_idx`: **`LR0`**…**`LR15`** — base byte offset into **`R_CYCLIC`** (cyclic, mod 512).",
+                    "`mask_offset`: immediate mask slot **`0`**…**`7`** — selects one of eight 128-bit masks in **`R_MASK`**.",
                     "`mask_shift`: **`LR0`**…**`LR15`** — index ∈ [−3, +3] (values >3 clamp to 3, values <−3 clamp to −3) selecting one of seven masks via sequential shift-and-AND: positive indices use partition_vector (0 at group start), negative indices use inverse_partition_vector (0 at group end).",
-                    "`fixed_idx`: **`LR0`**…**`LR15`** (value read live) — scalar index into **`R0`**/**`R1`**.",
                 ],
-                operation="For i in [0, 128): rb = R_CYCLIC[cyclic_offset + i] if in bounds else dtype_one; scalar from R0/R1; MULT_RES[i] = scalar * rb (then mask/shift).",
-                example="MULT.VE.PADDED LR0, 0, LR2, LR3;;",
+                operation="For each lane i: rb = R_CYCLIC[(rc_idx + i) % 512]; MULT_RES[i] = ipu_mult(rb, rb); then apply mask and shift.",
+                example="MULT.RC.VS LR0, 0, LR2;;",
                 notes="Lane masking via `mask_offset` and `mask_shift` zeroes lanes whose derived mask bit is **0** (deactivated) in `MULT_RES` before accumulation; lanes with bit **1** pass through. See [Masking](assembly-syntax.md#masking) for the full algorithm.",
             ),
-            "execute_fn": "execute_mult_ve_padded",
+            "execute_fn": "execute_mult_rc_vs",
         },
         "MULT_NOP": {
             "operands": [],
@@ -558,53 +552,51 @@ INSTRUCTION_SPEC = {
             ),
             "execute_fn": "execute_mult_nop",
         },
-        "MULT.VE.CR": {
+        "MULT.VE": {
             "operands": [
-                {"name": "cyclic_offset", "type": "LrIdx", "read": "live"},
-                {"name": "mask_offset", "type": "MultMaskOffsetImmediate"},
-                {"name": "mask_shift", "type": "LrIdx", "read": "live"},
+                {"name": "ra_idx", "type": "LrIdx", "read": "live"},
                 {"name": "cr_idx", "type": "CrIdx"},
-            ],
-            "doc": InstructionDoc(
-                title="Vector-Element Multiply (CR scalar)",
-                summary="Multiply each element of RC[cyclic_offset:cyclic_offset+128] by a scalar from a CR register. Elements beyond RC boundary are treated as 1 (dtype-specific).",
-                syntax="MULT.VE.CR cyclic_offset, mask_offset, mask_shift, cr_idx",
-                operands=[
-                    "cyclic_offset: Base offset into RC (cyclic register); non-cyclic — out-of-bounds elements are padded with 1",
-                    "mask_offset: Immediate mask slot 0–7 (128-bit slice of R_MASK)",
-                    "mask_shift: index ∈ [−3, +3] (values >3 clamp to 3, values <−3 clamp to −3) selecting one of seven masks via sequential shift-and-AND: positive indices use partition_vector (0 at group start), negative indices use inverse_partition_vector (0 at group end)",
-                    "cr_idx: CR register whose low byte supplies the fixed scalar multiplier (CR0–CR14)",
-                ],
-                operation="For i in [0,128): rb = RC[cyclic_offset+i] if in bounds else dtype_one; MULT_RES[i] = CR[cr_idx][0] * rb",
-                example="MULT.VE.CR LR0, 0, LR15, CR3;;",
-                notes="Lane masking via `mask_offset` and `mask_shift` zeroes lanes whose derived mask bit is **0** (deactivated) in `MULT_RES` before accumulation; lanes with bit **1** pass through. See [Masking](assembly-syntax.md#masking) for the full algorithm.",
-            ),
-            "execute_fn": "execute_mult_ve_cr",
-        },
-        "MULT.EE.RR": {
-            "operands": [
-                {"name": "ra", "type": "MultStageReg", "read": "live"},
                 {"name": "mask_offset", "type": "MultMaskOffsetImmediate"},
                 {"name": "mask_shift", "type": "LrIdx", "read": "live"},
             ],
             "doc": InstructionDoc(
-                title="Multi-Element Multiply (register by register)",
-                summary=(
-                    "Multi-element execution (MEE): multiply a mult-stage register "
-                    "element by element against itself. `ra` selects the execution "
-                    "mode — **`R0`** gives r0-by-r0, **`R1`** gives r1-by-r1."
-                ),
-                syntax="MULT.EE.RR ra, mask_offset, mask_shift",
+                title="Ra Vector × CR Scalar Multiply",
+                summary="Multiply Ra[ra_idx:ra_idx+128] (combined R0/R1) by a CR scalar, element-wise.",
+                syntax="MULT.VE ra_idx, cr_idx, mask_offset, mask_shift",
                 operands=[
-                    "`ra`: **`R0`** | **`R1`** — selects the MEE mode; the chosen register is both multiplicand and multiplier (same cycle as `LDR_MULT_REG` into **`R0`**/**`R1`** is allowed).",
-                    "`mask_offset`: immediate mask slot **`0`**…**`7`** — selects one of eight 128-bit masks in **`r_mask`**.",
+                    "`ra_idx`: **`LR0`**…**`LR15`** — base byte offset into combined Ra (`R0` ++ `R1`, 256 bytes, cyclic mod 256).",
+                    "`cr_idx`: **`CR0`**…**`CR14`** — CR register whose low byte supplies the scalar multiplier.",
+                    "`mask_offset`: immediate mask slot **`0`**…**`7`** — selects one of eight 128-bit masks in **`R_MASK`**.",
                     "`mask_shift`: **`LR0`**…**`LR15`** — index ∈ [−3, +3] (values >3 clamp to 3, values <−3 clamp to −3) selecting one of seven masks via sequential shift-and-AND: positive indices use partition_vector (0 at group start), negative indices use inverse_partition_vector (0 at group end).",
                 ],
-                operation="For each lane i: mult_res[i] = ipu_mult(ra[i], ra[i]); then apply mask and shift.",
-                example="MULT.EE.RR R0, 0, LR2;;",
+                operation="For each lane i: ra = Ra[(ra_idx + i) % 256]; MULT_RES[i] = ipu_mult(ra, CR[cr_idx][0]); then apply mask and shift.",
+                example="MULT.VE LR0, CR3, 0, LR2;;",
                 notes="Lane masking via `mask_offset` and `mask_shift` zeroes lanes whose derived mask bit is **0** (deactivated) in `MULT_RES` before accumulation; lanes with bit **1** pass through. See [Masking](assembly-syntax.md#masking) for the full algorithm.",
             ),
-            "execute_fn": "execute_mult_ee_rr",
+            "execute_fn": "execute_mult_ve",
+        },
+        "MULT.EE": {
+            "operands": [
+                {"name": "ra_idx", "type": "LrIdx", "read": "live"},
+                {"name": "cr_idx", "type": "CrIdx"},
+                {"name": "mask_offset", "type": "MultMaskOffsetImmediate"},
+                {"name": "mask_shift", "type": "LrIdx", "read": "live"},
+            ],
+            "doc": InstructionDoc(
+                title="Ra Element × CR Scalar Multiply (broadcast)",
+                summary="Multiply a single Ra element by a CR scalar; broadcast the product to all 128 lanes.",
+                syntax="MULT.EE ra_idx, cr_idx, mask_offset, mask_shift",
+                operands=[
+                    "`ra_idx`: **`LR0`**…**`LR15`** — index of the single Ra element to read (combined `R0` ++ `R1`, 256 bytes, mod 256).",
+                    "`cr_idx`: **`CR0`**…**`CR14`** — CR register whose low byte supplies the scalar multiplier.",
+                    "`mask_offset`: immediate mask slot **`0`**…**`7`** — selects one of eight 128-bit masks in **`R_MASK`**.",
+                    "`mask_shift`: **`LR0`**…**`LR15`** — index ∈ [−3, +3] (values >3 clamp to 3, values <−3 clamp to −3) selecting one of seven masks via sequential shift-and-AND: positive indices use partition_vector (0 at group start), negative indices use inverse_partition_vector (0 at group end).",
+                ],
+                operation="ra = Ra[ra_idx % 256]; result = ipu_mult(ra, CR[cr_idx][0]); for each lane i: MULT_RES[i] = result; then apply mask and shift.",
+                example="MULT.EE LR0, CR3, 0, LR2;;",
+                notes="Lane masking via `mask_offset` and `mask_shift` zeroes lanes whose derived mask bit is **0** (deactivated) in `MULT_RES` before accumulation; lanes with bit **1** pass through. See [Masking](assembly-syntax.md#masking) for the full algorithm.",
+            ),
+            "execute_fn": "execute_mult_ee",
         },
     },
 

--- a/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
@@ -23,7 +23,7 @@ from typing import Any
 
 from ipu_emu.ipu_state import IpuState, INST_MEM_SIZE, WideVectorArithmetic
 from ipu_emu.regfile import RegFile
-from ipu_emu.ipu_math import ipu_mult, ipu_add, ipu_sub, dtype_one_byte, DType
+from ipu_emu.ipu_math import ipu_mult, ipu_add, ipu_sub, DType
 from ipu_emu.ipu_config import REGISTER_WORD_VALUE_MASK, LR_CR_SCALAR_BITS, Partition
 from ipu_common.instruction_spec import (
     INSTRUCTION_SPEC,
@@ -578,205 +578,191 @@ class Ipu:
         """Execute MULT_NOP: No operation."""
         pass
 
-    def execute_mult_ee(self, *, ra: bytearray | int, cyclic_offset: int,
-                        mask_offset: int, mask_shift: int) -> None:
-        """Execute MULT.EE: Element-wise multiplication."""
-        mult_res = self.state.regfile.raw("mult_res")
+    def _mult_resolve_lcr_scalar(self, src: int) -> int:
+        """Resolve an LcrIdx ``src`` field that addresses a *byte* scalar.
 
-        if self._wide_vector_active():
-            self._wide_assert_lane_aligned_byte_offset("cyclic_offset", cyclic_offset)
-            ra_vals = self._debug_ra_lane_vals(ra)
-            rb_vals = self._debug_rb_lane_vals(cyclic_offset, self.state.regfile)
-            if self.state.wide_vector_arithmetic == WideVectorArithmetic.FP32:
-                for i in range(R_REG_SIZE):
-                    struct.pack_into("<f", mult_res, i * 4, float(ra_vals[i]) * float(rb_vals[i]))
-            else:
-                for i in range(R_REG_SIZE):
-                    struct.pack_into(
-                        "<i", mult_res, i * 4, self._wide_imult32(int(ra_vals[i]), int(rb_vals[i]))
-                    )
-            self._mult_mask_and_shift(mask_offset, mask_shift)
-            return
-
-        dtype = self.state.dtype
-        rb = self.state.regfile.get_r_cyclic_at(cyclic_offset, R_REG_SIZE)
-
-        for i in range(R_REG_SIZE):
-            result = ipu_mult(ra[i], rb[i], dtype)
-            struct.pack_into("<i" if dtype == DType.INT8 else "<f", mult_res, i * 4, result)
-
-        self._mult_mask_and_shift(mask_offset, mask_shift)
-
-    def execute_mult_ee_rr(self, *, ra: bytearray | int,
-                           mask_offset: int, mask_shift: int) -> None:
-        """Execute MULT.EE.RR: multi-element multiply of a mult-stage register by itself.
-
-        ``ra`` selects the MEE mode: R0 → r0-by-r0, R1 → r1-by-r1. Each lane is
-        multiplied by itself (element-wise square), then masked and shifted.
+        If ``src`` encodes an LR, the LR's stored value is itself used as an
+        index (mod 256) into the combined Ra buffer (``R0`` ++ ``R1``). If
+        ``src`` encodes a CR, the CR's low byte is the scalar directly.
         """
-        mult_res = self.state.regfile.raw("mult_res")
+        if src < LR_REG_COUNT:
+            idx = self.state.regfile.get_lr(src) % (2 * R_REG_SIZE)
+            r_buf = self.state.regfile.raw("r")
+            return r_buf[idx]
+        cr_idx = src - LR_REG_COUNT
+        return self.state.regfile.get_cr(cr_idx) & 0xFF
 
-        if self._wide_vector_active():
-            ra_vals = self._debug_ra_lane_vals(ra)
-            if self.state.wide_vector_arithmetic == WideVectorArithmetic.FP32:
-                for i in range(R_REG_SIZE):
-                    struct.pack_into(
-                        "<f", mult_res, i * 4, float(ra_vals[i]) * float(ra_vals[i])
-                    )
-            else:
-                for i in range(R_REG_SIZE):
-                    struct.pack_into(
-                        "<i", mult_res, i * 4,
-                        self._wide_imult32(int(ra_vals[i]), int(ra_vals[i])),
-                    )
-            self._mult_mask_and_shift(mask_offset, mask_shift)
-            return
-
-        dtype = self.state.dtype
-
-        for i in range(R_REG_SIZE):
-            result = ipu_mult(ra[i], ra[i], dtype)
-            struct.pack_into("<i" if dtype == DType.INT8 else "<f", mult_res, i * 4, result)
-
-        self._mult_mask_and_shift(mask_offset, mask_shift)
-
-    def _execute_mult_ve_variant(
-        self,
-        *,
-        pad_128_ones: bool,
-        cyclic_offset: int,
-        mask_offset: int,
-        mask_shift: int,
-        fixed_idx: int,
-    ) -> None:
-        """Shared mult.ve.cyclic / mult.ve.padded implementation."""
-        raw = cyclic_offset & 0xFFFFFFFF
-        co_cyclic = raw % R_CYCLIC_SIZE
-
-        mult_res = self.state.regfile.raw("mult_res")
-
-        if self._wide_vector_active():
-            co_wb = raw if pad_128_ones else co_cyclic
-            self._wide_assert_lane_aligned_byte_offset("cyclic_offset", co_wb)
+    def _mult_resolve_lcr_scalar_wide(self, src: int) -> float | int:
+        """Wide-vector counterpart of ``_mult_resolve_lcr_scalar``."""
+        if src < LR_REG_COUNT:
+            idx = self.state.regfile.get_lr(src) % (2 * R_REG_SIZE)
             r0_vals = self._debug_ra_lane_vals(0)
             r1_vals = self._debug_ra_lane_vals(1)
-            rb_vals = self._debug_rb_lane_vals(co_wb, self.state.regfile)
-            if fixed_idx < R_REG_SIZE:
-                ra_fixed = r0_vals[fixed_idx % R_REG_SIZE]
-            else:
-                ra_fixed = r1_vals[(fixed_idx - R_REG_SIZE) % R_REG_SIZE]
-            if self.state.wide_vector_arithmetic == WideVectorArithmetic.FP32:
-                one = 1.0
-                for i in range(R_REG_SIZE):
-                    pos = co_wb + i * 4
-                    if pad_128_ones and pos + 4 > R_CYCLIC_SIZE:
-                        rb_lane = one
-                    else:
-                        rb_lane = float(rb_vals[i])
-                    struct.pack_into("<f", mult_res, i * 4, float(ra_fixed) * rb_lane)
-            else:
-                one = 1
-                for i in range(R_REG_SIZE):
-                    pos = co_wb + i * 4
-                    if pad_128_ones and pos + 4 > R_CYCLIC_SIZE:
-                        rb_lane = one
-                    else:
-                        rb_lane = int(rb_vals[i])
-                    struct.pack_into(
-                        "<i", mult_res, i * 4, self._wide_imult32(int(ra_fixed), rb_lane)
-                    )
-            self._mult_mask_and_shift(mask_offset, mask_shift)
-            return
+            return r0_vals[idx] if idx < R_REG_SIZE else r1_vals[idx - R_REG_SIZE]
+        cr_idx = src - LR_REG_COUNT
+        cr_scalar = self._wide_cr_scalar_byte_as_int32(cr_idx)
+        if self.state.wide_vector_arithmetic == WideVectorArithmetic.FP32:
+            return float(cr_scalar)
+        return cr_scalar
 
-        dtype = self.state.dtype
-        r_buf = self.state.regfile.raw("r")  # 256 bytes: [0:128]=r0, [128:256]=r1
-        rc_buf = self.state.regfile.raw("r_cyclic")
-        one_byte = dtype_one_byte(dtype)
-        fmt = "<i" if dtype == DType.INT8 else "<f"
-
-        ra_fixed = r_buf[fixed_idx % (2 * R_REG_SIZE)]
-
-        if pad_128_ones:
-            for i in range(R_REG_SIZE):
-                pos = raw + i
-                rb_byte = rc_buf[pos] if pos < R_CYCLIC_SIZE else one_byte
-                result = ipu_mult(ra_fixed, rb_byte, dtype)
-                struct.pack_into(fmt, mult_res, i * 4, result)
-        else:
-            base = co_cyclic
-            for i in range(R_REG_SIZE):
-                pos = base + i
-                rb_byte = rc_buf[pos % R_CYCLIC_SIZE]
-                result = ipu_mult(ra_fixed, rb_byte, dtype)
-                struct.pack_into(fmt, mult_res, i * 4, result)
-
-        self._mult_mask_and_shift(mask_offset, mask_shift)
-
-    def execute_mult_ve_cyclic(self, *, cyclic_offset: int,
-                               mask_offset: int, mask_shift: int, fixed_idx: int) -> None:
-        """Execute MULT.VE.CYCLIC: fixed r0/r1 element × r_cyclic row with cyclic addressing."""
-        self._execute_mult_ve_variant(
-            pad_128_ones=False,
-            cyclic_offset=cyclic_offset,
-            mask_offset=mask_offset,
-            mask_shift=mask_shift,
-            fixed_idx=fixed_idx,
-        )
-
-    def execute_mult_ve_padded(self, *, cyclic_offset: int,
-                               mask_offset: int, mask_shift: int, fixed_idx: int) -> None:
-        """Execute MULT.VE.PADDED: fixed r0/r1 element × r_cyclic row with boundary padding."""
-        self._execute_mult_ve_variant(
-            pad_128_ones=True,
-            cyclic_offset=cyclic_offset,
-            mask_offset=mask_offset,
-            mask_shift=mask_shift,
-            fixed_idx=fixed_idx,
-        )
-
-    def execute_mult_ve_cr(self, *, cyclic_offset: int, mask_offset: int,
-                           mask_shift: int, cr_idx: int) -> None:
-        """Execute MULT.VE.CR: CR scalar × r_cyclic elements with boundary padding.
-
-        Multiplies the low byte of CR[cr_idx] against each byte of
-        RC[cyclic_offset : cyclic_offset+128]. Like mult.ve.padded, this is
-        non-cyclic: elements where cyclic_offset+i >= R_CYCLIC_SIZE are
-        padded with the dtype-specific encoding of 1 instead of wrapping.
-        """
-        dtype = self.state.dtype
+    def execute_mult_rc_vv(self, *, rc_idx: int, ra: bytearray | int,
+                           mask_offset: int, mask_shift: int) -> None:
+        """Execute MULT.RC.VV: R_CYCLIC vector × Ra (R0/R1) vector, element-wise."""
         mult_res = self.state.regfile.raw("mult_res")
 
         if self._wide_vector_active():
-            self._wide_assert_lane_aligned_byte_offset("cyclic_offset", cyclic_offset)
-            cr_scalar = self._wide_cr_scalar_byte_as_int32(cr_idx)
-            rb_vals = self._debug_rb_lane_vals(cyclic_offset, self.state.regfile)
+            self._wide_assert_lane_aligned_byte_offset("rc_idx", rc_idx)
+            ra_vals = self._debug_ra_lane_vals(ra)
+            rb_vals = self._debug_rb_lane_vals(rc_idx, self.state.regfile)
             if self.state.wide_vector_arithmetic == WideVectorArithmetic.FP32:
-                scalar_f = float(cr_scalar)
-                one = 1.0
                 for i in range(R_REG_SIZE):
-                    pos = cyclic_offset + i * 4
-                    rb_lane = float(rb_vals[i]) if pos + 4 <= R_CYCLIC_SIZE else one
-                    struct.pack_into("<f", mult_res, i * 4, scalar_f * rb_lane)
+                    struct.pack_into("<f", mult_res, i * 4, float(rb_vals[i]) * float(ra_vals[i]))
             else:
-                one = 1
                 for i in range(R_REG_SIZE):
-                    pos = cyclic_offset + i * 4
-                    rb_lane = int(rb_vals[i]) if pos + 4 <= R_CYCLIC_SIZE else one
                     struct.pack_into(
-                        "<i", mult_res, i * 4, self._wide_imult32(cr_scalar, rb_lane)
+                        "<i", mult_res, i * 4, self._wide_imult32(int(rb_vals[i]), int(ra_vals[i]))
                     )
             self._mult_mask_and_shift(mask_offset, mask_shift)
             return
 
-        scalar_byte = self.state.regfile.get_cr(cr_idx) & 0xFF
-        rc_buf = self.state.regfile.raw("r_cyclic")
-        one_byte = dtype_one_byte(dtype)
+        dtype = self.state.dtype
+        rc = self.state.regfile.get_r_cyclic_at(rc_idx, R_REG_SIZE)
+
+        for i in range(R_REG_SIZE):
+            result = ipu_mult(rc[i], ra[i], dtype)
+            struct.pack_into("<i" if dtype == DType.INT8 else "<f", mult_res, i * 4, result)
+
+        self._mult_mask_and_shift(mask_offset, mask_shift)
+
+    def execute_mult_rc_ve(self, *, rc_idx: int, src: int,
+                           mask_offset: int, mask_shift: int) -> None:
+        """Execute MULT.RC.VE: R_CYCLIC vector × scalar (R0/R1 element or CR value)."""
+        mult_res = self.state.regfile.raw("mult_res")
+
+        if self._wide_vector_active():
+            self._wide_assert_lane_aligned_byte_offset("rc_idx", rc_idx)
+            scalar = self._mult_resolve_lcr_scalar_wide(src)
+            rb_vals = self._debug_rb_lane_vals(rc_idx, self.state.regfile)
+            if self.state.wide_vector_arithmetic == WideVectorArithmetic.FP32:
+                scalar_f = float(scalar)
+                for i in range(R_REG_SIZE):
+                    struct.pack_into("<f", mult_res, i * 4, float(rb_vals[i]) * scalar_f)
+            else:
+                scalar_i = int(scalar)
+                for i in range(R_REG_SIZE):
+                    struct.pack_into(
+                        "<i", mult_res, i * 4, self._wide_imult32(int(rb_vals[i]), scalar_i)
+                    )
+            self._mult_mask_and_shift(mask_offset, mask_shift)
+            return
+
+        dtype = self.state.dtype
+        scalar_byte = self._mult_resolve_lcr_scalar(src)
+        rc = self.state.regfile.get_r_cyclic_at(rc_idx, R_REG_SIZE)
         fmt = "<i" if dtype == DType.INT8 else "<f"
 
         for i in range(R_REG_SIZE):
-            pos = cyclic_offset + i
-            rb_byte = rc_buf[pos] if pos < R_CYCLIC_SIZE else one_byte
-            result = ipu_mult(scalar_byte, rb_byte, dtype)
+            result = ipu_mult(rc[i], scalar_byte, dtype)
+            struct.pack_into(fmt, mult_res, i * 4, result)
+
+        self._mult_mask_and_shift(mask_offset, mask_shift)
+
+    def execute_mult_rc_vs(self, *, rc_idx: int,
+                           mask_offset: int, mask_shift: int) -> None:
+        """Execute MULT.RC.VS: R_CYCLIC vector self-multiply (square), element-wise."""
+        mult_res = self.state.regfile.raw("mult_res")
+
+        if self._wide_vector_active():
+            self._wide_assert_lane_aligned_byte_offset("rc_idx", rc_idx)
+            rb_vals = self._debug_rb_lane_vals(rc_idx, self.state.regfile)
+            if self.state.wide_vector_arithmetic == WideVectorArithmetic.FP32:
+                for i in range(R_REG_SIZE):
+                    struct.pack_into("<f", mult_res, i * 4, float(rb_vals[i]) * float(rb_vals[i]))
+            else:
+                for i in range(R_REG_SIZE):
+                    struct.pack_into(
+                        "<i", mult_res, i * 4, self._wide_imult32(int(rb_vals[i]), int(rb_vals[i]))
+                    )
+            self._mult_mask_and_shift(mask_offset, mask_shift)
+            return
+
+        dtype = self.state.dtype
+        rc = self.state.regfile.get_r_cyclic_at(rc_idx, R_REG_SIZE)
+        fmt = "<i" if dtype == DType.INT8 else "<f"
+
+        for i in range(R_REG_SIZE):
+            result = ipu_mult(rc[i], rc[i], dtype)
+            struct.pack_into(fmt, mult_res, i * 4, result)
+
+        self._mult_mask_and_shift(mask_offset, mask_shift)
+
+    def execute_mult_ve(self, *, ra_idx: int, cr_idx: int,
+                        mask_offset: int, mask_shift: int) -> None:
+        """Execute MULT.VE: Ra (combined R0/R1) vector × CR scalar, element-wise."""
+        mult_res = self.state.regfile.raw("mult_res")
+
+        if self._wide_vector_active():
+            r0_vals = self._debug_ra_lane_vals(0)
+            r1_vals = self._debug_ra_lane_vals(1)
+            cr_scalar = self._wide_cr_scalar_byte_as_int32(cr_idx)
+            if self.state.wide_vector_arithmetic == WideVectorArithmetic.FP32:
+                scalar_f = float(cr_scalar)
+                for i in range(R_REG_SIZE):
+                    pos = (ra_idx + i) % (2 * R_REG_SIZE)
+                    ra_lane = r0_vals[pos] if pos < R_REG_SIZE else r1_vals[pos - R_REG_SIZE]
+                    struct.pack_into("<f", mult_res, i * 4, float(ra_lane) * scalar_f)
+            else:
+                for i in range(R_REG_SIZE):
+                    pos = (ra_idx + i) % (2 * R_REG_SIZE)
+                    ra_lane = r0_vals[pos] if pos < R_REG_SIZE else r1_vals[pos - R_REG_SIZE]
+                    struct.pack_into(
+                        "<i", mult_res, i * 4, self._wide_imult32(int(ra_lane), cr_scalar)
+                    )
+            self._mult_mask_and_shift(mask_offset, mask_shift)
+            return
+
+        dtype = self.state.dtype
+        scalar_byte = self.state.regfile.get_cr(cr_idx) & 0xFF
+        r_buf = self.state.regfile.raw("r")  # 256 bytes: [0:128]=r0, [128:256]=r1
+        fmt = "<i" if dtype == DType.INT8 else "<f"
+
+        for i in range(R_REG_SIZE):
+            pos = (ra_idx + i) % (2 * R_REG_SIZE)
+            result = ipu_mult(r_buf[pos], scalar_byte, dtype)
+            struct.pack_into(fmt, mult_res, i * 4, result)
+
+        self._mult_mask_and_shift(mask_offset, mask_shift)
+
+    def execute_mult_ee(self, *, ra_idx: int, cr_idx: int,
+                        mask_offset: int, mask_shift: int) -> None:
+        """Execute MULT.EE: single Ra element × CR scalar, broadcast to all 128 lanes."""
+        mult_res = self.state.regfile.raw("mult_res")
+
+        if self._wide_vector_active():
+            r0_vals = self._debug_ra_lane_vals(0)
+            r1_vals = self._debug_ra_lane_vals(1)
+            cr_scalar = self._wide_cr_scalar_byte_as_int32(cr_idx)
+            pos = ra_idx % (2 * R_REG_SIZE)
+            ra_lane = r0_vals[pos] if pos < R_REG_SIZE else r1_vals[pos - R_REG_SIZE]
+            if self.state.wide_vector_arithmetic == WideVectorArithmetic.FP32:
+                result = float(ra_lane) * float(cr_scalar)
+                for i in range(R_REG_SIZE):
+                    struct.pack_into("<f", mult_res, i * 4, result)
+            else:
+                result = self._wide_imult32(int(ra_lane), cr_scalar)
+                for i in range(R_REG_SIZE):
+                    struct.pack_into("<i", mult_res, i * 4, result)
+            self._mult_mask_and_shift(mask_offset, mask_shift)
+            return
+
+        dtype = self.state.dtype
+        scalar_byte = self.state.regfile.get_cr(cr_idx) & 0xFF
+        r_buf = self.state.regfile.raw("r")  # 256 bytes: [0:128]=r0, [128:256]=r1
+        fmt = "<i" if dtype == DType.INT8 else "<f"
+
+        ra_byte = r_buf[ra_idx % (2 * R_REG_SIZE)]
+        result = ipu_mult(ra_byte, scalar_byte, dtype)
+        for i in range(R_REG_SIZE):
             struct.pack_into(fmt, mult_res, i * 4, result)
 
         self._mult_mask_and_shift(mask_offset, mask_shift)

--- a/src/tools/ipu-emu-py/test/test_execute.py
+++ b/src/tools/ipu-emu-py/test/test_execute.py
@@ -371,7 +371,7 @@ BKPT;;
         assert r1_data == bytearray(test_data)
 
     def test_store_to_memory(self):
-        """INT8: r1=all-2, cyclic=all-3, MULT.EE → acc should be 6 per word."""
+        """INT8: r1=all-2, cyclic=all-3, MULT.RC.VV → acc should be 6 per word."""
         r1_data = bytes([2] * 128)
         cyclic_data = bytes([3] * 512)
 
@@ -382,7 +382,7 @@ SET lr14 cr9;;
 SET lr15 cr10;;
 LDR_CYCLIC_MULT_REG lr14 cr0 lr15;;
 RESET_ACC;;
-MULT.EE r1 lr0 0 lr0;
+MULT.RC.VV lr0 r1 0 lr0;
 ACC;;
 SET lr0 cr11;;
 STR_ACC_REG lr0 cr0;;
@@ -483,7 +483,7 @@ LDR_MULT_MASK_REG lr3 cr0;;
 RESET_ACC;;
 SET lr5 cr10;;
 SET lr6 cr10;;
-MULT.EE r0 lr6 0 lr5;
+MULT.RC.VV lr6 r0 0 lr5;
 ACC;;
 SET lr9 cr12;;
 STR_ACC_REG lr9 cr0;;
@@ -522,7 +522,7 @@ LDR_MULT_MASK_REG lr3 cr0;;
 RESET_ACC;;
 SET lr5 cr12;;
 SET lr6 cr10;;
-MULT.EE r0 lr6 1 lr5;
+MULT.RC.VV lr6 r0 1 lr5;
 ACC;;
 SET lr9 cr13;;
 STR_ACC_REG lr9 cr0;;
@@ -1264,7 +1264,7 @@ LDR_CYCLIC_MULT_REG lr1 cr0 lr2;;
 RESET_ACC;;
 SET lr5 cr10;;
 SET lr6 cr10;;
-MULT.EE r0 lr6 0 lr5;
+MULT.RC.VV lr6 r0 0 lr5;
 ACC;;
 BKPT;;
 """,
@@ -1283,19 +1283,19 @@ BKPT;;
 
 
 # ============================================================================
-# MULT.VE.CR
+# MULT.RC.VE
 # ============================================================================
 
 
-class TestMultVeCr:
-    """Tests for the MULT.VE.CR instruction."""
+class TestMultRcVe:
+    """Tests for the MULT.RC.VE instruction."""
 
     # ------------------------------------------------------------------
-    # MULT.VE.CR
+    # MULT.RC.VE with a CR-encoded scalar source
     # ------------------------------------------------------------------
 
-    def test_mult_ve_cr_int8(self):
-        """MULT.VE.CR INT8: scalar from CR × RC elements."""
+    def test_mult_rc_ve_cr_int8(self):
+        """MULT.RC.VE INT8: scalar from CR × RC elements."""
         # CR scalar byte = 3, RC elements = all 2 → each result = 3*2 = 6
         cyclic_data = bytes([2] * 512)
 
@@ -1306,7 +1306,7 @@ LDR_CYCLIC_MULT_REG lr0 cr0 lr1;;
 RESET_ACC;;
 SET lr2 cr9;;
 SET lr4 cr9;;
-MULT.VE.CR lr2 0 lr4 cr3;
+MULT.RC.VE lr2 cr3 0 lr4;
 ACC;;
 BKPT;;
 """,
@@ -1321,8 +1321,8 @@ BKPT;;
             val = struct.unpack_from("<i", acc_raw, i * 4)[0]
             assert val == 6, f"acc word {i}: expected 6, got {val}"
 
-    def test_mult_ve_cr_negative_int8(self):
-        """MULT.VE.CR INT8: signed negative scalar × positive RC elements."""
+    def test_mult_rc_ve_cr_negative_int8(self):
+        """MULT.RC.VE INT8: signed negative scalar × positive RC elements."""
         # CR scalar byte = 0xFE = -2 (signed int8), RC elements = 5 → result = -10
         cyclic_data = bytes([5] * 512)
 
@@ -1333,7 +1333,7 @@ LDR_CYCLIC_MULT_REG lr0 cr0 lr1;;
 RESET_ACC;;
 SET lr2 cr9;;
 SET lr4 cr9;;
-MULT.VE.CR lr2 0 lr4 cr2;
+MULT.RC.VE lr2 cr2 0 lr4;
 ACC;;
 BKPT;;
 """,
@@ -1348,18 +1348,17 @@ BKPT;;
             val = struct.unpack_from("<i", acc_raw, i * 4)[0]
             assert val == -10, f"acc word {i}: expected -10, got {val}"
 
-    def test_mult_ve_cr_boundary_padding(self):
-        """MULT.VE.CR: elements beyond RC boundary (512 bytes) are padded with int8 1."""
-        # cyclic_offset = 450, so first 62 bytes come from RC, remaining 66 are padded with 1
-        rc_fill = 4  # RC filled with 4
+    def test_mult_rc_ve_cr_wraps_at_rc_boundary(self):
+        """MULT.RC.VE: RC indices wrap modulo 512 (cyclic, no padding)."""
+        # rc_idx = 450, so bytes 450..511 then 0..65 of RC are used — all rc_fill.
+        rc_fill = 4
         scalar = 7
-        pad_start = 62  # 512 - 450 = 62 elements in bounds
 
         state = _make_state("""\
 RESET_ACC;;
 SET lr2 cr8;;
 SET lr4 cr9;;
-MULT.VE.CR lr2 0 lr4 cr3;
+MULT.RC.VE lr2 cr3 0 lr4;
 ACC;;
 BKPT;;
 """,
@@ -1371,15 +1370,12 @@ BKPT;;
         run_until_complete(state)
 
         acc_raw = state.regfile.raw("r_acc")
-        for i in range(pad_start):
+        for i in range(128):
             val = struct.unpack_from("<i", acc_raw, i * 4)[0]
             assert val == scalar * rc_fill, f"word {i}: expected {scalar * rc_fill}, got {val}"
-        for i in range(pad_start, 128):
-            val = struct.unpack_from("<i", acc_raw, i * 4)[0]
-            assert val == scalar * 1, f"word {i} (padded): expected {scalar}, got {val}"
 
-    def test_mult_ve_cr_fp8e4m3(self):
-        """MULT.VE.CR fp8_e4: scalar 1.0 × RC elements 1.0 → result 1.0 each."""
+    def test_mult_rc_ve_cr_fp8e4m3(self):
+        """MULT.RC.VE fp8_e4: scalar 1.0 × RC elements 1.0 → result 1.0 each."""
         from ipu_emu.ipu_math import _float32_to_fp8_scalar
 
         one_fp8 = _float32_to_fp8_scalar(1.0, 4)
@@ -1392,7 +1388,7 @@ LDR_CYCLIC_MULT_REG lr0 cr0 lr1;;
 RESET_ACC;;
 SET lr2 cr9;;
 SET lr4 cr9;;
-MULT.VE.CR lr2 0 lr4 cr5;
+MULT.RC.VE lr2 cr5 0 lr4;
 ACC;;
 BKPT;;
 """,
@@ -1407,8 +1403,8 @@ BKPT;;
             val = struct.unpack_from("<f", acc_raw, i * 4)[0]
             assert abs(val - 1.0) < 0.01, f"acc word {i}: expected 1.0, got {val}"
 
-    def test_mult_ve_cr_boundary_padding_fp8e5m2(self):
-        """MULT.VE.CR fp8_e5: boundary elements padded with FP8 1.0."""
+    def test_mult_rc_ve_cr_wraps_fp8e5m2(self):
+        """MULT.RC.VE fp8_e5: RC indices wrap modulo 512 (cyclic, no padding)."""
         from ipu_emu.ipu_math import _float32_to_fp8_scalar
 
         two_fp8 = _float32_to_fp8_scalar(2.0, 5)
@@ -1418,7 +1414,7 @@ BKPT;;
 RESET_ACC;;
 SET lr2 cr8;;
 SET lr4 cr9;;
-MULT.VE.CR lr2 0 lr4 cr6;
+MULT.RC.VE lr2 cr6 0 lr4;
 ACC;;
 BKPT;;
 """,
@@ -1430,19 +1426,16 @@ BKPT;;
         run_until_complete(state)
 
         acc_raw = state.regfile.raw("r_acc")
-        for i in range(12):  # in-bounds (500..511): 3.0 * 2.0 = 6.0
+        for i in range(128):  # wraps modulo 512: every word reads 2.0 → 3.0 * 2.0 = 6.0
             val = struct.unpack_from("<f", acc_raw, i * 4)[0]
             assert abs(val - 6.0) < 0.1, f"word {i}: expected 6.0, got {val}"
-        for i in range(12, 128):  # padded (>=512): 3.0 * 1.0 = 3.0
-            val = struct.unpack_from("<f", acc_raw, i * 4)[0]
-            assert abs(val - 3.0) < 0.1, f"word {i} (padded): expected 3.0, got {val}"
 
     # ------------------------------------------------------------------
-    # Backward compatibility: existing instructions unaffected
+    # MULT.RC.VV / MULT.RC.VE behave correctly alongside each other
     # ------------------------------------------------------------------
 
-    def test_backward_compat_mult_ee(self):
-        """MULT.EE still works correctly after adding new mult variants."""
+    def test_mult_rc_vv_still_works(self):
+        """MULT.RC.VV still works correctly after adding MULT.RC.VE."""
         r0_data = bytes([4] * 128)
         cyclic_data = bytes([5] * 512)
 
@@ -1453,7 +1446,7 @@ SET lr1 cr9;;
 SET lr2 cr10;;
 LDR_CYCLIC_MULT_REG lr1 cr0 lr2;;
 RESET_ACC;;
-MULT.EE r0 lr2 0 lr2;
+MULT.RC.VV lr2 r0 0 lr2;
 ACC;;
 BKPT;;
 """,
@@ -1468,12 +1461,11 @@ BKPT;;
             val = struct.unpack_from("<i", acc_raw, i * 4)[0]
             assert val == 20, f"acc word {i}: expected 20, got {val}"
 
-    def test_backward_compat_mult_ve(self):
-        """MULT.VE.CYCLIC still works correctly after adding new mult variants."""
+    def test_mult_rc_ve_lr_scalar(self):
+        """MULT.RC.VE: src as LR uses the LR's value to index into R0 (combined Ra buffer)."""
         cyclic_data = bytes([6] * 512)
-        r0_data = bytes([0] * 128)
-        r0_data = bytearray(r0_data)
-        r0_data[0] = 3  # fixed_idx=0 → r0[0] = 3
+        r0_data = bytearray(128)
+        r0_data[0] = 3  # LR value 0 → Ra[0] = 3
 
         state = _make_state("""\
 SET lr0 cr8;;
@@ -1482,7 +1474,7 @@ SET lr1 cr9;;
 SET lr2 cr10;;
 LDR_CYCLIC_MULT_REG lr1 cr0 lr2;;
 RESET_ACC;;
-MULT.VE.CYCLIC lr2 0 lr2 lr2;
+MULT.RC.VE lr2 lr2 0 lr2;
 ACC;;
 BKPT;;
 """,
@@ -1497,77 +1489,11 @@ BKPT;;
             val = struct.unpack_from("<i", acc_raw, i * 4)[0]
             assert val == 18, f"acc word {i}: expected 18, got {val}"
 
-    def test_mult_ve_cyclic_wrap_at_rc_boundary(self):
-        """MULT.VE.CYCLIC: RC indices wrap modulo 512."""
-        # cyclic_offset = 450, so without wrap we'd read past 512; with wrap, bytes
-        # 450..511 then 0..65 of RC are used — all rc_fill.
-        rc_fill = 4
-        scalar = 5
-
-        r0_data = bytearray(128)
-        r0_data[0] = scalar  # fixed_idx=0 → r0[0] = 5
-
-        state = _make_state("""\
-SET lr0 cr8;;
-LDR_MULT_REG r0 lr0 cr0;;
-RESET_ACC;;
-SET lr2 cr9;;
-SET lr4 cr10;;
-SET lr5 cr10;;
-MULT.VE.CYCLIC lr2 0 lr4 lr5;
-ACC;;
-BKPT;;
-""",
-            cr={8: 4096, 9: 450, 10: 0})
-        state.dtype = DType.INT8
-        state.xmem.write_address(0x1000, bytes(r0_data))
-        state.regfile.set_r_cyclic_at(0, bytes([rc_fill] * 512))
-        run_until_complete(state)
-
-        acc_raw = state.regfile.raw("r_acc")
-        for i in range(128):
-            val = struct.unpack_from("<i", acc_raw, i * 4)[0]
-            assert val == scalar * rc_fill, f"word {i}: expected {scalar * rc_fill}, got {val}"
-
-    def test_mult_ve_padded_boundary(self):
-        """MULT.VE.PADDED: elements past RC byte 511 use dtype 1."""
-        rc_fill = 4
-        scalar = 5
-        pad_start = 62  # 512 - 450 = 62 elements in bounds before padding
-
-        r0_data = bytearray(128)
-        r0_data[0] = scalar
-
-        state = _make_state("""\
-SET lr0 cr8;;
-LDR_MULT_REG r0 lr0 cr0;;
-RESET_ACC;;
-SET lr2 cr9;;
-SET lr4 cr10;;
-SET lr5 cr10;;
-MULT.VE.PADDED lr2 0 lr4 lr5;
-ACC;;
-BKPT;;
-""",
-            cr={8: 4096, 9: 450, 10: 0})
-        state.dtype = DType.INT8
-        state.xmem.write_address(0x1000, bytes(r0_data))
-        state.regfile.set_r_cyclic_at(0, bytes([rc_fill] * 512))
-        run_until_complete(state)
-
-        acc_raw = state.regfile.raw("r_acc")
-        for i in range(pad_start):
-            val = struct.unpack_from("<i", acc_raw, i * 4)[0]
-            assert val == scalar * rc_fill, f"word {i}: expected {scalar * rc_fill}, got {val}"
-        for i in range(pad_start, 128):
-            val = struct.unpack_from("<i", acc_raw, i * 4)[0]
-            assert val == scalar * 1, f"word {i} (padded): expected {scalar}, got {val}"
-
-    def test_mult_ve_r1_scalar(self):
-        """MULT.VE.CYCLIC: fixed_idx in [128, 255] addresses R1[fixed_idx - 128] instead of R0."""
+    def test_mult_rc_ve_r1_scalar(self):
+        """MULT.RC.VE: src LR value in [128, 255] addresses R1[value - 128] instead of R0."""
         r0_data = bytearray(128)  # all zeros — must not be picked
         r1_data = bytearray(128)
-        r1_data[0] = 7  # fixed_idx=128 → r1[0] = 7
+        r1_data[0] = 7  # LR value=128 → r1[0] = 7
         cyclic_data = bytes([4] * 512)
 
         state = _make_state("""\
@@ -1580,7 +1506,7 @@ SET lr2 cr11;;
 LDR_CYCLIC_MULT_REG lr1 cr0 lr2;;
 RESET_ACC;;
 SET lr3 cr12;;
-MULT.VE.CYCLIC lr2 0 lr2 lr3;
+MULT.RC.VE lr2 lr3 0 lr2;
 ACC;;
 BKPT;;
 """,
@@ -1597,25 +1523,26 @@ BKPT;;
             assert val == 28, f"acc word {i}: expected 28 (r1[0]=7 × cyclic[i]=4), got {val}"
 
 
-class TestMultEeRr:
-    """MULT.EE.RR — multi-element execution (MEE): r0-by-r0 or r1-by-r1."""
+class TestMultRcVs:
+    """MULT.RC.VS — self-multiply (square) of RC vector elements."""
 
-    def test_mult_ee_rr_r0_by_r0(self):
-        """MEE mode R0: each lane multiplied by itself (4 × 4 = 16)."""
-        r0_data = bytes([4] * 128)
+    def test_mult_rc_vs_squares_rc(self):
+        """Each RC lane multiplied by itself (4 × 4 = 16)."""
+        cyclic_data = bytes([4] * 512)
 
         state = _make_state("""\
 SET lr0 cr8;;
-LDR_MULT_REG r0 lr0 cr0;;
+SET lr1 cr9;;
+LDR_CYCLIC_MULT_REG lr0 cr0 lr1;;
 RESET_ACC;;
 SET lr5 cr9;;
-MULT.EE.RR r0 0 lr5;
+MULT.RC.VS lr1 0 lr5;
 ACC;;
 BKPT;;
 """,
             cr={8: 4096, 9: 0})
         state.dtype = DType.INT8
-        state.xmem.write_address(0x1000, r0_data)
+        state.xmem.write_address(0x1000, cyclic_data)
         run_until_complete(state)
 
         acc_raw = state.regfile.raw("r_acc")
@@ -1623,54 +1550,50 @@ BKPT;;
             val = struct.unpack_from("<i", acc_raw, i * 4)[0]
             assert val == 16, f"acc word {i}: expected 16 (4×4), got {val}"
 
-    def test_mult_ee_rr_r1_by_r1(self):
-        """MEE mode R1 squares r1 (3 × 3 = 9); r0 holds a decoy value."""
-        r0_data = bytes([9] * 128)   # decoy — must be ignored when ra=R1
-        r1_data = bytes([3] * 128)
+    def test_mult_rc_vs_wraps_at_boundary(self):
+        """rc_idx near the 512-byte boundary wraps cyclically (3 × 3 = 9)."""
+        cyclic_data = bytes([3] * 512)
 
         state = _make_state("""\
-SET lr0 cr8;;
-LDR_MULT_REG r0 lr0 cr0;;
-SET lr1 cr9;;
-LDR_MULT_REG r1 lr1 cr0;;
 RESET_ACC;;
-SET lr5 cr10;;
-MULT.EE.RR r1 0 lr5;
+SET lr2 cr10;;
+SET lr5 cr11;;
+MULT.RC.VS lr2 0 lr5;
 ACC;;
 BKPT;;
 """,
-            cr={8: 4096, 9: 4352, 10: 0})
+            cr={10: 450, 11: 0})
         state.dtype = DType.INT8
-        state.xmem.write_address(0x1000, r0_data)
-        state.xmem.write_address(0x1100, r1_data)
+        state.regfile.set_r_cyclic_at(0, cyclic_data)
         run_until_complete(state)
 
         acc_raw = state.regfile.raw("r_acc")
         for i in range(128):
             val = struct.unpack_from("<i", acc_raw, i * 4)[0]
-            assert val == 9, f"acc word {i}: expected 9 (r1 3×3, not r0), got {val}"
+            assert val == 9, f"acc word {i}: expected 9 (3×3), got {val}"
 
-    def test_mult_ee_rr_mask_zeroes_lanes(self):
+    def test_mult_rc_vs_mask_zeroes_lanes(self):
         """mask_offset/mask_shift still gate lanes (first 64 active, rest zeroed)."""
-        r0_data = bytes([3] * 128)   # squared → 9
+        cyclic_data = bytes([3] * 512)   # squared → 9
         mask_data = bytearray(128)
         for i in range(8):           # 64 bits set → first 64 lanes active
             mask_data[i] = 0xFF
 
         state = _make_state("""\
 SET lr0 cr8;;
-LDR_MULT_REG r0 lr0 cr0;;
-SET lr3 cr9;;
+SET lr1 cr9;;
+LDR_CYCLIC_MULT_REG lr0 cr0 lr1;;
+SET lr3 cr10;;
 LDR_MULT_MASK_REG lr3 cr0;;
 RESET_ACC;;
-SET lr5 cr10;;
-MULT.EE.RR r0 0 lr5;
+SET lr5 cr9;;
+MULT.RC.VS lr1 0 lr5;
 ACC;;
 BKPT;;
 """,
-            cr={8: 4096, 9: 8192, 10: 0})
+            cr={8: 4096, 9: 0, 10: 8192})
         state.dtype = DType.INT8
-        state.xmem.write_address(0x1000, r0_data)
+        state.xmem.write_address(0x1000, cyclic_data)
         state.xmem.write_address(0x2000, bytes(mask_data))
         run_until_complete(state)
 
@@ -1699,20 +1622,21 @@ class TestMaskShiftSequential:
     The partition_vector is derived from CR15.partition (0 = no partitioning).
     """
 
-    _R0_ADDR = 0x1000   # xmem address for R0 data
+    _RC_ADDR = 0x1000   # xmem address for R_CYCLIC data
     _MASK_ADDR = 0x2000  # xmem address for mask data
-    _R0_CR = 8           # CR holding R0 xmem address
+    _RC_CR = 8           # CR holding R_CYCLIC xmem address
     _MASK_CR = 9         # CR holding mask xmem address
     _SHIFT_CR = 2        # CR holding mask_shift_idx (set per test)
 
     _ASM = """\
 SET lr0 cr8;;
-LDR_MULT_REG r0 lr0 cr0;;
+SET lr1 cr0;;
+LDR_CYCLIC_MULT_REG lr0 cr0 lr1;;
 SET lr3 cr9;;
 LDR_MULT_MASK_REG lr3 cr0;;
 RESET_ACC;;
 SET lr5 cr2;;
-MULT.EE.RR r0 0 lr5;
+MULT.RC.VS lr1 0 lr5;
 ACC;;
 BKPT;;
 """
@@ -1724,19 +1648,19 @@ BKPT;;
         shift_idx: int,
         partition: int = 0,
     ) -> bytearray:
-        """Run MULT.EE.RR with given 128-bit base mask and mask_shift_idx; return r_acc."""
+        """Run MULT.RC.VS with given 128-bit base mask and mask_shift_idx; return r_acc."""
         mask_bytes = base_mask_bits.to_bytes(16, byteorder="little") + bytes(112)
         state = _make_state(
             self._ASM,
             cr={
-                self._R0_CR: self._R0_ADDR,
+                self._RC_CR: self._RC_ADDR,
                 self._MASK_CR: self._MASK_ADDR,
                 self._SHIFT_CR: shift_idx & 0xFFFFFFFF,
             },
         )
         state.dtype = DType.INT8
         state.set_cr_dstructure(valid_elements=128, partition=partition)
-        state.xmem.write_address(self._R0_ADDR, bytes([2] * 128))
+        state.xmem.write_address(self._RC_ADDR, bytes([2] * 512))
         state.xmem.write_address(self._MASK_ADDR, mask_bytes)
         run_until_complete(state)
         return state.regfile.raw("r_acc")

--- a/src/tools/ipu-emu-py/test/test_stats.py
+++ b/src/tools/ipu-emu-py/test/test_stats.py
@@ -85,10 +85,10 @@ class TestStatsCountedDuringExecution:
 
     def test_mult_active_counted(self):
         # LDR_MULT_REG (1 read) + MULT.EE in one cycle, then BKPT
-        # MULT.EE syntax: ra, cyclic_offset(LR), mask_offset(imm), mask_shift(LR)
+        # MULT.EE syntax: ra_idx(LR), cr_idx(CR), mask_offset(imm), mask_shift(LR)
         asm = """\
 SET lr0 cr0;;
-LDR_MULT_REG r0 lr0 cr0;MULT.EE r0 lr0 0 lr0;;
+LDR_MULT_REG r0 lr0 cr0;MULT.EE lr0 cr0 0 lr0;;
 BKPT;;
 """
         state = IpuState()

--- a/src/tools/ipu-emu-py/test/test_wide_vector_debug.py
+++ b/src/tools/ipu-emu-py/test/test_wide_vector_debug.py
@@ -59,7 +59,7 @@ SET lr2 cr8;;
 LDR_MULT_REG r0 lr0 cr0;;
 LDR_CYCLIC_MULT_REG lr1 cr0 lr2;;
 RESET_ACC;;
-MULT.EE r0 lr2 0 lr2;;
+MULT.RC.VV lr2 r0 0 lr2;;
 acc.first;;
 BKPT;;
 """
@@ -83,7 +83,7 @@ SET lr2 cr8;;
 LDR_MULT_REG r0 lr0 cr0;;
 LDR_CYCLIC_MULT_REG lr1 cr0 lr2;;
 RESET_ACC;;
-MULT.EE r0 lr2 0 lr2;;
+MULT.RC.VV lr2 r0 0 lr2;;
 acc.first;;
 SET lr0 cr9;;
 ACTIVATE identity 0;;
@@ -113,7 +113,7 @@ SET lr2 cr8;;
 LDR_MULT_REG r0 lr0 cr0;;
 LDR_CYCLIC_MULT_REG lr1 cr0 lr2;;
 RESET_ACC;;
-MULT.EE r0 lr2 0 lr2;;
+MULT.RC.VV lr2 r0 0 lr2;;
 acc.first;;
 SET lr0 cr9;;
 ACTIVATE identity 0;;
@@ -147,7 +147,7 @@ SET lr2 cr8;;
 LDR_MULT_REG r0 lr0 cr0;;
 LDR_CYCLIC_MULT_REG lr1 cr0 lr2;;
 RESET_ACC;;
-MULT.EE r0 lr2 0 lr2;;
+MULT.RC.VV lr2 r0 0 lr2;;
 acc.first;;
 BKPT;;
 """
@@ -193,7 +193,7 @@ LDR_MULT_REG r0 lr0 cr0;;
 LDR_MULT_REG r1 lr1 cr0;;
 LDR_CYCLIC_MULT_REG lr2 cr0 lr3;;
 RESET_ACC;;
-MULT.EE {which} lr3 0 lr3;;
+MULT.RC.VV lr3 {which} 0 lr3;;
 acc.first;;
 BKPT;;
 """
@@ -229,14 +229,16 @@ BKPT;;
             run_until_complete(st)
 
 
-class TestWideVectorPadding:
-    """Lanes past the r_cyclic byte window use padding (×1) in wide FP32 mode."""
+class TestWideVectorWrap:
+    """RC lanes past byte 511 wrap cyclically (no padding) in wide FP32 mode."""
 
-    def test_mult_ve_cr_fp32_boundary_padding(self) -> None:
-        # cyclic_offset=384 (aligned): lane 31 ends at byte 508; lane 32 starts at 512 → pad.
+    def test_mult_rc_ve_fp32_cr_scalar_wraps(self) -> None:
+        # rc_idx=384 (aligned): lane 31 ends at byte 508; lane 32 starts at 512 → wraps to byte 0.
         buf = bytearray(512)
         for k in range(32):
             struct.pack_into("<f", buf, 384 + k * 4, 3.0)
+        for k in range(96):
+            struct.pack_into("<f", buf, k * 4, 5.0)
         st = IpuState(wide_vector_debug=True, wide_vector_arithmetic=WideVectorArithmetic.FP32)
         st.dtype = DType.INT8
         st.regfile.set_cr(2, 2)  # low byte 2 → scalar 2.0 in wide FP32 path
@@ -246,43 +248,7 @@ class TestWideVectorPadding:
         asm = """\
 SET lr0 cr6;;
 SET lr2 cr7;;
-MULT.VE.CR lr0 0 lr2 cr2;;
-RESET_ACC;;
-acc.first;;
-BKPT;;
-"""
-        encoded = assemble(asm)
-        load_program(st, [decode_instruction_word(w) for w in encoded])
-        run_until_complete(st)
-        mult_res = st.regfile.raw("mult_res")
-        for i in range(32):
-            assert struct.unpack_from("<f", mult_res, i * 4)[0] == pytest.approx(6.0), f"lane {i}"
-        for i in range(32, 128):
-            assert struct.unpack_from("<f", mult_res, i * 4)[0] == pytest.approx(2.0), f"lane {i}"
-
-    def test_mult_ve_fp32_wide_cyclic_past_boundary(self) -> None:
-        """MULT.VE.CYCLIC (wide FP32): RC lanes wrap at 512 bytes."""
-        buf = bytearray(512)
-        for k in range(32):
-            struct.pack_into("<f", buf, 384 + k * 4, 3.0)
-        for k in range(96):
-            struct.pack_into("<f", buf, k * 4, 5.0)
-        st = IpuState(wide_vector_debug=True, wide_vector_arithmetic=WideVectorArithmetic.FP32)
-        st.dtype = DType.INT8
-        st.regfile.set_cr(0, 0)
-        st.regfile.set_r_cyclic_at(0, buf)
-        st.xmem.write_address(0x1000, struct.pack("<128f", *([2.0] * 128)))
-        st.regfile.set_cr(10, 0x1000)
-        st.regfile.set_cr(6, 384)
-        st.regfile.set_cr(7, 0)
-        st.regfile.set_cr(8, 0)
-        asm = """\
-SET lr4 cr10;;
-LDR_MULT_REG r0 lr4 cr0;;
-SET lr0 cr6;;
-SET lr2 cr7;;
-SET lr3 cr8;;
-MULT.VE.CYCLIC lr0 0 lr2 lr3;;
+MULT.RC.VE lr0 cr2 0 lr2;;
 RESET_ACC;;
 acc.first;;
 BKPT;;
@@ -296,8 +262,8 @@ BKPT;;
         for i in range(32, 128):
             assert struct.unpack_from("<f", mult_res, i * 4)[0] == pytest.approx(10.0), f"lane {i}"
 
-    def test_mult_ve_fp32_wide_padded_past_boundary(self) -> None:
-        """MULT.VE.PADDED (wide FP32): lanes past byte 511 use ×1."""
+    def test_mult_rc_ve_fp32_lr_scalar_wraps(self) -> None:
+        """MULT.RC.VE (wide FP32, LR-encoded src): RC lanes wrap at 512 bytes."""
         buf = bytearray(512)
         for k in range(32):
             struct.pack_into("<f", buf, 384 + k * 4, 3.0)
@@ -318,7 +284,7 @@ LDR_MULT_REG r0 lr4 cr0;;
 SET lr0 cr6;;
 SET lr2 cr7;;
 SET lr3 cr8;;
-MULT.VE.PADDED lr0 0 lr2 lr3;;
+MULT.RC.VE lr0 lr2 0 lr3;;
 RESET_ACC;;
 acc.first;;
 BKPT;;
@@ -330,7 +296,7 @@ BKPT;;
         for i in range(32):
             assert struct.unpack_from("<f", mult_res, i * 4)[0] == pytest.approx(6.0), f"lane {i}"
         for i in range(32, 128):
-            assert struct.unpack_from("<f", mult_res, i * 4)[0] == pytest.approx(2.0), f"lane {i}"
+            assert struct.unpack_from("<f", mult_res, i * 4)[0] == pytest.approx(10.0), f"lane {i}"
 
 
 class TestWideVectorAgg:
@@ -399,7 +365,7 @@ LDR_MULT_REG r0 lr0 cr0;;
 LDR_CYCLIC_MULT_REG lr1 cr0 lr2;;
 SET lr3 cr9;;
 RESET_ACC;;
-MULT.EE r0 lr3 0 lr3;;
+MULT.RC.VV lr3 r0 0 lr3;;
 BKPT;;
 """
         encoded = assemble(asm)


### PR DESCRIPTION
## Summary

This PR consolidates and renames the multiply instruction family to use a unified R_CYCLIC (RC)-based addressing scheme. The old `MULT.EE`, `MULT.VE.CYCLIC`, `MULT.VE.PADDED`, and `MULT.VE.CR` instructions are replaced with three new instructions (`MULT.RC.VV`, `MULT.RC.VE`, `MULT.RC.VS`) that provide clearer semantics and eliminate redundant variants.

## Key Changes

- **Instruction Consolidation:**
  - `MULT.EE` → `MULT.RC.VV` (RC vector × Ra vector, element-wise)
  - `MULT.VE.CYCLIC` + `MULT.VE.PADDED` → `MULT.RC.VE` (RC vector × scalar, with cyclic wrapping only)
  - `MULT.VE.CR` → `MULT.RC.VE` (same instruction, scalar from CR or LR-indexed Ra element)
  - `MULT.EE.RR` → `MULT.RC.VS` (RC vector self-multiply/square)

- **Operand Reordering & Renaming:**
  - `MULT.RC.VV`: operands now `rc_idx, ra, mask_offset, mask_shift` (was `ra, cyclic_offset, ...`)
  - `MULT.RC.VE`: operands now `rc_idx, src, mask_offset, mask_shift` (was `cyclic_offset, mask_offset, mask_shift, fixed_idx`)
  - `MULT.RC.VS`: operands now `rc_idx, mask_offset, mask_shift` (was `ra, mask_offset, mask_shift`)
  - All RC-based instructions use `rc_idx` (LR) to address R_CYCLIC with cyclic wrapping (mod 512)

- **Scalar Resolution:**
  - Added `_mult_resolve_lcr_scalar()` and `_mult_resolve_lcr_scalar_wide()` helper methods to handle LcrIdx operands
  - LR-encoded scalars: LR value (mod 256) indexes into combined Ra buffer (R0 ++ R1)
  - CR-encoded scalars: CR's low byte is used directly

- **Boundary Behavior:**
  - Removed padding-with-1 behavior; all RC addressing now wraps cyclically (mod 512)
  - Simplified logic: no more `pad_128_ones` parameter or boundary checks

- **Test Updates:**
  - Updated all test cases to use new instruction names and operand order
  - Removed tests for `MULT.VE.PADDED` boundary padding (no longer applicable)
  - Renamed test classes: `TestMultVeCr` → `TestMultRcVe`, `TestMultEeRr` → `TestMultRcVs`
  - Updated wide-vector debug tests to reflect new instruction semantics

- **Documentation:**
  - Updated `instruction_spec.py` with new instruction definitions, operand descriptions, and examples
  - Updated assembly examples in `fully_connected.asm` and other documentation
  - Updated operand type documentation in `gen_docs.py`

## Implementation Details

- Operand order now follows a consistent pattern: `rc_idx` (or `ra_idx` for MULT.VE) first, then scalar/vector operand, then mask parameters
- RC indices are always cyclic (mod 512); no special padding mode
- Scalar resolution is unified via LcrIdx type, supporting both LR and CR sources
- Multiplication operand order adjusted for consistency (RC/scalar first, then Ra/element)
- All tests pass with new instruction semantics

https://claude.ai/code/session_01SZsUkCE4JEjZ54DALV3RA5