### PR TITLE
Fix BLT/BGE sign-extension at 20-bit register width

### DIFF
--- a/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
@@ -1072,22 +1072,22 @@ class Ipu:
         self.state.program_counter = label if reg1 != reg2 else self.state.program_counter + 1
 
     @staticmethod
-    def _to_signed_32(value: int) -> int:
-        """Interpret an unsigned 32-bit value as signed."""
-        if value >= 0x80000000:
-            return value - 0x100000000
+    def _to_signed_reg(value: int) -> int:
+        """Sign-extend a value at the LR/CR register width (20 bits)."""
+        if value >= (1 << (LR_CR_SCALAR_BITS - 1)):
+            return value - (1 << LR_CR_SCALAR_BITS)
         return value
 
     def execute_blt(self, *, reg1: int, reg2: int, label: int) -> None:
         """Execute BLT: Branch if less than (signed comparison)."""
-        s1 = self._to_signed_32(reg1)
-        s2 = self._to_signed_32(reg2)
+        s1 = self._to_signed_reg(reg1)
+        s2 = self._to_signed_reg(reg2)
         self.state.program_counter = label if s1 < s2 else self.state.program_counter + 1
 
     def execute_bge(self, *, reg1: int, reg2: int, label: int) -> None:
         """Execute BGE: Branch if greater or equal (signed comparison)."""
-        s1 = self._to_signed_32(reg1)
-        s2 = self._to_signed_32(reg2)
+        s1 = self._to_signed_reg(reg1)
+        s2 = self._to_signed_reg(reg2)
         self.state.program_counter = label if s1 >= s2 else self.state.program_counter + 1
 
     def execute_br(self, *, reg: int) -> None:

--- a/src/tools/ipu-emu-py/test/test_execute.py
+++ b/src/tools/ipu-emu-py/test/test_execute.py
@@ -705,6 +705,36 @@ BKPT;;
         run_until_complete(state)
         assert state.regfile.get_lr(2) == 1
 
+    def test_blt_negative_counter(self):
+        """BLT sign-extends at 20 bits: -1 < 0 must branch (issue #142)."""
+        state = _run("""\
+SET lr0 cr8;;
+SET lr1 cr9;;
+BLT lr0 lr1 neg_branch;;
+SET lr2 cr10;;
+BKPT;;
+neg_branch:
+SET lr2 cr11;;
+BKPT;;
+""",
+            cr={8: -1, 9: 0, 10: 0, 11: 1})
+        assert state.regfile.get_lr(2) == 1
+
+    def test_bge_negative_not_taken(self):
+        """BGE sign-extends at 20 bits: -1 >= 0 must not branch (issue #142)."""
+        state = _run("""\
+SET lr0 cr8;;
+SET lr1 cr9;;
+BGE lr0 lr1 neg_ge_branch;;
+SET lr2 cr10;;
+BKPT;;
+neg_ge_branch:
+SET lr2 cr11;;
+BKPT;;
+""",
+            cr={8: -1, 9: 0, 10: 1, 11: 0})
+        assert state.regfile.get_lr(2) == 1
+
     def test_loop_with_cr_limit(self):
         """Loop using bne against a CR constant instead of an LR."""
         state = _make_state("""\


### PR DESCRIPTION
## Summary

`BLT` and `BGE` used `_to_signed_32`, which sign-extended operands at bit 31.
LR/CR registers are 20-bit, so a negative value like -1 is stored as `0xFFFFF`.
The 32-bit helper read that as `+1,048,575` instead of `-1`, causing signed
comparisons to produce wrong results — e.g. `BLT(-1, 0)` never branched, so
loops with negative counters executed only once.

The fix mirrors the existing mask-shift reader, which already sign-extends
correctly at bit 19.

## Changes

- **`ipu.py`** — rename `_to_signed_32` → `_to_signed_reg`; threshold and wrap
  now use `LR_CR_SCALAR_BITS` (20) instead of hardcoded 32-bit constants. Both
  `execute_blt` and `execute_bge` updated.
- **`test_execute.py`** — two regression tests: `test_blt_negative_counter`
  (`-1 < 0` must branch) and `test_bge_negative_not_taken` (`-1 >= 0` must not
  branch).

`BGT` and `BLE` are pseudo-instructions that assemble to `BLT`/`BGE` with
swapped operands, so they get the fix for free. `BEQ`, `BNE`, `BZ`, `BNZ`, and
`B` use equality tests where sign is irrelevant — no changes needed.