### PR TITLE
Unifies the per-slot NOP variants + slot description

### DIFF
--- a/src/tools/ipu-as-py/src/ipu_as/compound_inst.py
+++ b/src/tools/ipu-as-py/src/ipu_as/compound_inst.py
@@ -28,11 +28,26 @@ class CompoundInst:
         inst_types_list = self.instruction_types()
 
         for instruction in instructions["instructions"]:
-            inst_type = inst.Inst.find_inst_type_by_opcode(
-                instruction["opcode"].token.value
-            )
+            opcode_str = instruction["opcode"].token.value
             if address is None:
                 address = instruction["opcode"].instr_id
+
+            # NOP is context-aware: fill the next available unfilled slot.
+            if opcode_str.lower() == "nop":
+                slot_filled = False
+                for i, expected_type in enumerate(inst_types_list):
+                    if self.instructions[i] is None:
+                        self.instructions[i] = expected_type(instruction)
+                        slot_filled = True
+                        break
+                if not slot_filled:
+                    raise ValueError(
+                        f"NOP: all slots are already filled\n"
+                        f"At: {instruction['opcode'].get_location_string()}"
+                    )
+                continue
+
+            inst_type = inst.Inst.find_inst_type_by_opcode(opcode_str)
 
             # Find the first available slot for this instruction type
             slot_filled = False

--- a/src/tools/ipu-as-py/src/ipu_as/gen_docs.py
+++ b/src/tools/ipu-as-py/src/ipu_as/gen_docs.py
@@ -6,7 +6,13 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-from ipu_common.instruction_spec import PSEUDO_INSTRUCTION_SPEC, VALID_OPERAND_TYPES
+from ipu_common.instruction_spec import (
+    PSEUDO_INSTRUCTION_SPEC,
+    VALID_OPERAND_TYPES,
+    SLOT_COUNT,
+    SLOT_METADATA,
+    COMPOUND_LAYOUT_SLOT_ORDER,
+)
 from ipu_common.registers import create_assembler_reg_enums
 
 # Long-form reference for each operand type string in instruction_spec (single source: VALID_OPERAND_TYPES).
@@ -380,6 +386,36 @@ bazel run //src/tools/ipu-as-py:ipu-as -- assemble --input prog.asm --output pro
     print(f"Generated assembly syntax page at {output_path}")
 
 
+def _generate_slots_section() -> str:
+    """Generate the Slots overview section from instruction_spec metadata."""
+    lines: list[str] = [
+        "## Slots\n",
+        "A VLIW instruction word encodes one sub-instruction per slot. "
+        "Slots are grouped into pipeline stages that execute sequentially within a cycle: "
+        "**CTRL** (COND + LR run concurrently; LOAD address is resolved here and the data feeds MULT) "
+        "→ **MULT** → **ACC** → **AAQ** → **STORE**. "
+        "`ACC_STORE` and `BREAK` are simulation-only. "
+        "Any omitted slot is filled with `NOP` by the assembler automatically.\n",
+        "| Slot | Count | Description |",
+        "|------|------:|-------------|",
+    ]
+    for slot in COMPOUND_LAYOUT_SLOT_ORDER:
+        count = SLOT_COUNT[slot]
+        meta = SLOT_METADATA.get(slot, {})
+        description = meta.get("description", "")
+        lines.append(f"| `{slot.upper()}` | {count} | {description} |")
+    lines += [
+        "",
+        "### `NOP` — No Operation\n",
+        "**Syntax:** `NOP`\n",
+        "No operation. Every slot accepts `NOP`. "
+        "The assembler fills any omitted slot with `NOP` automatically. "
+        "When written explicitly in a compound instruction, `NOP` is assigned to "
+        "the next unfilled slot in compound-layout order (COND → LR → LOAD → MULT → ACC → AAQ → STORE → ACC_STORE → BREAK).\n",
+    ]
+    return "\n".join(lines)
+
+
 def generate_instruction_docs(output_path: Path) -> None:
     """Generate instruction reference documentation."""
     from ipu_as.inst import Inst
