### PR TITLE
Update AGG instruction references to use MULT_RES lanes 

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -95,7 +95,7 @@ LDR_MULT_REG R0, LR0, CR0; MULT.RC.VV LR1, R0, 0, LR3; ACC; ADD LR0, LR0, 1; BNE
 | STORE | `STR_POST_AAQ_REG` | Last-stage memory store (drains `POST_AAQ_REG`) |
 | ACC_STORE | `STR_ACC_REG` | **Simulation-only** — store `R_ACC` to external memory |
 | MULT | `MULT.RC.VV`, `MULT.RC.VE`, `MULT.RC.VS`, `MULT.VE`, `MULT.EE` | 8-bit vector multiply |
-| ACC | `ACC`, `ACC.FIRST`, `ACC.STRIDE`, `AGG.SUM`, `AGG.SUM.FIRST`, `AGG.MAX`, `AGG.MAX.FIRST` | Accumulate into `R_ACC`; in-place aggregation (sum/max) writing a single slot of `R_ACC` |
+| ACC | `ACC`, `ACC.FIRST`, `ACC.STRIDE`, `AGG.SUM`, `AGG.SUM.FIRST`, `AGG.MAX`, `AGG.MAX.FIRST` | Accumulate into `R_ACC`; AGG instructions reduce `MULT_RES` lanes (sum/max) into a single slot of `R_ACC` |
 | AAQ | `AAQ`, `ACTIVATE` | **`ACTIVATE`** reads **`R_ACC`** and writes activated **32b** lanes into **`POST_AAQ_REG`** (512 B staging). **`AAQ`** (INT8) quantizes wide lanes in **`POST_AAQ_REG`** into the leading **128 B**; **`STR_POST_AAQ_REG`** stores the full **512 B** register to XMEM. See `docs/content/building-applications.md#activations-emulator`. |
 | LR (×3) | `SET`, `ADD`, `SUB`, `INCR_MOD_POW2`, `INC`, `DEC` | Scalar loop register ops (`SET` copies from a **`CR`** register; `INC`/`DEC` read-modify-write with union-derived immediate) |
 | COND | `BEQ`, `BNE`, `BLT`, `BGE`, `BR`, `BKPT` | Branches. `BGT`, `BLE`, `BZ`, `BNZ`, `B` are pseudo-instructions (assembler-expanded, no opcode) — see `PSEUDO_INSTRUCTION_SPEC` in `instruction_spec.py` |

--- a/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
@@ -893,26 +893,26 @@ class Ipu:
         return best
 
     def execute_agg_sum_first(self, *, dest_slot: int, full_xmem_row: int) -> None:
-        """Execute AGG.SUM.FIRST: sum active R_ACC lanes, write to R_ACC[dest] (clean init)."""
+        """Execute AGG.SUM.FIRST: sum active MULT_RES lanes, write to R_ACC[dest] (clean init)."""
         valid_elements = 128 if full_xmem_row else self.state.get_config_valid_elements()
         fmt = self._acc_agg_lane_fmt()
-        snap_acc = self.snapshot.raw("r_acc")
+        mult_res = self.state.regfile.raw("mult_res")
         active = self._agg_active_lane_count(valid_elements)
