### PR TITLE
Remove ElementsInRow=8 and expand variants from ACC.STRIDE

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -105,6 +105,8 @@ LDR_MULT_REG R0, LR0, CR0; MULT.RC.VV LR1, R0, 0, LR3; ACC; ADD LR0, LR0, 1; BNE
 
 `MultStageReg`, `LrIdx`, `CrIdx`, `LcrIdx`, `LrIncDecImmediate`, `FullXmemRow`, `ActivationFn`, `ElementsInRow`, `HorizontalStride`, `VerticalStride`, `LrModPow2KImmediate`, `MultMaskOffsetImmediate`, `BreakImmediate`, `Label`
 
+`ACC.STRIDE` operand enums (see `acc_stride_enums.py`): `ElementsInRow` = **`16`**, **`32`**, **`64`**; `HorizontalStride` = **`off`**, **`on`**, **`on_inv`** (expand is fixed hardware behaviour, not programmable).
+
 ---
 
 ## How to Add a New Instruction

--- a/src/tools/ipu-as-py/src/ipu_as/gen_docs.py
+++ b/src/tools/ipu-as-py/src/ipu_as/gen_docs.py
@@ -40,12 +40,13 @@ OPERAND_TYPE_DETAILS: dict[str, str] = {
         "constant. Valid range: **`0`** to **`2^W − 1`**."
     ),
     "ElementsInRow": (
-        "ACC-slot immediate: encoded **elements-per-row** selector (see `acc_stride_enums` in "
-        "`ipu_common`)."
+        "ACC-slot immediate: elements per row for **`ACC.STRIDE`**. Valid values: **`16`**, **`32`**, "
+        "**`64`** (minimum is 16; encoded 0→16, 1→32, 2→64). See `acc_stride_enums` in `ipu_common`."
     ),
     "HorizontalStride": (
-        "ACC-slot immediate: **horizontal stride** bit pattern for `ACC.STRIDE` (see "
-        "`acc_stride_enums`)."
+        "ACC-slot immediate: horizontal stride mode for **`ACC.STRIDE`**. Valid values: **`off`**, "
+        "**`on`**, **`on_inv`**. Expand padding is fixed hardware behaviour and is not programmable. "
+        "See `acc_stride_enums` in `ipu_common`."
     ),
     "VerticalStride": (
         "ACC-slot immediate: **vertical stride** bit pattern for `ACC.STRIDE` (see "

--- a/src/tools/ipu-as-py/src/ipu_as/gen_docs.py
+++ b/src/tools/ipu-as-py/src/ipu_as/gen_docs.py
@@ -45,8 +45,8 @@ OPERAND_TYPE_DETAILS: dict[str, str] = {
     ),
     "HorizontalStride": (
         "ACC-slot immediate: horizontal stride mode for **`ACC.STRIDE`**. Valid values: **`off`**, "
-        "**`on`**, **`on_inv`**. Expand padding is fixed hardware behaviour and is not programmable. "
-        "See `acc_stride_enums` in `ipu_common`."
+        "**`on`**, **`on_inv`** (2-bit encoded enum; **`reserved3`** is reserved). Expand padding "
+        "is fixed hardware behaviour and is not programmable. See `acc_stride_enums` in `ipu_common`."
     ),
     "VerticalStride": (
         "ACC-slot immediate: **vertical stride** bit pattern for `ACC.STRIDE` (see "

--- a/src/tools/ipu-as-py/src/ipu_as/immediate.py
+++ b/src/tools/ipu-as-py/src/ipu_as/immediate.py
@@ -152,14 +152,14 @@ class LrIncDecImmediate(ipu_token.IpuToken):
 # ---------------------------------------------------------------------------
 
 class ElementsInRowField(ipu_token.EnumToken):
-    """Elements per row: 8, 16, 32, or 64."""
+    """Elements per row: 16, 32, or 64."""
     @classmethod
     def enum_array(cls) -> list[str]:
         return list(ELEMENTS_IN_ROW_NAMES)
 
 
 class HorizontalStrideField(ipu_token.EnumToken):
-    """Horizontal stride: enabled(1), inverted(2), expand(3). Bits 0..2."""
+    """Horizontal stride: off, on, or on_inv."""
     @classmethod
     def enum_array(cls) -> list[str]:
         return list(HORIZONTAL_STRIDE_NAMES)

--- a/src/tools/ipu-common/src/ipu_common/acc_stride_enums.py
+++ b/src/tools/ipu-common/src/ipu_common/acc_stride_enums.py
@@ -5,8 +5,8 @@ Used by:
 - ipu-emu: interpretation of encoded values in execute_acc_stride
 
 Encoding convention:
-- elements_in_row: index 0..3 → 8, 16, 32, 64 elements per row.
-- horizontal_stride: semantic enum 0..4 → (enabled, inverted, expand) via lookup table.
+- elements_in_row: index 0..2 → 16, 32, 64 elements per row.
+- horizontal_stride: semantic enum 0..2 → (enabled, inverted) via lookup table.
 - vertical_stride: semantic enum 0..2 → (enabled, inverted) via lookup table.
 
 Note: horizontal/vertical stride values are NOT a packed bit-field; they are a
@@ -20,42 +20,40 @@ from __future__ import annotations
 # Elements per row (acc.stride first operand)
 # ---------------------------------------------------------------------------
 
-ELEMENTS_IN_ROW_NAMES: tuple[str, ...] = ("8", "16", "32", "64")
-ELEMENTS_IN_ROW_VALUES: tuple[int, ...] = (8, 16, 32, 64)
+ELEMENTS_IN_ROW_NAMES: tuple[str, ...] = ("16", "32", "64")
+ELEMENTS_IN_ROW_VALUES: tuple[int, ...] = (16, 32, 64)
 
 
 def get_elements_per_row(encoded: int) -> int:
-    """Return elements per row for encoded value 0..3."""
+    """Return elements per row for encoded value 0..2."""
     return ELEMENTS_IN_ROW_VALUES[encoded & 3]
 
 
 # ---------------------------------------------------------------------------
-# Horizontal stride (semantic enum: 0=off, 1=on, 2=on_inv, 3=on_expand, 4=on_inv_expand)
+# Horizontal stride (semantic enum: 0=off, 1=on, 2=on_inv)
 # ---------------------------------------------------------------------------
 
 HORIZONTAL_STRIDE_NAMES: tuple[str, ...] = (
-    "off",           # 0: disabled
-    "on",            # 1: enabled, not inverted, no expand
-    "on_inv",        # 2: enabled, inverted, no expand
-    "on_expand",     # 3: enabled, not inverted, expand
-    "on_inv_expand", # 4: enabled, inverted, expand
+    "off",        # 0: disabled
+    "on",         # 1: enabled, not inverted
+    "on_inv",     # 2: enabled, inverted
+    "reserved3",
+    "reserved4",
     "reserved5",
     "reserved6",
     "reserved7",
 )
 
 
-_HORIZONTAL_STRIDE_DECODE: dict[int, tuple[bool, bool, bool]] = {
-    0: (False, False, False),  # off
-    1: (True,  False, False),  # on
-    2: (True,  True,  False),  # on_inv
-    3: (True,  False, True),   # on_expand
-    4: (True,  True,  True),   # on_inv_expand
+_HORIZONTAL_STRIDE_DECODE: dict[int, tuple[bool, bool]] = {
+    0: (False, False),  # off
+    1: (True,  False),  # on
+    2: (True,  True),   # on_inv
 }
 
 
-def get_horizontal_stride_bits(encoded: int) -> tuple[bool, bool, bool]:
-    """Return (enabled, inverted, expand) for encoded horizontal stride 0..4."""
+def get_horizontal_stride_bits(encoded: int) -> tuple[bool, bool]:
+    """Return (enabled, inverted) for encoded horizontal stride 0..2."""
     return _HORIZONTAL_STRIDE_DECODE[encoded]
 
 

--- a/src/tools/ipu-common/src/ipu_common/acc_stride_enums.py
+++ b/src/tools/ipu-common/src/ipu_common/acc_stride_enums.py
@@ -38,10 +38,6 @@ HORIZONTAL_STRIDE_NAMES: tuple[str, ...] = (
     "on",         # 1: enabled, not inverted
     "on_inv",     # 2: enabled, inverted
     "reserved3",
-    "reserved4",
-    "reserved5",
-    "reserved6",
-    "reserved7",
 )
 
 

--- a/src/tools/ipu-common/src/ipu_common/instruction_spec.py
+++ b/src/tools/ipu-common/src/ipu_common/instruction_spec.py
@@ -661,16 +661,17 @@ INSTRUCTION_SPEC = {
                 summary="Reorder the multiplication result into R_ACC using horizontal/vertical stride decimation. Only updates the RACC indexes written; leaves the rest unchanged.",
                 syntax="ACC.STRIDE elements_in_row, horizontal_stride, vertical_stride, offset",
                 operands=[
-                    "elements_in_row: Elements per row (8, 16, 32, or 64)",
-                    "horizontal_stride: Horizontal stride mode (enabled, inverted, expand)",
+                    "elements_in_row: Elements per row (16, 32, or 64; minimum is 16)",
+                    "horizontal_stride: Horizontal stride mode (off, on, on_inv)",
                     "vertical_stride: Vertical stride mode (enabled, inverted)",
                     "offset: LR register; value % 4 gives start index in RACC (0, 32, 64, or 96)",
                 ],
                 operation=(
-                    "Decimate MULT_RES as rows×cols; apply horizontal stride (take every 2nd column, optional expand); "
-                    "then vertical stride (take every 2nd row). Write result into R_ACC[start:start+N] where start = (offset%4)*32, N = 32|64|128."
+                    "Decimate MULT_RES as rows×cols; apply horizontal stride (take every 2nd column); "
+                    "then vertical stride (take every 2nd row). Write result into R_ACC[start:start+N] where start = (offset%4)*32, N = 32|64|128. "
+                    "When a data structure has fewer than 8 elements, hardware pads to 16 automatically (not programmable)."
                 ),
-                example="ACC.STRIDE 8, off, off, LR0;;",
+                example="ACC.STRIDE 16, off, off, LR0;;",
             ),
             "execute_fn": "execute_acc_stride",
         },

--- a/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
@@ -823,7 +823,7 @@ class Ipu:
         elements_per_row = get_elements_per_row(elements_in_row)
         num_rows = R_REG_SIZE // elements_per_row
 
-        h_enabled, h_inverted, h_expand = get_horizontal_stride_bits(horizontal_stride)
+        h_enabled, h_inverted = get_horizontal_stride_bits(horizontal_stride)
         v_enabled, v_inverted = get_vertical_stride_bits(vertical_stride)
 
         # Build list of source indices (0..127) or -1 for zero padding
@@ -839,12 +839,8 @@ class Ipu:
                     indices_in_row = [base + 1 + 2 * j for j in range(half)]
                 else:
                     indices_in_row = [base + 2 * j for j in range(half)]
-                if h_expand:
-                    after_h.extend(indices_in_row)
-                    after_h.extend([-1] * (elements_per_row - half))
-                else:
-                    after_h.extend(indices_in_row)
-            effective_row_len = elements_per_row if h_expand else half
+                after_h.extend(indices_in_row)
+            effective_row_len = half
 
         num_rows_after_h = len(after_h) // effective_row_len
         if not v_enabled:

--- a/src/tools/ipu-emu-py/test/test_execute.py
+++ b/src/tools/ipu-emu-py/test/test_execute.py
@@ -803,7 +803,7 @@ BKPT;;
         """ACC.STRIDE with both strides off copies all 128 mult_res words to r_acc from start 0."""
         state = _make_state("""\
 SET lr0 cr8;;
-ACC.STRIDE 8 off off lr0;;
+ACC.STRIDE 16 off off lr0;;
 BKPT;;
 """,
             cr={8: 0})
@@ -816,11 +816,11 @@ BKPT;;
             w = state.regfile.get_r_acc_word(i)
             assert w == i, f"word {i}: expected {i}, got {w}"
 
-    def test_acc_stride_horizontal_no_expand(self):
-        """ACC.STRIDE with horizontal on, no expand: take every 2nd column → 64 elements at r_acc[0:64]."""
+    def test_acc_stride_horizontal(self):
+        """ACC.STRIDE with horizontal on: take every 2nd column → 64 elements at r_acc[0:64]."""
         state = _make_state("""\
 SET lr0 cr8;;
-ACC.STRIDE 8 on off lr0;;
+ACC.STRIDE 16 on off lr0;;
 BKPT;;
 """,
             cr={8: 0})
@@ -829,11 +829,11 @@ BKPT;;
         for i in range(128):
             struct.pack_into("<i", mult_buf, i * 4, i)
         run_until_complete(state)
-        # Rows of 8: even columns 0,2,4,6 → indices 0,2,4,6, 8,10,12,14, ...
+        # Rows of 16: even columns 0,2,4,...,14 → 8 per row × 8 rows = 64 elements
         for out_i in range(64):
-            row = out_i // 4
-            col = (out_i % 4) * 2
-            expected = row * 8 + col
+            row = out_i // 8
+            col = (out_i % 8) * 2
+            expected = row * 16 + col
             w = state.regfile.get_r_acc_word(out_i)
             assert w == expected, f"out[{out_i}]: expected {expected}, got {w}"
 
@@ -841,11 +841,11 @@ BKPT;;
         """ACC.STRIDE with offset: (lr0 % 4)*32 is start index; 64 elements written at r_acc[32:96]."""
         state = _make_state("""\
 SET lr0 cr8;;
-ACC.STRIDE 8 on off lr0;;
+ACC.STRIDE 16 on off lr0;;
 BKPT;;
 """,
             cr={8: 1})
-        # lr0=1 → offset % 4 = 1 → start index 32. Horizontal on, no expand → 64 elements.
+        # lr0=1 → offset % 4 = 1 → start index 32. Horizontal on → 64 elements.
         state.dtype = DType.INT8
         for i in range(128):
             state.regfile.set_r_acc_word(i, 0)
@@ -857,9 +857,9 @@ BKPT;;
             w = state.regfile.get_r_acc_word(i)
             assert w == 0, f"word {i} (before start): expected 0, got {w}"
         for out_i in range(64):
-            row = out_i // 4
-            col = (out_i % 4) * 2
-            expected_src = row * 8 + col
+            row = out_i // 8
+            col = (out_i % 8) * 2
+            expected_src = row * 16 + col
             w = state.regfile.get_r_acc_word(32 + out_i)
             assert w == 100 + expected_src, f"word {32 + out_i}: expected {100 + expected_src}, got {w}"
         for i in range(96, 128):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements #138: removes `ElementsInRow=8` and the programmable `expand` horizontal-stride variants from `ACC.STRIDE`.

- **ElementsInRow**: valid values are now `16`, `32`, `64` only (encoded 0→16, 1→32, 2→64; still 2 bits).
- **HorizontalStride**: valid values are now `off`, `on`, `on_inv`; `on_expand` and `on_inv_expand` are removed. Enum shrinks from 3 bits to **2 bits** (matching `VerticalStride`: `off`, `on`, `on_inv`, `reserved3`).
- **Emulator**: `execute_acc_stride` no longer branches on an expand flag — expand is documented as fixed hardware behaviour when padding sub-8-element structures to 16.
- **Docs**: updated `instruction_spec.py`, `gen_docs.py`, and `SKILL.md`.
- **Tests**: updated `ACC.STRIDE` tests to use `16` elements per row.

## Test plan

- [x] `bazel test //...` — all tests pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-723f7ecd-718d-47d4-ac7e-0d426081ac7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-723f7ecd-718d-47d4-ac7e-0d426081ac7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