@@ -391,6 +427,8 @@ def generate_instruction_docs(output_path: Path) -> None:
         "`instruction_spec.py`. Operand **types** link to the shared "
         "[operand type reference](operand-types.md).\n"
     )
+
+    content.append(_generate_slots_section())
 
     content.append("## Compound Instruction Layout\n")
     content.append(

--- a/src/tools/ipu-as-py/src/ipu_as/inst.py
+++ b/src/tools/ipu-as-py/src/ipu_as/inst.py
@@ -291,6 +291,8 @@ class Inst:
             lines.append("")
 
         for opcode, struct_entry in cls.struct_by_opcode_table().items():
+            if opcode == "NOP":
+                continue  # documented once globally in the Slots section
             instruction_format = cls._struct_entry(opcode)
             if instruction_format.doc is None:
                 continue
@@ -375,7 +377,7 @@ class LoadInst(Inst):
         return LoadInst(
             {
                 "opcode": ipu_token.AnnotatedToken(
-                    token=lark.Token("TOKEN", "LOAD_NOP", line=0, column=0),
+                    token=lark.Token("TOKEN", "NOP", line=0, column=0),
                     instr_id=addr,
                 ),
                 "operands": [],
@@ -413,7 +415,7 @@ class StoreInst(Inst):
         return StoreInst(
             {
                 "opcode": ipu_token.AnnotatedToken(
-                    token=lark.Token("TOKEN", "STORE_NOP", line=0, column=0),
+                    token=lark.Token("TOKEN", "NOP", line=0, column=0),
                     instr_id=addr,
                 ),
                 "operands": [],
@@ -451,7 +453,7 @@ class AccStoreInst(Inst):
         return AccStoreInst(
             {
                 "opcode": ipu_token.AnnotatedToken(
-                    token=lark.Token("TOKEN", "ACC_STORE_NOP", line=0, column=0),
+                    token=lark.Token("TOKEN", "NOP", line=0, column=0),
                     instr_id=addr,
                 ),
                 "operands": [],
@@ -489,7 +491,7 @@ class MultInst(Inst):
         return MultInst(
             {
                 "opcode": ipu_token.AnnotatedToken(
-                    token=lark.Token("TOKEN", "MULT_NOP", line=0, column=0),
+                    token=lark.Token("TOKEN", "NOP", line=0, column=0),
                     instr_id=addr,
                 ),
                 "operands": [],
@@ -526,7 +528,7 @@ class AccInst(Inst):
         return AccInst(
             {
                 "opcode": ipu_token.AnnotatedToken(
-                    token=lark.Token("TOKEN", "ACC_NOP", line=0, column=0),
+                    token=lark.Token("TOKEN", "NOP", line=0, column=0),
                     instr_id=addr,
                 ),
                 "operands": [],
@@ -561,7 +563,7 @@ class AaqInst(Inst):
         return AaqInst(
             {
                 "opcode": ipu_token.AnnotatedToken(
-                    token=lark.Token("TOKEN", "AAQ_NOP", line=0, column=0),
+                    token=lark.Token("TOKEN", "NOP", line=0, column=0),
                     instr_id=addr,
                 ),
                 "operands": [],
@@ -596,19 +598,10 @@ class LrInst(Inst):
         return LrInst(
             {
                 "opcode": ipu_token.AnnotatedToken(
-                    token=lark.Token("TOKEN", "INC", line=0, column=0),
+                    token=lark.Token("TOKEN", "NOP", line=0, column=0),
                     instr_id=addr,
                 ),
-                "operands": [
-                    ipu_token.AnnotatedToken(
-                        token=lark.Token("TOKEN", "lr0", line=0, column=0),
-                        instr_id=addr,
-                    ),
-                    ipu_token.AnnotatedToken(
-                        token=lark.Token("TOKEN", "0", line=0, column=0),
-                        instr_id=addr,
-                    ),
-                ],
+                "operands": [],
             }
         )
 
@@ -637,26 +630,12 @@ class CondInst(Inst):
 
     @classmethod
     def nop_inst(cls, addr: int) -> str:
-        # B is a pseudo-instruction (expands to BEQ CR0, CR0, label), so the
-        # cond-slot filler is written directly as the real BEQ it expands to:
-        # CR0 always equals itself, so this branches to the very next
-        # instruction, i.e. falls through like a NOP.
         return CondInst(
             {
                 "opcode": ipu_token.AnnotatedToken(
-                    token=lark.Token("TOKEN", "BEQ", line=0, column=0), instr_id=addr
+                    token=lark.Token("TOKEN", "NOP", line=0, column=0), instr_id=addr
                 ),
-                "operands": [
-                    ipu_token.AnnotatedToken(
-                        token=lark.Token("TOKEN", "CR0", line=0, column=0), instr_id=addr
-                    ),
-                    ipu_token.AnnotatedToken(
-                        token=lark.Token("TOKEN", "CR0", line=0, column=0), instr_id=addr
-                    ),
-                    ipu_token.AnnotatedToken(
-                        token=lark.Token("TOKEN", "+1", line=0, column=0), instr_id=addr
-                    ),
-                ],
+                "operands": [],
             }
         )
 
@@ -688,7 +667,7 @@ class BreakInst(Inst):
         return BreakInst(
             {
                 "opcode": ipu_token.AnnotatedToken(
-                    token=lark.Token("TOKEN", "BREAK_NOP", line=0, column=0),
+                    token=lark.Token("TOKEN", "NOP", line=0, column=0),
                     instr_id=addr,
                 ),
                 "operands": [],

--- a/src/tools/ipu-as-py/src/ipu_as/opcodes.py
+++ b/src/tools/ipu-as-py/src/ipu_as/opcodes.py
@@ -32,14 +32,18 @@ Opcode = LoadInstOpcode.__bases__[0]
 
 def validate_unique_opcodes() -> None:
     """Validate that all opcodes are unique across all Opcode subclasses.
-    
-    This is a sanity check to ensure INSTRUCTION_SPEC has no duplicates.
+
+    NOP is intentionally shared across all slot classes; the assembler resolves
+    it to the correct slot by context. All other opcodes must be globally unique.
     """
+    SHARED_OPCODES = {"NOP"}
     opcodes_subclasses = Opcode.__subclasses__()
     opcode_to_class = {}
 
     for cls in opcodes_subclasses:
         for opcode in cls.enum_array():
+            if opcode in SHARED_OPCODES:
+                continue
             if opcode in opcode_to_class:
                 existing_class = opcode_to_class[opcode]
                 raise AssertionError(

--- a/src/tools/ipu-common/src/ipu_common/instruction_spec.py
+++ b/src/tools/ipu-common/src/ipu_common/instruction_spec.py
@@ -167,8 +167,16 @@ COMPOUND_LAYOUT_SLOT_ORDER: list[str] = [
 
 # Per-slot metadata.  ``hardware: False`` marks simulation-only slots that are
 # not implemented in real IPU hardware (excluded from HW codegen).
-SLOT_METADATA: dict[str, dict[str, bool]] = {
-    "acc_store": {"hardware": False},
+SLOT_METADATA: dict[str, dict] = {
+    "load":      {"description": "First-stage memory loads that feed the multiply unit (mult-stage, cyclic, and mask registers)."},
+    "store":     {"description": "Last-stage memory stores that drain POST_AAQ_REG to external memory after activation and quantization."},
+    "acc_store": {"hardware": False, "description": "Simulation-only stores of R_ACC to external memory (STR_ACC_REG). Not implemented in real IPU hardware."},
+    "mult":      {"description": "Multiply-stage instructions: element-wise and vector multiply operations."},
+    "acc":       {"description": "Accumulation instructions for combining multiply results into R_ACC."},
+    "aaq":       {"description": "Activation and quantization: aggregate R_ACC into AAQ registers; quantize POST_AAQ_REG."},
+    "lr":        {"description": "Loop register instructions for controlling addresses, counters, and scalars. Three independent sub-slots per cycle."},
+    "cond":      {"description": "Conditional and unconditional branches; control flow based on register comparisons."},
+    "break":     {"description": "Debug break: halts execution or enters debug mode."},
 }
 
 
@@ -246,12 +254,12 @@ INSTRUCTION_SPEC = {
             ),
             "execute_fn": "execute_ldr_mult_mask_reg",
         },
-        "LOAD_NOP": {
+        "NOP": {
             "operands": [],
             "doc": InstructionDoc(
-                title="No Operation (LOAD)",
+                title="No Operation",
                 summary="No operation for load slot.",
-                syntax="LOAD_NOP",
+                syntax="NOP",
                 operands=[],
             ),
             "execute_fn": "execute_load_nop",
@@ -283,12 +291,12 @@ INSTRUCTION_SPEC = {
             ),
             "execute_fn": "execute_str_post_aaq_reg",
         },
-        "STORE_NOP": {
+        "NOP": {
             "operands": [],
             "doc": InstructionDoc(
-                title="No Operation (STORE)",
+                title="No Operation",
                 summary="No operation for store slot.",
-                syntax="STORE_NOP",
+                syntax="NOP",
                 operands=[],
             ),
             "execute_fn": "execute_store_nop",
@@ -321,12 +329,12 @@ INSTRUCTION_SPEC = {
             ),
             "execute_fn": "execute_str_acc_reg",
         },
-        "ACC_STORE_NOP": {
+        "NOP": {
             "operands": [],
             "doc": InstructionDoc(
-                title="No Operation (ACC_STORE)",
+                title="No Operation",
                 summary="No operation for acc_store slot (simulation-only).",
-                syntax="ACC_STORE_NOP",
+                syntax="NOP",
                 operands=[],
             ),
             "execute_fn": "execute_acc_store_nop",
@@ -335,7 +343,7 @@ INSTRUCTION_SPEC = {
     
     # =========================================================================
     # LR Slot (Loop Register Instructions)
-    # Opcode = position: SET=0, ADD=1, SUB=2, INCR_MOD_POW2=3, INC=4, DEC=5
+    # Opcode = position: SET=0, ADD=1, SUB=2, INCR_MOD_POW2=3, INC=4, DEC=5, NOP=6
     # =========================================================================
     "lr": {
         "SET": {
@@ -464,11 +472,21 @@ INSTRUCTION_SPEC = {
             ),
             "execute_fn": "execute_lr_dec",
         },
+        "NOP": {
+            "operands": [],
+            "doc": InstructionDoc(
+                title="No Operation",
+                summary="No operation for LR slot.",
+                syntax="NOP",
+                operands=[],
+            ),
+            "execute_fn": "execute_lr_nop",
+        },
     },
-    
+
     # =========================================================================
     # MULT Slot (Multiply Instructions)
-    # Opcode = position: MULT.EE=0, MULT.VE.CYCLIC=1, MULT.VE.PADDED=2, MULT_NOP=3,
+    # Opcode = position: MULT.EE=0, MULT.VE.CYCLIC=1, MULT.VE.PADDED=2, NOP=3,
     #          MULT.VE.CR=4, MULT.EE.RR=5
     # =========================================================================
     "mult": {
@@ -548,12 +566,12 @@ INSTRUCTION_SPEC = {
             ),
             "execute_fn": "execute_mult_ve_padded",
         },
-        "MULT_NOP": {
+        "NOP": {
             "operands": [],
             "doc": InstructionDoc(
-                title="No Operation (MULT)",
+                title="No Operation",
                 summary="No operation for multiply slot.",
-                syntax="MULT_NOP",
+                syntax="NOP",
                 operands=[],
             ),
             "execute_fn": "execute_mult_nop",
@@ -610,7 +628,7 @@ INSTRUCTION_SPEC = {
 
     # =========================================================================
     # ACC Slot (Accumulator Instructions)
-    # Opcode = position: ACC=0, ACC.FIRST=1, RESET_ACC=2, ACC_NOP=3, ACC.STRIDE=4, AGG.SUM.FIRST=5, AGG.SUM=6, AGG.MAX.FIRST=7, AGG.MAX=8
+    # Opcode = position: ACC=0, ACC.FIRST=1, RESET_ACC=2, NOP=3, ACC.STRIDE=4, AGG.SUM.FIRST=5, AGG.SUM=6, AGG.MAX.FIRST=7, AGG.MAX=8
     # =========================================================================
     "acc": {
         "ACC": {
@@ -647,12 +665,12 @@ INSTRUCTION_SPEC = {
             ),
             "execute_fn": "execute_reset_acc",
         },
-        "ACC_NOP": {
+        "NOP": {
             "operands": [],
             "doc": InstructionDoc(
-                title="No Operation (ACC)",
+                title="No Operation",
                 summary="No operation for accumulator slot.",
-                syntax="ACC_NOP",
+                syntax="NOP",
                 operands=[],
             ),
             "execute_fn": "execute_acc_nop",
@@ -791,15 +809,15 @@ INSTRUCTION_SPEC = {
 
     # =========================================================================
     # AAQ Slot (Activation and Quantization)
-    # Opcode = position: AAQ_NOP=0, AAQ=1, ACTIVATE=2
+    # Opcode = position: NOP=0, AAQ=1, ACTIVATE=2
     # =========================================================================
     "aaq": {
-        "AAQ_NOP": {
+        "NOP": {
             "operands": [],
             "doc": InstructionDoc(
-                title="No Operation (AAQ)",
+                title="No Operation",
                 summary="No operation for AAQ slot.",
-                syntax="AAQ_NOP",
+                syntax="NOP",
                 operands=[],
             ),
             "execute_fn": "execute_aaq_nop",
@@ -873,7 +891,7 @@ INSTRUCTION_SPEC = {
 
     # =========================================================================
     # COND Slot (Conditional Branch Instructions)
-    # Opcode = position: BEQ=0, BNE=1, BLT=2, BGE=3, BR=4, BKPT=5
+    # Opcode = position: BEQ=0, BNE=1, BLT=2, BGE=3, BR=4, BKPT=5, NOP=6
     # BNZ, BZ, and B are pseudo-instructions (see PSEUDO_INSTRUCTION_SPEC):
     # they're each exactly expressible via BEQ/BNE against CR0 (always zero),
     # so they don't need their own opcode.
@@ -983,11 +1001,21 @@ INSTRUCTION_SPEC = {
             ),
             "execute_fn": "execute_bkpt",
         },
+        "NOP": {
+            "operands": [],
+            "doc": InstructionDoc(
+                title="No Operation",
+                summary="No operation for COND slot; advances PC by one.",
+                syntax="NOP",
+                operands=[],
+            ),
+            "execute_fn": "execute_cond_nop",
+        },
     },
 
     # =========================================================================
     # BREAK Slot (Break Instructions)
-    # Opcode = position: BREAK=0, BREAK.IFEQ=1, BREAK_NOP=2
+    # Opcode = position: BREAK=0, BREAK.IFEQ=1, NOP=2
     # =========================================================================
     "break": {
         "BREAK": {
@@ -1019,12 +1047,12 @@ INSTRUCTION_SPEC = {
             ),
             "execute_fn": "execute_break_ifeq",
         },
-        "BREAK_NOP": {
+        "NOP": {
             "operands": [],
             "doc": InstructionDoc(
-                title="No Operation (BREAK)",
+                title="No Operation",
                 summary="No operation for BREAK slot.",
-                syntax="BREAK_NOP",
+                syntax="NOP",
                 operands=[],
             ),
             "execute_fn": "execute_break_nop",

--- a/src/tools/ipu-emu-py/src/ipu_emu/execute.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/execute.py
@@ -14,10 +14,10 @@ An instruction is stored as a ``dict[str, int]`` whose keys match the
 C struct field names produced by ``CompoundInst.get_fields()``, e.g.::
 
     {
-        "break_inst_token_0_break_inst_opcode": 2,   # BREAK_NOP
-        "load_inst_token_0_load_inst_opcode": 3,     # LOAD_NOP
-        "store_inst_token_0_store_inst_opcode": 1,   # STORE_NOP
-        "acc_store_inst_token_0_acc_store_inst_opcode": 1,   # ACC_STORE_NOP
+        "break_inst_token_0_break_inst_opcode": 2,   # NOP (break slot)
+        "load_inst_token_0_load_inst_opcode": 3,     # NOP (load slot)
+        "store_inst_token_0_store_inst_opcode": 1,   # NOP (store slot)
+        "acc_store_inst_token_0_acc_store_inst_opcode": 1,   # NOP (acc_store slot)
         ...
     }
 

--- a/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
@@ -410,15 +410,15 @@ class Ipu:
     # -----------------------------------------------------------------------
 
     def execute_load_nop(self) -> None:
-        """Execute LOAD_NOP: No operation."""
+        """Execute NOP in load slot: No operation."""
         pass
 
     def execute_store_nop(self) -> None:
-        """Execute STORE_NOP: No operation."""
+        """Execute NOP in store slot: No operation."""
         pass
 
     def execute_acc_store_nop(self) -> None:
-        """Execute ACC_STORE_NOP: No operation."""
+        """Execute NOP in acc_store slot: No operation."""
         pass
 
     def execute_str_acc_reg(self, *, offset: int, base: int) -> None:
@@ -528,6 +528,10 @@ class Ipu:
         mask = (1 << k_exp) - 1
         self.state.regfile.set_lr(dest, ((cur + step_u) & 0xFFFFFFFF) & mask)
 
+    def execute_lr_nop(self) -> None:
+        """Execute NOP in LR slot: No operation."""
+        pass
+
     def _dispatch_lr_slots(self, inst: dict[str, int]) -> None:
         """Dispatch all LR sub-slots with conflict detection.
 
@@ -545,10 +549,6 @@ class Ipu:
             inst_name, spec = get_instruction_by_opcode("lr", opcode)
             field_map = _INSTRUCTION_FIELD_MAP[("lr", inst_name, slot_idx)]
             kwargs = {name: inst[field_key] for name, field_key in field_map.items()}
-
-            # Unfilled LR slots encode ``INC lrX 0``: identity, no write.
-            if inst_name in ("INC", "DEC") and kwargs.get("imm") == 0:
-                continue
 
             # Auto-resolve 'read' operands to register values.
             read_types = _INSTRUCTION_READ_TYPES.get(("lr", inst_name), {})
@@ -575,7 +575,7 @@ class Ipu:
     # -----------------------------------------------------------------------
 
     def execute_mult_nop(self) -> None:
-        """Execute MULT_NOP: No operation."""
+        """Execute NOP in mult slot: No operation."""
         pass
 
     def execute_mult_ee(self, *, ra: bytearray | int, cyclic_offset: int,
@@ -786,7 +786,7 @@ class Ipu:
     # -----------------------------------------------------------------------
 
     def execute_acc_nop(self) -> None:
-        """Execute ACC_NOP: No operation."""
+        """Execute NOP in acc slot: No operation."""
         pass
 
     def execute_reset_acc(self) -> None:
@@ -884,7 +884,7 @@ class Ipu:
             struct.pack_into(fmt, acc_buf, (base + i) * 4, val)
 
     def execute_aaq_nop(self) -> None:
-        """Execute AAQ_NOP: No operation for AAQ slot."""
+        """Execute NOP in aaq slot: No operation."""
         pass
 
     def _agg_active_lane_count(self, valid_elements: int) -> int:
@@ -1112,12 +1112,16 @@ class Ipu:
         """Execute BKPT: Breakpoint (halt execution)."""
         self.state.program_counter = INST_MEM_SIZE  # halt
 
+    def execute_cond_nop(self) -> None:
+        """Execute NOP in cond slot: No operation; advance PC."""
+        self.state.program_counter += 1
+
     # -----------------------------------------------------------------------
     # BREAK Instruction Handlers
     # -----------------------------------------------------------------------
 
     def execute_break_nop(self) -> BreakResult:
-        """Execute BREAK_NOP: No operation."""
+        """Execute NOP in break slot: No operation."""
         return BreakResult.CONTINUE
 
     def execute_break(self) -> BreakResult:
@@ -1171,16 +1175,16 @@ class Ipu:
         # Update run statistics
         stats = self.state.stats
         if slot_type == "mult":
-            if instruction_name != "MULT_NOP":
+            if instruction_name != "NOP":
                 stats.mult_active_cycles += 1
         elif slot_type == "acc":
-            if instruction_name != "ACC_NOP":
+            if instruction_name != "NOP":
                 stats.acc_active_cycles += 1
         elif slot_type == "load":
-            if instruction_name != "LOAD_NOP":
+            if instruction_name != "NOP":
                 stats.xmem_reads += 1
         elif slot_type in {"store", "acc_store"}:
-            if instruction_name not in {"STORE_NOP", "ACC_STORE_NOP"}:
+            if instruction_name != "NOP":
                 stats.xmem_writes += 1
 
         # Call handler with named arguments


### PR DESCRIPTION
Unifies the per-slot NOP variants (`LOAD_NOP`, `STORE_NOP`, `MULT_NOP`, `ACC_NOP`, `AAQ_NOP`, `BREAK_NOP`, `ACC_STORE_NOP`) into a single `NOP` mnemonic shared across all slots, adds the previously missing `NOP` to the LR and COND slots, and generates a Slots overview section in the instruction reference.

## Changes

### `instruction_spec.py`
- Renamed all slot-specific NOP keys to `NOP` (opcodes are position-derived, so no encoding changes for existing slots).
- Added `NOP` to the **LR** slot (opcode 6, handler `execute_lr_nop`) — previously missing.
- Added `NOP` to the **COND** slot (opcode 6, handler `execute_cond_nop`) — previously missing.
- Extended `SLOT_METADATA` with a `description` field for every slot, used by the doc generator.

### `ipu.py`
- Added `execute_lr_nop` (no-op) and `execute_cond_nop` (advances PC by 1, matching all other COND handlers).
- Updated stats accounting checks from old NOP names (`"MULT_NOP"`, `"ACC_NOP"`, etc.) to `"NOP"`.
- Removed the `INC lrX 0` identity-skip hack in `_dispatch_lr_slots` — now superseded by the real LR `NOP`.

### `inst.py`
- All `nop_inst` methods now emit `"NOP"` instead of slot-specific tokens.
- `LrInst.nop_inst` drops the `INC lr0 0` workaround; `CondInst.nop_inst` drops the `BEQ CR0, CR0, +1` workaround.
- `_render_instruction_docs` skips `NOP` — it is documented once globally, not once per slot.

### `opcodes.py`
- `validate_unique_opcodes` exempts `NOP` from the cross-slot uniqueness check; all other mnemonics must still be globally unique.

### `compound_inst.py`
- Context-aware NOP resolution: when a user writes explicit `NOP` in a compound instruction, the assembler places it in the next unfilled slot in compound-layout order (COND → LR → LOAD → MULT → ACC → AAQ → STORE → ACC_STORE → BREAK).

### `gen_docs.py`
- Generates a **Slots** section at the top of the instruction reference, derived from `COMPOUND_LAYOUT_SLOT_ORDER`, `SLOT_COUNT`, and `SLOT_METADATA`.
- Includes a single `NOP` entry (syntax, behaviour, assembler resolution rule) — not repeated per slot.
- Slot description accurately reflects the pipeline structure: CTRL (COND + LR concurrent; LOAD address resolved here) → MULT → ACC → AAQ → STORE; ACC_STORE and BREAK are simulation-only.