-        result = self._agg_sum_lanes(fmt, snap_acc, active)
+        result = self._agg_sum_lanes(fmt, mult_res, active)
         dest = int(dest_slot) % (R_ACC_SIZE // 4)
         if fmt == "<i":
             result = self._to_int32(result)
         struct.pack_into(fmt, self.state.regfile.raw("r_acc"), dest * 4, result)
 
     def execute_agg_sum(self, *, dest_slot: int, full_xmem_row: int) -> None:
-        """Execute AGG.SUM: sum active R_ACC lanes and add to R_ACC[dest] (running accumulation)."""
+        """Execute AGG.SUM: sum active MULT_RES lanes and add to R_ACC[dest] (running accumulation)."""
         valid_elements = 128 if full_xmem_row else self.state.get_config_valid_elements()
         fmt = self._acc_agg_lane_fmt()
-        snap_acc = self.snapshot.raw("r_acc")
+        mult_res = self.state.regfile.raw("mult_res")
         active = self._agg_active_lane_count(valid_elements)
         dest = int(dest_slot) % (R_ACC_SIZE // 4)
-        snap_dest = struct.unpack_from(fmt, snap_acc, dest * 4)[0]
-        partial = self._agg_sum_lanes(fmt, snap_acc, active)
+        snap_dest = struct.unpack_from(fmt, self.snapshot.raw("r_acc"), dest * 4)[0]
+        partial = self._agg_sum_lanes(fmt, mult_res, active)
         if fmt == "<f":
             result: float | int = float(partial) + float(snap_dest)
         else:
@@ -920,29 +920,29 @@ class Ipu:
         struct.pack_into(fmt, self.state.regfile.raw("r_acc"), dest * 4, result)
 
     def execute_agg_max_first(self, *, dest_slot: int, full_xmem_row: int) -> None:
-        """Execute AGG.MAX.FIRST: max of active R_ACC lanes, write to R_ACC[dest] (no seed).
+        """Execute AGG.MAX.FIRST: max of active MULT_RES lanes, write to R_ACC[dest] (no seed).
 
         When no lanes are active (valid_elements=0) the identity seed
         (INT32_MIN / -inf) is written, so the destination is always defined.
         """
         valid_elements = 128 if full_xmem_row else self.state.get_config_valid_elements()
         fmt = self._acc_agg_lane_fmt()
-        snap_acc = self.snapshot.raw("r_acc")
+        mult_res = self.state.regfile.raw("mult_res")
         active = self._agg_active_lane_count(valid_elements)
         seed: float | int = -2147483648 if fmt == "<i" else float("-inf")
-        result = self._agg_max_lanes(fmt, snap_acc, active, seed)
+        result = self._agg_max_lanes(fmt, mult_res, active, seed)
         dest = int(dest_slot) % (R_ACC_SIZE // 4)
         struct.pack_into(fmt, self.state.regfile.raw("r_acc"), dest * 4, result)
 
     def execute_agg_max(self, *, dest_slot: int, full_xmem_row: int) -> None:
-        """Execute AGG.MAX: max of active R_ACC lanes seeded with R_ACC[dest] (running max)."""
+        """Execute AGG.MAX: max of active MULT_RES lanes seeded with R_ACC[dest] (running max)."""
         valid_elements = 128 if full_xmem_row else self.state.get_config_valid_elements()
         fmt = self._acc_agg_lane_fmt()
-        snap_acc = self.snapshot.raw("r_acc")
+        mult_res = self.state.regfile.raw("mult_res")
         active = self._agg_active_lane_count(valid_elements)
         dest = int(dest_slot) % (R_ACC_SIZE // 4)
-        snap_dest = struct.unpack_from(fmt, snap_acc, dest * 4)[0]
-        result = self._agg_max_lanes(fmt, snap_acc, active, snap_dest)
+        snap_dest = struct.unpack_from(fmt, self.snapshot.raw("r_acc"), dest * 4)[0]
+        result = self._agg_max_lanes(fmt, mult_res, active, snap_dest)
         struct.pack_into(fmt, self.state.regfile.raw("r_acc"), dest * 4, result)
 
     def execute_aaq(self, *, full_xmem_row: int) -> None:

--- a/src/tools/ipu-emu-py/test/test_execute.py
+++ b/src/tools/ipu-emu-py/test/test_execute.py
@@ -885,7 +885,7 @@ BKPT;;
             assert w == 0, f"word {i} (after segment): expected 0, got {w}"
 
     def test_agg_sum_first_basic(self):
-        """AGG.SUM.FIRST: sum all 128 lanes and write to R_ACC[dest] (clean init)."""
+        """AGG.SUM.FIRST: sum all 128 MULT_RES lanes and write to R_ACC[dest] (clean init)."""
         state = _make_state(
             """\
 AGG.SUM.FIRST LR0 1;;
@@ -896,17 +896,17 @@ BKPT;;
         state.set_cr_dstructure(128)
         state.regfile.set_lr(0, 127)  # dest = R_ACC[127]
         for i in range(128):
-            state.regfile.set_r_acc_word(i, struct.unpack("<I", struct.pack("<i", 1))[0])
+            state.regfile.set_mult_res_word(i, struct.unpack("<I", struct.pack("<i", 1))[0])
         run_until_complete(state)
         raw = state.regfile.get_r_acc_word(127)
         result = struct.unpack("<i", struct.pack("<I", raw))[0]
         assert result == 128, f"expected sum=128, got {result}"
 
     def test_agg_sum_first_ignores_existing_dest(self):
-        """AGG.SUM.FIRST: existing value at dest is NOT added to the result (clean initialisation).
+        """AGG.SUM.FIRST: existing R_ACC[dest] is NOT added to the result (clean initialisation).
 
-        Dest is placed outside the active lane range so its value is excluded from the sum
-        but would be added as a seed in the non-FIRST variant.
+        Dest is placed outside the active lane range so its value would be added
+        as a seed in the non-FIRST variant, but must be ignored here.
         """
         state = _make_state(
             """\
@@ -918,16 +918,16 @@ BKPT;;
         state.set_cr_dstructure(4)  # only lanes 0..3 active
         state.regfile.set_lr(0, 127)  # dest = R_ACC[127], outside active range
         for i in range(128):
-            state.regfile.set_r_acc_word(i, struct.unpack("<I", struct.pack("<i", 1))[0])
+            state.regfile.set_mult_res_word(i, struct.unpack("<I", struct.pack("<i", 1))[0])
         state.regfile.set_r_acc_word(127, struct.unpack("<I", struct.pack("<i", 9999))[0])
         run_until_complete(state)
         raw = state.regfile.get_r_acc_word(127)
         result = struct.unpack("<i", struct.pack("<I", raw))[0]
-        # sum of active lanes 0..3 = 4; existing dest (9999) is NOT added
+        # sum of active MULT_RES lanes 0..3 = 4; existing dest (9999) is NOT added
         assert result == 4, f"expected sum=4 (not 4+9999), got {result}"
 
     def test_agg_sum_first_uses_valid_elements(self):
-        """AGG.SUM.FIRST: only active prefix contributes; tail is excluded."""
+        """AGG.SUM.FIRST: only active MULT_RES prefix contributes; tail is excluded."""
         state = _make_state(
             """\
 AGG.SUM.FIRST LR0 0;;
@@ -939,14 +939,14 @@ BKPT;;
         state.regfile.set_lr(0, 127)
         for i in range(128):
             v = 10 if i < 4 else 1000
-            state.regfile.set_r_acc_word(i, struct.unpack("<I", struct.pack("<i", v))[0])
+            state.regfile.set_mult_res_word(i, struct.unpack("<I", struct.pack("<i", v))[0])
         run_until_complete(state)
         raw = state.regfile.get_r_acc_word(127)
         result = struct.unpack("<i", struct.pack("<I", raw))[0]
         assert result == 40, f"expected sum of 4 tens = 40, got {result}"
 
     def test_agg_sum_first_full_xmem_row_overrides_valid_elements(self):
-        """AGG.SUM.FIRST with full_xmem_row=1 uses all 128 lanes regardless of CR15."""
+        """AGG.SUM.FIRST with full_xmem_row=1 uses all 128 MULT_RES lanes regardless of CR15."""
         state = _make_state(
             """\
 AGG.SUM.FIRST LR0 1;;
@@ -957,14 +957,14 @@ BKPT;;
         state.set_cr_dstructure(valid_elements=4)
         state.regfile.set_lr(0, 127)
         for i in range(128):
-            state.regfile.set_r_acc_word(i, struct.unpack("<I", struct.pack("<i", 1))[0])
+            state.regfile.set_mult_res_word(i, struct.unpack("<I", struct.pack("<i", 1))[0])
         run_until_complete(state)
         raw = state.regfile.get_r_acc_word(127)
         result = struct.unpack("<i", struct.pack("<I", raw))[0]
         assert result == 128, f"expected sum of all 128 lanes = 128, got {result}"
 
     def test_agg_sum_accumulates(self):
-        """AGG.SUM: sum of active lanes is ADDED to existing R_ACC[dest] (running accumulation).
+        """AGG.SUM: sum of active MULT_RES lanes is ADDED to existing R_ACC[dest] (running acc).
 
         Dest is placed outside the active lane range so it acts as a pure accumulator
         that is not double-counted in the sum.
@@ -979,16 +979,16 @@ BKPT;;
         state.set_cr_dstructure(64)  # only lanes 0..63 active
         state.regfile.set_lr(0, 127)  # dest = R_ACC[127], outside active range
         for i in range(128):
-            state.regfile.set_r_acc_word(i, struct.unpack("<I", struct.pack("<i", 1))[0])
+            state.regfile.set_mult_res_word(i, struct.unpack("<I", struct.pack("<i", 1))[0])
         state.regfile.set_r_acc_word(127, struct.unpack("<I", struct.pack("<i", 50))[0])
         run_until_complete(state)
-        # sum(R_ACC[0..63]) = 64; R_ACC[127] was 50 → result = 64 + 50 = 114
+        # sum(MULT_RES[0..63]) = 64; R_ACC[127] was 50 → result = 64 + 50 = 114
         raw = state.regfile.get_r_acc_word(127)
         result = struct.unpack("<i", struct.pack("<I", raw))[0]
         assert result == 114, f"expected 64+50=114, got {result}"
 
     def test_agg_max_first_basic(self):
-        """AGG.MAX.FIRST: max of all 128 lanes, no seed from dest."""
+        """AGG.MAX.FIRST: max of all 128 MULT_RES lanes, no seed from dest."""
         state = _make_state(
             """\
 AGG.MAX.FIRST LR0 1;;
@@ -999,19 +999,19 @@ BKPT;;
         state.set_cr_dstructure(128)
         state.regfile.set_lr(0, 127)
         for i in range(128):
-            state.regfile.set_r_acc_word(i, struct.unpack("<I", struct.pack("<i", 5 + (i % 10)))[0])
-        state.regfile.set_r_acc_word(127, struct.unpack("<I", struct.pack("<i", 9999))[0])
+            state.regfile.set_mult_res_word(i, struct.unpack("<I", struct.pack("<i", 5 + (i % 10)))[0])
+        state.regfile.set_mult_res_word(127, struct.unpack("<I", struct.pack("<i", 9999))[0])
         run_until_complete(state)
         raw = state.regfile.get_r_acc_word(127)
         result = struct.unpack("<i", struct.pack("<I", raw))[0]
-        assert result == 9999, f"expected max=9999 (from slot 127), got {result}"
+        assert result == 9999, f"expected max=9999 (from MULT_RES slot 127), got {result}"
 
     def test_agg_max_first_ignores_garbage_dest(self):
-        """AGG.MAX.FIRST: existing dest value is NOT used as a seed.
+        """AGG.MAX.FIRST: existing R_ACC[dest] is NOT used as a seed.
 
         Dest is placed outside the active lane range and pre-loaded with a
         large garbage value; a seeded implementation would return it, the
-        clean-init implementation must return the max of the active lanes.
+        clean-init implementation must return the max of the active MULT_RES lanes.
         """
         state = _make_state(
             """\
@@ -1023,12 +1023,12 @@ BKPT;;
         state.set_cr_dstructure(64)  # only lanes 0..63 active
         state.regfile.set_lr(0, 127)  # dest = R_ACC[127], outside active range
         for i in range(128):
-            state.regfile.set_r_acc_word(i, struct.unpack("<I", struct.pack("<i", 5))[0])
+            state.regfile.set_mult_res_word(i, struct.unpack("<I", struct.pack("<i", 5))[0])
         state.regfile.set_r_acc_word(127, struct.unpack("<I", struct.pack("<i", 9999))[0])
         run_until_complete(state)
         raw = state.regfile.get_r_acc_word(127)
         result = struct.unpack("<i", struct.pack("<I", raw))[0]
-        assert result == 5, f"expected max of active lanes = 5 (not seed 9999), got {result}"
+        assert result == 5, f"expected max of active MULT_RES lanes = 5 (not R_ACC seed 9999), got {result}"
 
     def test_agg_max_first_zero_active_writes_identity_seed(self):
         """AGG.MAX.FIRST with valid_elements=0: dest gets the identity seed (INT32_MIN)."""
@@ -1048,7 +1048,7 @@ BKPT;;
         assert result == -2147483648, f"expected INT32_MIN identity seed, got {result}"
 
     def test_agg_max_first_masks_tail(self):
-        """AGG.MAX.FIRST: tail lanes beyond valid_elements are excluded."""
+        """AGG.MAX.FIRST: MULT_RES tail lanes beyond valid_elements are excluded."""
         state = _make_state(
             """\
 AGG.MAX.FIRST LR0 0;;
@@ -1060,15 +1060,14 @@ BKPT;;
         state.regfile.set_lr(0, 127)
         for i in range(128):
             v = 3 if i < 50 else 9999
-            state.regfile.set_r_acc_word(i, struct.unpack("<I", struct.pack("<i", v))[0])
-        state.regfile.set_r_acc_word(127, struct.unpack("<I", struct.pack("<i", 3))[0])
+            state.regfile.set_mult_res_word(i, struct.unpack("<I", struct.pack("<i", v))[0])
         run_until_complete(state)
         raw = state.regfile.get_r_acc_word(127)
         result = struct.unpack("<i", struct.pack("<I", raw))[0]
-        assert result == 3, f"expected max of active prefix = 3, got {result}"
+        assert result == 3, f"expected max of active MULT_RES prefix = 3, got {result}"
 
     def test_agg_max_seed_wins(self):
-        """AGG.MAX: existing dest value beats all active lanes — dest unchanged."""
+        """AGG.MAX: existing R_ACC[dest] seed beats all active MULT_RES lanes — dest unchanged."""
         state = _make_state(
             """\
 AGG.MAX LR0 1;;
@@ -1079,15 +1078,15 @@ BKPT;;
         state.set_cr_dstructure(128)
         state.regfile.set_lr(0, 127)
         for i in range(128):
-            state.regfile.set_r_acc_word(i, struct.unpack("<I", struct.pack("<i", 10))[0])
+            state.regfile.set_mult_res_word(i, struct.unpack("<I", struct.pack("<i", 10))[0])
         state.regfile.set_r_acc_word(127, struct.unpack("<I", struct.pack("<i", 99))[0])
         run_until_complete(state)
         raw = state.regfile.get_r_acc_word(127)
         result = struct.unpack("<i", struct.pack("<I", raw))[0]
-        assert result == 99, f"expected seed 99 to remain (beats all lanes=10), got {result}"
+        assert result == 99, f"expected seed 99 to remain (beats all MULT_RES lanes=10), got {result}"
 
     def test_agg_max_lane_wins(self):
-        """AGG.MAX: an active lane beats the existing dest — dest updated."""
+        """AGG.MAX: an active MULT_RES lane beats the existing R_ACC[dest] seed — dest updated."""
         state = _make_state(
             """\
 AGG.MAX LR0 0;;
@@ -1099,8 +1098,8 @@ BKPT;;
         state.regfile.set_lr(0, 127)
         for i in range(128):
             v = 5 if i < 100 else 1
-            state.regfile.set_r_acc_word(i, struct.unpack("<I", struct.pack("<i", v))[0])
-        state.regfile.set_r_acc_word(63, struct.unpack("<I", struct.pack("<i", 77))[0])
+            state.regfile.set_mult_res_word(i, struct.unpack("<I", struct.pack("<i", v))[0])
+        state.regfile.set_mult_res_word(63, struct.unpack("<I", struct.pack("<i", 77))[0])
         state.regfile.set_r_acc_word(127, struct.unpack("<I", struct.pack("<i", 3))[0])
         run_until_complete(state)
         raw = state.regfile.get_r_acc_word(127)
@@ -1110,10 +1109,8 @@ BKPT;;
     def test_agg_and_activate_same_cycle_use_snapshot(self):
         """AGG.SUM.FIRST in ACC slot and ACTIVATE in AAQ slot issued together.
 
-        Both must read from the cycle-start snapshot, not from each other's
-        write. ACTIVATE writes POST_AAQ_REG; AGG writes r_acc[dest].
-        Neither's output should be influenced by the other's write in the
-        same cycle.
+        AGG reads from MULT_RES (live) and writes r_acc[dest].
+        ACTIVATE reads from the cycle-start snapshot of r_acc (not the AGG write).
         """
         state = _make_state(
             """\
@@ -1123,19 +1120,19 @@ BKPT;;
         )
         state.dtype = DType.INT8
         state.regfile.set_lr(0, 0)  # AGG dest = r_acc[0]
-        # Fill lanes: all 3.0 as float32 for ACTIVATE; values = 3 as int32 for AGG
         import struct as _struct
         for i in range(128):
-            # Store int32(3) — used by AGG.SUM.FIRST
+            # MULT_RES lanes = 3 (source for AGG.SUM.FIRST)
+            state.regfile.set_mult_res_word(i, _struct.unpack("<I", _struct.pack("<i", 3))[0])
+            # r_acc lanes = 3 (source for ACTIVATE snapshot)
             state.regfile.set_r_acc_word(i, _struct.unpack("<I", _struct.pack("<i", 3))[0])
 
         run_until_complete(state)
 
-        # AGG.SUM.FIRST must have summed the snapshot r_acc (128 lanes × 3 = 384)
-        # NOT the post-ACTIVATE live state
+        # AGG.SUM.FIRST must have summed MULT_RES (128 lanes × 3 = 384) into r_acc[0]
         raw_agg = state.regfile.get_r_acc_word(0)
         agg_result = _struct.unpack("<i", _struct.pack("<I", raw_agg))[0]
-        assert agg_result == 384, f"AGG saw wrong r_acc: expected 384, got {agg_result}"
+        assert agg_result == 384, f"AGG saw wrong mult_res: expected 384, got {agg_result}"
 
         # ACTIVATE relu must have applied relu to the snapshot r_acc (all lanes 3 → 3)
         # NOT the post-AGG r_acc where lane 0 = 384.

--- a/src/tools/ipu-emu-py/test/test_wide_vector_debug.py
+++ b/src/tools/ipu-emu-py/test/test_wide_vector_debug.py
@@ -296,11 +296,11 @@ class TestWideVectorAgg:
     """Wide-vector coverage for the ACC-slot AGG.* instructions."""
 
     def _run_agg(
-        self, asm: str, arithmetic: WideVectorArithmetic, acc: bytearray
+        self, asm: str, arithmetic: WideVectorArithmetic, mult_res: bytearray
     ) -> IpuState:
         st = IpuState(wide_vector_debug=True, wide_vector_arithmetic=arithmetic)
         st.dtype = DType.INT8
-        st.regfile.set_r_acc_bytes(acc)
+        st.regfile.set_mult_res_bytes(mult_res)
         st.set_cr_dstructure(128)
         st.regfile.set_lr(0, 127)  # dest = r_acc lane 127
         encoded = assemble(asm)
@@ -310,31 +310,31 @@ class TestWideVectorAgg:
 
     def test_agg_sum_first_int32_wide(self) -> None:
         """AGG.SUM.FIRST with INT32 wide lanes: 128×4 = 512 written to dest lane."""
-        acc = bytearray(512)
-        struct.pack_into("<128i", acc, 0, *([4] * 128))
+        mult_res = bytearray(512)
+        struct.pack_into("<128i", mult_res, 0, *([4] * 128))
         st = self._run_agg(
-            "AGG.SUM.FIRST LR0 0;;\nBKPT;;\n", WideVectorArithmetic.INT32, acc
+            "AGG.SUM.FIRST LR0 0;;\nBKPT;;\n", WideVectorArithmetic.INT32, mult_res
         )
         raw = st.regfile.raw("r_acc")
         assert struct.unpack_from("<i", raw, 127 * 4)[0] == 512
 
     def test_agg_sum_first_fp32_wide(self) -> None:
         """AGG.SUM.FIRST with FP32 wide lanes: 128×0.5 = 64.0 written to dest lane."""
-        acc = bytearray(512)
-        struct.pack_into("<128f", acc, 0, *([0.5] * 128))
+        mult_res = bytearray(512)
+        struct.pack_into("<128f", mult_res, 0, *([0.5] * 128))
         st = self._run_agg(
-            "AGG.SUM.FIRST LR0 0;;\nBKPT;;\n", WideVectorArithmetic.FP32, acc
+            "AGG.SUM.FIRST LR0 0;;\nBKPT;;\n", WideVectorArithmetic.FP32, mult_res
         )
         raw = st.regfile.raw("r_acc")
         assert struct.unpack_from("<f", raw, 127 * 4)[0] == pytest.approx(64.0)
 
     def test_agg_max_first_fp32_wide(self) -> None:
         """AGG.MAX.FIRST with FP32 wide lanes picks the largest lane."""
-        acc = bytearray(512)
-        struct.pack_into("<128f", acc, 0, *([1.0] * 128))
-        struct.pack_into("<f", acc, 3 * 4, 7.5)
+        mult_res = bytearray(512)
+        struct.pack_into("<128f", mult_res, 0, *([1.0] * 128))
+        struct.pack_into("<f", mult_res, 3 * 4, 7.5)
         st = self._run_agg(
-            "AGG.MAX.FIRST LR0 0;;\nBKPT;;\n", WideVectorArithmetic.FP32, acc
+            "AGG.MAX.FIRST LR0 0;;\nBKPT;;\n", WideVectorArithmetic.FP32, mult_res
         )
         raw = st.regfile.raw("r_acc")
         assert struct.unpack_from("<f", raw, 127 * 4)[0] == pytest.approx(7.5)


### PR DESCRIPTION
## Summary

- **Bug:** All four AGG instruction handlers (`AGG.SUM.FIRST`, `AGG.SUM`, `AGG.MAX.FIRST`, `AGG.MAX`) were reading lane data from `R_ACC` (via the cycle-start snapshot) instead of `MULT_RES` (the multiplication stage output), causing them to reduce the accumulator over itself rather than over the multiply result.
- **Fix:** Each handler now reads lane data from `self.state.regfile.raw("mult_res")` (live). The non-FIRST variants (`AGG.SUM`, `AGG.MAX`) still read their running-accumulator seed from `snapshot.r_acc[dest]`, which is correct.
- **Tests:** All existing AGG tests were updated to populate `MULT_RES` (via `set_mult_res_word` / `set_mult_res_bytes`) as the source data. The snapshot-isolation test (`test_agg_and_activate_same_cycle_use_snapshot`) was updated to populate both `MULT_RES` (for AGG) and `R_ACC` (for ACTIVATE's snapshot read).
- **Docs:** Updated descriptions and pseudocode for all four AGG instructions in `docs/content/instructions.md` and the ACC-slot row in `SKILL.md` to say `MULT_RES` instead of `R_ACC` as the lane source.

## Files changed

| File | Change |
|------|--------|
| `src/tools/ipu-emu-py/src/ipu_emu/ipu.py` | Fixed `execute_agg_sum_first`, `execute_agg_sum`, `execute_agg_max_first`, `execute_agg_max` to read from `mult_res` |
| `src/tools/ipu-emu-py/test/test_execute.py` | Updated all AGG tests to source data from `MULT_RES` |
| `src/tools/ipu-emu-py/test/test_wide_vector_debug.py` | Updated `_run_agg` helper to populate `mult_res` instead of `r_acc` |
| `docs/content/instructions.md` | Corrected description + pseudocode for all four AGG variants |
| `SKILL.md` | Corrected ACC-slot description |