### PR TITLE
Allow per-command CR register for dstructure in mult/acc/aaq stages (#130)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -103,7 +103,7 @@ LDR_MULT_REG R0, LR0, CR0; MULT.RC.VV LR1, R0, 0, LR3; ACC; ADD LR0, LR0, 1; BNE
 
 ### Operand Types (defined in instruction_spec)
 
-`MultStageReg`, `LrIdx`, `CrIdx`, `LcrIdx`, `LrIncDecImmediate`, `FullXmemRow`, `ActivationFn`, `ElementsInRow`, `HorizontalStride`, `VerticalStride`, `LrModPow2KImmediate`, `MultMaskOffsetImmediate`, `BreakImmediate`, `Label`
+`MultStageReg`, `LrIdx`, `CrIdx`, `LcrIdx`, `DstructureCrIdx`, `LrIncDecImmediate`, `ActivationFn`, `ElementsInRow`, `HorizontalStride`, `VerticalStride`, `LrModPow2KImmediate`, `MultMaskOffsetImmediate`, `BreakImmediate`, `Label`
 
 `ACC.STRIDE` operand enums (see `acc_stride_enums.py`): `ElementsInRow` = **`16`**, **`32`**, **`64`**; `HorizontalStride` = **`off`**, **`on`**, **`on_inv`** (expand is fixed hardware behaviour, not programmable).
 

--- a/docs/content/building-applications.md
+++ b/docs/content/building-applications.md
@@ -29,7 +29,8 @@ def setup(self, state: IpuState) -> None:
     # dtype is emulator-only state, not a CR register.
     state.dtype = DType.INT8
 
-    # CR15 dstructure: AGG.*, ACTIVATE, and AAQ read this by default (cr_idx omitted).
+    # CR15 dstructure: configure whichever CR register your AGG.*/ACTIVATE/AAQ
+    # instructions name via their mandatory cr_idx operand.
     state.set_cr_dstructure(valid_elements=128, partition=0)
 
     # CR0 and CR1 are read-only constants (0 and 1). Use CR2-CR14 for app data.
@@ -41,17 +42,18 @@ def setup(self, state: IpuState) -> None:
     state.regfile.set_cr(9, (-128) & LR_CR_SCALAR_VALUE_MASK)
 ```
 
-In assembly, the dstructure lane count comes from `CR15` by default, or from an
-explicit `cr_idx` operand:
+In assembly, every `AGG.*`/`ACTIVATE`/`AAQ` instruction must name its
+dstructure CR register explicitly via a mandatory `cr_idx` operand — there is
+no implicit default:
 
 ```asm
-AGG.SUM LR0;;
-ACTIVATE relu;;
+AGG.SUM LR0, CR15;;
+ACTIVATE relu, CR15;;
 AGG.SUM LR0, CR3;;
 ACTIVATE relu, CR3;;
 ```
 
-For aggregation (`AGG.SUM`, `AGG.MAX`, etc.) the lane count is controlled by the optional `cr_idx` operand — it reads `valid_elements` from the named CR register, defaulting to `CR15` when omitted.
+For aggregation (`AGG.SUM`, `AGG.MAX`, etc.) the lane count is controlled by the required `cr_idx` operand — it reads `valid_elements` from the named CR register. `CR15` remains a valid choice (it is the dstructure register's conventional home), but it must be written out like any other register.
 
 ## Wide-vector debug mode (optional)
 
@@ -64,10 +66,10 @@ The [AAQ stage spec](specs/stage-aaq.md) describes how **real hardware** wires a
 The **Python emulator** in this repository adds a convenience AAQ-slot instruction **`ACTIVATE`** so programs can apply the same nine activation shapes to lanes read from **`R_ACC`**, writing results into **`POST_AAQ_REG`** (without modifying **`R_ACC`**), without modeling the full `act_cr_idx` path:
 
 ```asm
-ACTIVATE relu;;
+ACTIVATE relu, CR15;;
 ```
 
-- **Syntax:** `ACTIVATE activation_fn[, cr_idx]`, where *activation_fn* is a **keyword** (`identity`, `relu`, `relu6`, `sigmoid`, `tanh`, `gelu`, `softplus`, `elu`, `exp2`). The active lane count comes from `cr_idx`'s `valid_elements`, the same dstructure field used by the `AGG.*` instructions; `cr_idx` defaults to `CR15` when omitted.
+- **Syntax:** `ACTIVATE activation_fn, cr_idx`, where *activation_fn* is a **keyword** (`identity`, `relu`, `relu6`, `sigmoid`, `tanh`, `gelu`, `softplus`, `elu`, `exp2`). The active lane count comes from `cr_idx`'s `valid_elements`, the same dstructure field used by the `AGG.*` instructions; `cr_idx` is mandatory (any `CR0`–`CR15`, no implicit default).
 - **Single source of truth:** keyword order and the pure-Python math live in `src/tools/ipu-common/src/ipu_common/activations.py` (`ACTIVATION_FN_NAMES`, `apply_activation`).
 
 ### `R_ACC`, `POST_AAQ_REG`, and `STR_POST_AAQ_REG` (staging vs export)

--- a/docs/content/building-applications.md
+++ b/docs/content/building-applications.md
@@ -29,7 +29,7 @@ def setup(self, state: IpuState) -> None:
     # dtype is emulator-only state, not a CR register.
     state.dtype = DType.INT8
 
-    # CR15 dstructure: AGG.*, ACTIVATE, and AAQ read this when full_xmem_row=0.
+    # CR15 dstructure: AGG.*, ACTIVATE, and AAQ read this by default (cr_idx omitted).
     state.set_cr_dstructure(valid_elements=128, partition=0)
 
     # CR0 and CR1 are read-only constants (0 and 1). Use CR2-CR14 for app data.
@@ -41,15 +41,17 @@ def setup(self, state: IpuState) -> None:
     state.regfile.set_cr(9, (-128) & LR_CR_SCALAR_VALUE_MASK)
 ```
 
-In assembly, the selected dstructure lane count is implicit when
-`full_xmem_row=0`:
+In assembly, the dstructure lane count comes from `CR15` by default, or from an
+explicit `cr_idx` operand:
 
 ```asm
-AGG.SUM LR0, 0;;
-ACTIVATE relu, 0;;
+AGG.SUM LR0;;
+ACTIVATE relu;;
+AGG.SUM LR0, CR3;;
+ACTIVATE relu, CR3;;
 ```
 
-For aggregation (`AGG.SUM`, `AGG.MAX`, etc.) the lane count is controlled by the explicit `full_xmem_row` operand — `0` reads from `CR15.valid_elements`, `1` always uses 128 lanes.
+For aggregation (`AGG.SUM`, `AGG.MAX`, etc.) the lane count is controlled by the optional `cr_idx` operand — it reads `valid_elements` from the named CR register, defaulting to `CR15` when omitted.
 
 ## Wide-vector debug mode (optional)
 
@@ -62,10 +64,10 @@ The [AAQ stage spec](specs/stage-aaq.md) describes how **real hardware** wires a
 The **Python emulator** in this repository adds a convenience AAQ-slot instruction **`ACTIVATE`** so programs can apply the same nine activation shapes to lanes read from **`R_ACC`**, writing results into **`POST_AAQ_REG`** (without modifying **`R_ACC`**), without modeling the full `act_cr_idx` path:
 
 ```asm
-ACTIVATE relu, 0;;
+ACTIVATE relu;;
 ```
 
-- **Syntax:** `ACTIVATE activation_fn, full_xmem_row`, where *activation_fn* is a **keyword** (`identity`, `relu`, `relu6`, `sigmoid`, `tanh`, `gelu`, `softplus`, `elu`, `exp2`). With `full_xmem_row=0` the active lane count comes from `CR15.valid_elements`, the same implicit dstructure field used by the `AGG.*` instructions; `full_xmem_row=1` always uses all 128 lanes.
+- **Syntax:** `ACTIVATE activation_fn[, cr_idx]`, where *activation_fn* is a **keyword** (`identity`, `relu`, `relu6`, `sigmoid`, `tanh`, `gelu`, `softplus`, `elu`, `exp2`). The active lane count comes from `cr_idx`'s `valid_elements`, the same dstructure field used by the `AGG.*` instructions; `cr_idx` defaults to `CR15` when omitted.
 - **Single source of truth:** keyword order and the pure-Python math live in `src/tools/ipu-common/src/ipu_common/activations.py` (`ACTIVATION_FN_NAMES`, `apply_activation`).
 
 ### `R_ACC`, `POST_AAQ_REG`, and `STR_POST_AAQ_REG` (staging vs export)

--- a/docs/content/ipu-configuration.md
+++ b/docs/content/ipu-configuration.md
@@ -49,10 +49,10 @@ class MyApp(IpuApp):
 ## Selecting lane count and partition
 
 The `AGG.*` aggregation instructions, `ACTIVATE`, and `AAQ` do not take a
-`valid_elements` assembly operand. When their `full_xmem_row` flag is `0`,
-they read the active lane count from `CR15.valid_elements` implicitly
-(`full_xmem_row=1` always uses all 128 lanes). Configure it from Python
-before running the program:
+`valid_elements` assembly operand directly. Instead, they take an optional
+`cr_idx` operand naming the CR register that supplies `valid_elements`; when
+`cr_idx` is omitted, it defaults to `CR15`. Configure it from Python before
+running the program:
 
 ```python
 state.set_cr_dstructure(valid_elements=64, partition=0)
@@ -66,14 +66,19 @@ Activation clamps the active lane count to the available 128 lanes at execution
 time.
 
 The ACC-slot aggregation instructions (`AGG.SUM`, `AGG.SUM.FIRST`, `AGG.MAX`,
-`AGG.MAX.FIRST`) take an explicit `full_xmem_row` operand: `1` always uses all
-128 lanes; `0` reads the active count from `CR15.valid_elements` at runtime.
-The destination slot in `R_ACC` is given by an LR register:
+`AGG.MAX.FIRST`) take an optional `cr_idx` operand: the active lane count is
+read from that register's `valid_elements` at runtime, defaulting to `CR15`
+when `cr_idx` is omitted. The destination slot in `R_ACC` is given by an LR
+register:
 
 ```asm
-AGG.SUM LR0, 0;;
-AGG.MAX.FIRST LR1, 0;;
-ACTIVATE relu, 0;;
+AGG.SUM LR0;;
+AGG.MAX.FIRST LR1;;
+ACTIVATE relu;;
+
+AGG.SUM LR0, CR3;;
+AGG.MAX.FIRST LR1, CR3;;
+ACTIVATE relu, CR3;;
 ```
 
 ## Setting CR application constants

--- a/docs/content/ipu-configuration.md
+++ b/docs/content/ipu-configuration.md
@@ -49,10 +49,11 @@ class MyApp(IpuApp):
 ## Selecting lane count and partition
 
 The `AGG.*` aggregation instructions, `ACTIVATE`, and `AAQ` do not take a
-`valid_elements` assembly operand directly. Instead, they take an optional
-`cr_idx` operand naming the CR register that supplies `valid_elements`; when
-`cr_idx` is omitted, it defaults to `CR15`. Configure it from Python before
-running the program:
+`valid_elements` assembly operand directly. Instead, they take a mandatory
+`cr_idx` operand naming the CR register that supplies `valid_elements` — there
+is no implicit default, every instruction must name a CR register explicitly
+(any `CR0`-`CR15`). Configure the chosen register from Python before running
+the program:
 
 ```python
 state.set_cr_dstructure(valid_elements=64, partition=0)
@@ -66,15 +67,14 @@ Activation clamps the active lane count to the available 128 lanes at execution
 time.
 
 The ACC-slot aggregation instructions (`AGG.SUM`, `AGG.SUM.FIRST`, `AGG.MAX`,
-`AGG.MAX.FIRST`) take an optional `cr_idx` operand: the active lane count is
-read from that register's `valid_elements` at runtime, defaulting to `CR15`
-when `cr_idx` is omitted. The destination slot in `R_ACC` is given by an LR
-register:
+`AGG.MAX.FIRST`) take a mandatory `cr_idx` operand: the active lane count is
+read from that register's `valid_elements` at runtime. The destination slot in
+`R_ACC` is given by an LR register:
 
 ```asm
-AGG.SUM LR0;;
-AGG.MAX.FIRST LR1;;
-ACTIVATE relu;;
+AGG.SUM LR0, CR15;;
+AGG.MAX.FIRST LR1, CR15;;
+ACTIVATE relu, CR15;;
 
 AGG.SUM LR0, CR3;;
 AGG.MAX.FIRST LR1, CR3;;

--- a/docs/content/specs/stage-aaq.md
+++ b/docs/content/specs/stage-aaq.md
@@ -59,8 +59,7 @@ flowchart LR
             r_acc  ─────>│                                      │
        act_cr_idx  ─────>│                                      │
             dtype  ─────>│                                      │
-   valid_elements  ─────>│                                      │
-    full_xmem_row  ─────>│                                      │
+           cr_idx  ─────>│                                      │
                          └──────────────────────────────────────┘
 ```
 
@@ -75,8 +74,7 @@ flowchart LR
 | `r_acc` | `input logic [127:0][31:0]` | 128-lane accumulator (128 × 32-bit). |
 | `act_cr_idx` | `input logic [3:0]` | CR register index whose value selects the activation function (see §7.0). |
 | `dtype` | `input logic [2:0]` | Global data type forwarded from outside configuration; governs lane interpretation for all AAQ operations. Must be `DType.INT8` (0) for `aaq`. |
-| `valid_elements` | `input logic [7:0]` | Active lane count. Sourced from `CR15.valid_elements` (bits [7:0] of the CR15 dstructure register). Ignored when `full_xmem_row` = 1. |
-| `full_xmem_row` | `input logic [0:0]` | Lane-count override. 1 = always use all 128 lanes (ignore `valid_elements`); 0 = use `valid_elements`. Applies to `AAQ` and `ACTIVATE`. |
+| `cr_idx` | `input logic [3:0]` | CR register selecting the dstructure configuration (`valid_elements`, bits [7:0]) used for lane gating. Defaults to CR15 when the operand is omitted. Applies to `AAQ` and `ACTIVATE`. |
 
 ### 3.2 Outputs
 
@@ -121,7 +119,7 @@ The function is selected at runtime by reading the CR register indexed by
 ```text
 // Applied to all valid lanes before quantization
 activation_fn = cr[act_cr_idx]
-n             = 128 if full_xmem_row else min(valid_elements, 128)
+n             = min(cr[cr_idx].valid_elements, 128)
 POST_AAQ_REG[i]  = activation_fn(r_acc[i])   for i in 0..n-1
 POST_AAQ_REG[n..127] = 0
 ```
@@ -148,8 +146,8 @@ Earlier revisions of this stage owned the cross-lane sum/max reduction
 (`agg` / `agg.first`) and a 4 × 32-bit scalar register file (`aaq0`–`aaq3`)
 with post functions. That functionality has been replaced by the ACC-slot
 `AGG.SUM`, `AGG.SUM.FIRST`, `AGG.MAX`, and `AGG.MAX.FIRST` instructions,
-which reduce `r_acc[0..n-1]` (with `n` selected by `full_xmem_row` /
-`CR15.valid_elements` exactly as in §3.1) and write the scalar result into
+which reduce `r_acc[0..n-1]` (with `n` selected by the instruction's `cr_idx`
+operand, defaulting to CR15, exactly as in §3.1) and write the scalar result into
 the `r_acc` slot given by an LR register. The AAQ stage no longer holds a
 register file and exposes no RF feedback to the MULT or ACC stages.
 
@@ -161,7 +159,7 @@ lanes as FP32, quantizes to INT8, clamps, and writes the 128-byte result to
 
 ```text
 // dtype must be DType.INT8; POST_AAQ_REG lanes are FP32
-n = 128 if full_xmem_row else min(CR15.valid_elements, 128)
+n = min(cr[cr_idx].valid_elements, 128)
 for i in 0..n-1:
     val            = POST_AAQ_REG[i]        // FP32
     aaq_result[i]  = clamp(round(val), -128, 127)
@@ -197,8 +195,8 @@ duplicated here.
 
 The AAQ slot is resolved by CTRL and forwarded down the dispatch chain;
 the stage does not read the CR/LR register files itself (see the
-Control Stage spec, §5). The active lane count is determined by `full_xmem_row`:
-`1` = always 128, `0` = `CR15.valid_elements` at cycle start.
+Control Stage spec, §5). The active lane count is determined by the `cr_idx`
+operand: `valid_elements` from the selected CR's dstructure configuration at cycle start (default CR15).
 
 ### 8.1 `AAQ_NOP` — No Operation
 
@@ -210,35 +208,35 @@ Control Stage spec, §5). The active lane count is determined by `full_xmem_row`
 
 ### 8.2 `AAQ` — Quantize Accumulator
 
-- **Summary:** Quantize wide lanes in `POST_AAQ_REG` to 8-bit and write the 128-byte `aaq_result` register. Requires INT8 mode. The `full_xmem_row` flag controls how many lanes are active.
-- **Syntax:** `AAQ full_xmem_row`
+- **Summary:** Quantize wide lanes in `POST_AAQ_REG` to 8-bit and write the 128-byte `aaq_result` register. Requires INT8 mode. The optional `cr_idx` operand selects which CR's dstructure configuration controls how many lanes are active.
+- **Syntax:** `AAQ[ cr_idx]`
 - **Operands:**
-  - `full_xmem_row`: `1` = always process all 128 lanes (full XMEM row, ignores `CR15.valid_elements`); `0` = process only the first `CR15.valid_elements` lanes (clamped to 128) and zero the rest. Defaults to `0`.
+  - `cr_idx`: CR0…CR15 supplying `valid_elements` (clamped to 128). Defaults to CR15 when omitted.
 - **Operation:**
   ```text
   // requires dtype == DType.INT8
-  n = 128 if full_xmem_row else min(CR15.valid_elements, 128)
+  n = min(cr[cr_idx].valid_elements, 128)
   for i in 0..n-1:
       aaq_result[i] = clamp(trunc(POST_AAQ_REG[i]), -128, 127)
   aaq_result[n..127] = 0
   ```
   The Quantization block appends 12 bits of metadata to the 1024-bit payload (see §7.2).
-- **Example:** `AAQ 1;;` (full row), `AAQ 0;;` (use `CR15.valid_elements`).
+- **Example:** `AAQ CR3;;` (use `CR3.valid_elements`), `AAQ;;` (use `CR15.valid_elements`).
 - **Notes:** `aaq_result` must be flushed with `XMEM.STORE_AAQ_RESULT offset base` before the next `AAQ` overwrites it (see §7.2).
 
 ### 8.3 `ACTIVATE` — Apply Activation Function
 
 - **Summary:** Apply an element-wise activation function to the active lanes of `r_acc` and write the activated 32-bit lanes into `POST_AAQ_REG`. `r_acc` is not modified.
-- **Syntax:** `ACTIVATE activation_fn, full_xmem_row`
+- **Syntax:** `ACTIVATE activation_fn[, cr_idx]`
 - **Operands:**
   - `activation_fn` — activation keyword (see §7.0): `identity`, `relu`, `relu6`, `sigmoid`, `tanh`, `gelu`, `softplus`, `elu`, `exp2`, `reciprocal`, `rsqrt`.
-  - `full_xmem_row` — `1` = always use 128 lanes; `0` = use `CR15.valid_elements`.
+  - `cr_idx` — CR0…CR15 supplying `valid_elements` (clamped to 128). Defaults to CR15 when omitted.
 - **Operation:**
   ```text
-  n = 128 if full_xmem_row else min(CR15.valid_elements, 128)
+  n = min(cr[cr_idx].valid_elements, 128)
   POST_AAQ_REG[i] = activation_fn(r_acc[i])   for i in 0..n-1
   ```
-- **Example:** `ACTIVATE relu, 0;;`
+- **Example:** `ACTIVATE relu, CR3;;`
 - **Notes:** Reads `r_acc` from the cycle-start snapshot, so an ACC-slot instruction (e.g. `AGG.*`) issued in the same VLIW word does not affect the activated values.
 
 ### 8.4 Summary Table
@@ -246,5 +244,5 @@ Control Stage spec, §5). The active lane count is determined by `full_xmem_row`
 | Slot | Mnemonic | Operands | One-line Effect |
 |------|----------|----------|-----------------|
 | AAQ | `AAQ_NOP`   | —                              | no state change |
-| AAQ | `AAQ`       | `full_xmem_row`                | `aaq_result[0..n-1] = clamp(trunc(POST_AAQ_REG[i]), -128, 127)`, n = 128 if full_xmem_row else CR15.valid_elements |
-| AAQ | `ACTIVATE`  | `activation_fn, full_xmem_row` | `POST_AAQ_REG[0..n-1] = activation_fn(r_acc[i])`, n = 128 if full_xmem_row else CR15.valid_elements |
+| AAQ | `AAQ`       | `[cr_idx]`                | `aaq_result[0..n-1] = clamp(trunc(POST_AAQ_REG[i]), -128, 127)`, n = cr[cr_idx].valid_elements (default CR15) |
+| AAQ | `ACTIVATE`  | `activation_fn[, cr_idx]` | `POST_AAQ_REG[0..n-1] = activation_fn(r_acc[i])`, n = cr[cr_idx].valid_elements (default CR15) |

--- a/docs/content/specs/stage-aaq.md
+++ b/docs/content/specs/stage-aaq.md
@@ -59,7 +59,8 @@ flowchart LR
             r_acc  ─────>│                                      │
        act_cr_idx  ─────>│                                      │
             dtype  ─────>│                                      │
-           cr_idx  ─────>│                                      │
+   valid_elements  ─────>│                                      │
+    full_xmem_row  ─────>│                                      │
                          └──────────────────────────────────────┘
 ```
 
@@ -74,7 +75,8 @@ flowchart LR
 | `r_acc` | `input logic [127:0][31:0]` | 128-lane accumulator (128 × 32-bit). |
 | `act_cr_idx` | `input logic [3:0]` | CR register index whose value selects the activation function (see §7.0). |
 | `dtype` | `input logic [2:0]` | Global data type forwarded from outside configuration; governs lane interpretation for all AAQ operations. Must be `DType.INT8` (0) for `aaq`. |
-| `cr_idx` | `input logic [3:0]` | CR register selecting the dstructure configuration (`valid_elements`, bits [7:0]) used for lane gating. Defaults to CR15 when the operand is omitted. Applies to `AAQ` and `ACTIVATE`. |
+| `valid_elements` | `input logic [7:0]` | Active lane count. Sourced from `CR15.valid_elements` (bits [7:0] of the CR15 dstructure register). Ignored when `full_xmem_row` = 1. |
+| `full_xmem_row` | `input logic [0:0]` | Lane-count override. 1 = always use all 128 lanes (ignore `valid_elements`); 0 = use `valid_elements`. Applies to `AAQ` and `ACTIVATE`. |
 
 ### 3.2 Outputs
 
@@ -119,7 +121,7 @@ The function is selected at runtime by reading the CR register indexed by
 ```text
 // Applied to all valid lanes before quantization
 activation_fn = cr[act_cr_idx]
-n             = min(cr[cr_idx].valid_elements, 128)
+n             = 128 if full_xmem_row else min(valid_elements, 128)
 POST_AAQ_REG[i]  = activation_fn(r_acc[i])   for i in 0..n-1
 POST_AAQ_REG[n..127] = 0
 ```
@@ -146,8 +148,8 @@ Earlier revisions of this stage owned the cross-lane sum/max reduction
 (`agg` / `agg.first`) and a 4 × 32-bit scalar register file (`aaq0`–`aaq3`)
 with post functions. That functionality has been replaced by the ACC-slot
 `AGG.SUM`, `AGG.SUM.FIRST`, `AGG.MAX`, and `AGG.MAX.FIRST` instructions,
-which reduce `r_acc[0..n-1]` (with `n` selected by the instruction's `cr_idx`
-operand, defaulting to CR15, exactly as in §3.1) and write the scalar result into
+which reduce `r_acc[0..n-1]` (with `n` selected by `full_xmem_row` /
+`CR15.valid_elements` exactly as in §3.1) and write the scalar result into
 the `r_acc` slot given by an LR register. The AAQ stage no longer holds a
 register file and exposes no RF feedback to the MULT or ACC stages.
 
@@ -159,7 +161,7 @@ lanes as FP32, quantizes to INT8, clamps, and writes the 128-byte result to
 
 ```text
 // dtype must be DType.INT8; POST_AAQ_REG lanes are FP32
-n = min(cr[cr_idx].valid_elements, 128)
+n = 128 if full_xmem_row else min(CR15.valid_elements, 128)
 for i in 0..n-1:
     val            = POST_AAQ_REG[i]        // FP32
     aaq_result[i]  = clamp(round(val), -128, 127)
@@ -195,8 +197,8 @@ duplicated here.
 
 The AAQ slot is resolved by CTRL and forwarded down the dispatch chain;
 the stage does not read the CR/LR register files itself (see the
-Control Stage spec, §5). The active lane count is determined by the `cr_idx`
-operand: `valid_elements` from the selected CR's dstructure configuration at cycle start (default CR15).
+Control Stage spec, §5). The active lane count is determined by `full_xmem_row`:
+`1` = always 128, `0` = `CR15.valid_elements` at cycle start.
 
 ### 8.1 `AAQ_NOP` — No Operation
 
@@ -208,35 +210,35 @@ operand: `valid_elements` from the selected CR's dstructure configuration at cyc
 
 ### 8.2 `AAQ` — Quantize Accumulator
 
-- **Summary:** Quantize wide lanes in `POST_AAQ_REG` to 8-bit and write the 128-byte `aaq_result` register. Requires INT8 mode. The optional `cr_idx` operand selects which CR's dstructure configuration controls how many lanes are active.
-- **Syntax:** `AAQ[ cr_idx]`
+- **Summary:** Quantize wide lanes in `POST_AAQ_REG` to 8-bit and write the 128-byte `aaq_result` register. Requires INT8 mode. The `full_xmem_row` flag controls how many lanes are active.
+- **Syntax:** `AAQ full_xmem_row`
 - **Operands:**
-  - `cr_idx`: CR0…CR15 supplying `valid_elements` (clamped to 128). Defaults to CR15 when omitted.
+  - `full_xmem_row`: `1` = always process all 128 lanes (full XMEM row, ignores `CR15.valid_elements`); `0` = process only the first `CR15.valid_elements` lanes (clamped to 128) and zero the rest. Defaults to `0`.
 - **Operation:**
   ```text
   // requires dtype == DType.INT8
-  n = min(cr[cr_idx].valid_elements, 128)
+  n = 128 if full_xmem_row else min(CR15.valid_elements, 128)
   for i in 0..n-1:
       aaq_result[i] = clamp(trunc(POST_AAQ_REG[i]), -128, 127)
   aaq_result[n..127] = 0
   ```
   The Quantization block appends 12 bits of metadata to the 1024-bit payload (see §7.2).
-- **Example:** `AAQ CR3;;` (use `CR3.valid_elements`), `AAQ;;` (use `CR15.valid_elements`).
+- **Example:** `AAQ 1;;` (full row), `AAQ 0;;` (use `CR15.valid_elements`).
 - **Notes:** `aaq_result` must be flushed with `XMEM.STORE_AAQ_RESULT offset base` before the next `AAQ` overwrites it (see §7.2).
 
 ### 8.3 `ACTIVATE` — Apply Activation Function
 
 - **Summary:** Apply an element-wise activation function to the active lanes of `r_acc` and write the activated 32-bit lanes into `POST_AAQ_REG`. `r_acc` is not modified.
-- **Syntax:** `ACTIVATE activation_fn[, cr_idx]`
+- **Syntax:** `ACTIVATE activation_fn, full_xmem_row`
 - **Operands:**
   - `activation_fn` — activation keyword (see §7.0): `identity`, `relu`, `relu6`, `sigmoid`, `tanh`, `gelu`, `softplus`, `elu`, `exp2`, `reciprocal`, `rsqrt`.
-  - `cr_idx` — CR0…CR15 supplying `valid_elements` (clamped to 128). Defaults to CR15 when omitted.
+  - `full_xmem_row` — `1` = always use 128 lanes; `0` = use `CR15.valid_elements`.
 - **Operation:**
   ```text
-  n = min(cr[cr_idx].valid_elements, 128)
+  n = 128 if full_xmem_row else min(CR15.valid_elements, 128)
   POST_AAQ_REG[i] = activation_fn(r_acc[i])   for i in 0..n-1
   ```
-- **Example:** `ACTIVATE relu, CR3;;`
+- **Example:** `ACTIVATE relu, 0;;`
 - **Notes:** Reads `r_acc` from the cycle-start snapshot, so an ACC-slot instruction (e.g. `AGG.*`) issued in the same VLIW word does not affect the activated values.
 
 ### 8.4 Summary Table
@@ -244,5 +246,5 @@ operand: `valid_elements` from the selected CR's dstructure configuration at cyc
 | Slot | Mnemonic | Operands | One-line Effect |
 |------|----------|----------|-----------------|
 | AAQ | `AAQ_NOP`   | —                              | no state change |
-| AAQ | `AAQ`       | `[cr_idx]`                | `aaq_result[0..n-1] = clamp(trunc(POST_AAQ_REG[i]), -128, 127)`, n = cr[cr_idx].valid_elements (default CR15) |
-| AAQ | `ACTIVATE`  | `activation_fn[, cr_idx]` | `POST_AAQ_REG[0..n-1] = activation_fn(r_acc[i])`, n = cr[cr_idx].valid_elements (default CR15) |
+| AAQ | `AAQ`       | `full_xmem_row`                | `aaq_result[0..n-1] = clamp(trunc(POST_AAQ_REG[i]), -128, 127)`, n = 128 if full_xmem_row else CR15.valid_elements |
+| AAQ | `ACTIVATE`  | `activation_fn, full_xmem_row` | `POST_AAQ_REG[0..n-1] = activation_fn(r_acc[i])`, n = 128 if full_xmem_row else CR15.valid_elements |

--- a/src/tools/ipu-as-py/src/ipu_as/gen_docs.py
+++ b/src/tools/ipu-as-py/src/ipu_as/gen_docs.py
@@ -76,10 +76,12 @@ OPERAND_TYPE_DETAILS: dict[str, str] = {
         "**`mask_shift`** remains an **`LrIdx`**."
     ),
     "BreakImmediate": "16-bit value for **`BREAK`** / breakpoint slot conditions.",
-    "FullXmemRow": (
-        "1-bit control flag on **`AAQ`**: **`1`** = always process all **128 lanes** (full XMEM row, "
-        "ignores ``CR15.valid_elements``); **`0`** = process only the first ``CR15.valid_elements`` "
-        "lanes (clamped to 128) and zero the rest. Defaults to **`1`** for backward compatibility."
+    "DstructureCrIdx": (
+        "Constant-register index: **`cr0`** … **`cr15`**, selecting which CR supplies the "
+        "**valid element mask** / dstructure configuration (`valid_elements`, `partition`) for "
+        "`AGG.SUM`, `AGG.SUM.FIRST`, `AGG.MAX`, `AGG.MAX.FIRST`, `AAQ`, and `ACTIVATE`. Unlike "
+        "**`CrIdx`**, **`cr15`** is allowed here — it's the default dstructure register and is "
+        "used when the operand is omitted."
     ),
     "Label": (
         "Branch target: a symbolic **`label`** or a relative offset accepted by the cond slot "

--- a/src/tools/ipu-as-py/src/ipu_as/immediate.py
+++ b/src/tools/ipu-as-py/src/ipu_as/immediate.py
@@ -172,29 +172,3 @@ class VerticalStrideField(ipu_token.EnumToken):
         return list(VERTICAL_STRIDE_NAMES)
 
 
-class FullXmemRowField(ipu_token.IpuToken):
-    """1-bit flag on AAQ: 1=always 128 elements (full row), 0=use CR15.valid_elements."""
-
-    @classmethod
-    def bits(cls) -> int:
-        return 1
-
-    @classmethod
-    def default(cls) -> "ipu_token.IpuToken":
-        return cls(ipu_token.AnnotatedToken(lark.Token("NUMBER", "0"), 0))
-
-    def __init__(self, token: ipu_token.AnnotatedToken):
-        super().__init__(token)
-        try:
-            self.int = int(token.token.value, 0)
-        except ValueError:
-            self._raise_error(f"Value {self.token.value} is not a valid integer")
-        if self.int not in (0, 1):
-            self._raise_error("full_xmem_row must be 0 or 1")
-
-    def encode(self) -> int:
-        return self.int
-
-    @classmethod
-    def decode(cls, value: int) -> str:
-        return str(value & 1)

--- a/src/tools/ipu-as-py/src/ipu_as/inst.py
+++ b/src/tools/ipu-as-py/src/ipu_as/inst.py
@@ -87,18 +87,14 @@ class Inst:
         struct_entry = struct_table[struct_names[opcode_idx]]
         operand_types = self._operand_types_from_struct(struct_entry)
 
-        if len(inst["operands"]) > len(operand_types):
+        if len(inst["operands"]) != len(operand_types):
             raise ValueError(
-                f"Instruction {inst['opcode'].token.value} expects at most {len(operand_types)} operands, "
+                f"Instruction {inst['opcode'].token.value} expects {len(operand_types)} operands, "
                 f"got {len(inst['operands'])}, in Line {self.opcode.token.line}, Column {self.opcode.token.column}."
             )
 
-        # Trailing operands omitted from the assembly source fall back to each
-        # operand type's default() (e.g. an omitted dstructure CR defaults to CR15).
         self.operands = [
             op_type(op) for op_type, op in zip(operand_types, inst["operands"])
-        ] + [
-            op_type.default() for op_type in operand_types[len(inst["operands"]):]
         ]
         self.specific_operand_types = operand_types
 

--- a/src/tools/ipu-as-py/src/ipu_as/inst.py
+++ b/src/tools/ipu-as-py/src/ipu_as/inst.py
@@ -34,6 +34,7 @@ OPERAND_TYPE_MAP: dict[str, type[ipu_token.IpuToken]] = {
     "MultStageReg": reg.MultStageRegField,
     "LrIdx": reg.LrRegField,
     "CrIdx": reg.CrRegField,
+    "DstructureCrIdx": reg.DstructureCrRegField,
     "LcrIdx": reg.LcrRegField,
     "LrIncDecImmediate": immediate.LrIncDecImmediate,
     "ElementsInRow": immediate.ElementsInRowField,
@@ -43,7 +44,6 @@ OPERAND_TYPE_MAP: dict[str, type[ipu_token.IpuToken]] = {
     "MultMaskOffsetImmediate": immediate.MultMaskOffsetImmediate,
     "ActivationFn": immediate.ActivationFnField,
     "BreakImmediate": immediate.BreakImmediateType,
-    "FullXmemRow": immediate.FullXmemRowField,
     "Label": ipu_token.LabelToken,
 }
 
@@ -87,14 +87,18 @@ class Inst:
         struct_entry = struct_table[struct_names[opcode_idx]]
         operand_types = self._operand_types_from_struct(struct_entry)
 
-        if len(inst["operands"]) != len(operand_types):
+        if len(inst["operands"]) > len(operand_types):
             raise ValueError(
-                f"Instruction {inst['opcode'].token.value} expects {len(operand_types)} operands, "
+                f"Instruction {inst['opcode'].token.value} expects at most {len(operand_types)} operands, "
                 f"got {len(inst['operands'])}, in Line {self.opcode.token.line}, Column {self.opcode.token.column}."
             )
 
+        # Trailing operands omitted from the assembly source fall back to each
+        # operand type's default() (e.g. an omitted dstructure CR defaults to CR15).
         self.operands = [
             op_type(op) for op_type, op in zip(operand_types, inst["operands"])
+        ] + [
+            op_type.default() for op_type in operand_types[len(inst["operands"]):]
         ]
         self.specific_operand_types = operand_types
 

--- a/src/tools/ipu-as-py/src/ipu_as/reg.py
+++ b/src/tools/ipu-as-py/src/ipu_as/reg.py
@@ -8,6 +8,7 @@ Old code uses: from ipu_as.reg import MultStageRegField, LrRegField, etc.
 New code uses: from ipu_common.registers import create_regfile_schema, etc.
 """
 
+import lark
 import ipu_as.ipu_token as ipu_token
 from ipu_common.registers import create_assembler_reg_classes, create_assembler_reg_enums
 
@@ -66,6 +67,18 @@ class LcrRegField(_LcrRegFieldBase):
         _reject_cr15(token, "LcrRegField")
         super().__init__(token)
 
+
+class DstructureCrRegField(_CrRegFieldBase):
+    """CR0–CR15 selector for an instruction's dstructure (valid-element mask) operand.
+
+    Unlike ``CrRegField``, CR15 is allowed here: it's the default dstructure
+    register, and this is the reserved use case CR15 exists for.
+    """
+
+    @classmethod
+    def default(cls) -> "ipu_token.IpuToken":
+        return cls(ipu_token.AnnotatedToken(lark.Token("ENUM", "cr15"), 0))
+
 # For documentation and introspection, also expose the enum arrays
 _enums = create_assembler_reg_enums()
 MULT_STAGE_REG_R_FIELDS = _enums.get("MultStageRegField", [])
@@ -86,6 +99,7 @@ __all__ = [
     "LrRegField",
     "CrRegField",
     "LcrRegField",
+    "DstructureCrRegField",
     # Field lists
     "MULT_STAGE_REG_R_FIELDS",
     "LR_REG_FIELDS",

--- a/src/tools/ipu-as-py/src/ipu_as/reg.py
+++ b/src/tools/ipu-as-py/src/ipu_as/reg.py
@@ -8,7 +8,6 @@ Old code uses: from ipu_as.reg import MultStageRegField, LrRegField, etc.
 New code uses: from ipu_common.registers import create_regfile_schema, etc.
 """
 
-import lark
 import ipu_as.ipu_token as ipu_token
 from ipu_common.registers import create_assembler_reg_classes, create_assembler_reg_enums
 
@@ -71,13 +70,10 @@ class LcrRegField(_LcrRegFieldBase):
 class DstructureCrRegField(_CrRegFieldBase):
     """CR0–CR15 selector for an instruction's dstructure (valid-element mask) operand.
 
-    Unlike ``CrRegField``, CR15 is allowed here: it's the default dstructure
-    register, and this is the reserved use case CR15 exists for.
+    Unlike ``CrRegField``, CR15 is allowed here: it's the reserved use case
+    CR15 exists for. This operand is mandatory — every AGG.*/AAQ/ACTIVATE
+    instruction must name its dstructure CR explicitly (e.g. ``AAQ cr15;;``).
     """
-
-    @classmethod
-    def default(cls) -> "ipu_token.IpuToken":
-        return cls(ipu_token.AnnotatedToken(lark.Token("ENUM", "cr15"), 0))
 
 # For documentation and introspection, also expose the enum arrays
 _enums = create_assembler_reg_enums()

--- a/src/tools/ipu-common/src/ipu_common/instruction_spec.py
+++ b/src/tools/ipu-common/src/ipu_common/instruction_spec.py
@@ -685,105 +685,109 @@ INSTRUCTION_SPEC = {
         "AGG.SUM.FIRST": {
             "operands": [
                 {"name": "dest_slot", "type": "LrIdx", "read": "snapshot"},
-                {"name": "full_xmem_row", "type": "FullXmemRow"},
+                {"name": "cr_idx", "type": "DstructureCrIdx"},
             ],
             "doc": InstructionDoc(
                 title="Aggregate Sum (First)",
                 summary=(
                     "Sum active R_ACC lanes and write the result into R_ACC at the slot given by LR. "
                     "The current value at the destination slot is NOT included in the sum (clean initialisation). "
-                    "``full_xmem_row=1`` always uses 128 lanes; ``full_xmem_row=0`` uses CR15.valid_elements."
+                    "The active lane count and partition come from ``cr_idx``'s dstructure configuration "
+                    "(defaults to CR15 when omitted)."
                 ),
-                syntax="AGG.SUM.FIRST dest_slot, full_xmem_row",
+                syntax="AGG.SUM.FIRST dest_slot[, cr_idx]",
                 operands=[
                     "dest_slot: LR register whose value gives the destination slot in R_ACC (0–127)",
-                    "full_xmem_row: 1 = always 128 lanes; 0 = use CR15.valid_elements",
+                    "cr_idx: CR0…CR15 supplying valid_elements (default CR15)",
                 ],
                 operation=(
-                    "Let n = 128 if full_xmem_row else min(CR15.valid_elements, 128). "
+                    "Let n = min(CR[cr_idx].valid_elements, 128). "
                     "dest = LR[dest_slot] % 128. "
                     "R_ACC[dest] = sum(R_ACC[0..n-1])."
                 ),
-                example="AGG.SUM.FIRST LR0, 0;;",
+                example="AGG.SUM.FIRST LR0, CR3;;",
             ),
             "execute_fn": "execute_agg_sum_first",
         },
         "AGG.SUM": {
             "operands": [
                 {"name": "dest_slot", "type": "LrIdx", "read": "snapshot"},
-                {"name": "full_xmem_row", "type": "FullXmemRow"},
+                {"name": "cr_idx", "type": "DstructureCrIdx"},
             ],
             "doc": InstructionDoc(
                 title="Aggregate Sum",
                 summary=(
                     "Sum active R_ACC lanes and ADD the result to R_ACC at the slot given by LR "
                     "(running cross-cycle accumulation). "
-                    "``full_xmem_row=1`` always uses 128 lanes; ``full_xmem_row=0`` uses CR15.valid_elements."
+                    "The active lane count and partition come from ``cr_idx``'s dstructure configuration "
+                    "(defaults to CR15 when omitted)."
                 ),
-                syntax="AGG.SUM dest_slot, full_xmem_row",
+                syntax="AGG.SUM dest_slot[, cr_idx]",
                 operands=[
                     "dest_slot: LR register whose value gives the destination slot in R_ACC (0–127)",
-                    "full_xmem_row: 1 = always 128 lanes; 0 = use CR15.valid_elements",
+                    "cr_idx: CR0…CR15 supplying valid_elements (default CR15)",
                 ],
                 operation=(
-                    "Let n = 128 if full_xmem_row else min(CR15.valid_elements, 128). "
+                    "Let n = min(CR[cr_idx].valid_elements, 128). "
                     "dest = LR[dest_slot] % 128. "
                     "R_ACC[dest] = sum(R_ACC[0..n-1]) + R_ACC[dest]."
                 ),
-                example="AGG.SUM LR0, 0;;",
+                example="AGG.SUM LR0, CR3;;",
             ),
             "execute_fn": "execute_agg_sum",
         },
         "AGG.MAX.FIRST": {
             "operands": [
                 {"name": "dest_slot", "type": "LrIdx", "read": "snapshot"},
-                {"name": "full_xmem_row", "type": "FullXmemRow"},
+                {"name": "cr_idx", "type": "DstructureCrIdx"},
             ],
             "doc": InstructionDoc(
                 title="Aggregate Max (First)",
                 summary=(
                     "Find the maximum of active R_ACC lanes and write it into R_ACC at the slot given by LR. "
                     "The current value at the destination slot is NOT used as a seed (clean initialisation). "
-                    "``full_xmem_row=1`` always uses 128 lanes; ``full_xmem_row=0`` uses CR15.valid_elements."
+                    "The active lane count and partition come from ``cr_idx``'s dstructure configuration "
+                    "(defaults to CR15 when omitted)."
                 ),
-                syntax="AGG.MAX.FIRST dest_slot, full_xmem_row",
+                syntax="AGG.MAX.FIRST dest_slot[, cr_idx]",
                 operands=[
                     "dest_slot: LR register whose value gives the destination slot in R_ACC (0–127)",
-                    "full_xmem_row: 1 = always 128 lanes; 0 = use CR15.valid_elements",
+                    "cr_idx: CR0…CR15 supplying valid_elements (default CR15)",
                 ],
                 operation=(
-                    "Let n = 128 if full_xmem_row else min(CR15.valid_elements, 128). "
+                    "Let n = min(CR[cr_idx].valid_elements, 128). "
                     "dest = LR[dest_slot] % 128. "
                     "R_ACC[dest] = max(R_ACC[0..n-1]); when n = 0 the identity seed "
                     "(INT32_MIN for integer lanes, -inf for float lanes) is written."
                 ),
-                example="AGG.MAX.FIRST LR0, 0;;",
+                example="AGG.MAX.FIRST LR0, CR3;;",
             ),
             "execute_fn": "execute_agg_max_first",
         },
         "AGG.MAX": {
             "operands": [
                 {"name": "dest_slot", "type": "LrIdx", "read": "snapshot"},
-                {"name": "full_xmem_row", "type": "FullXmemRow"},
+                {"name": "cr_idx", "type": "DstructureCrIdx"},
             ],
             "doc": InstructionDoc(
                 title="Aggregate Max",
                 summary=(
                     "Find the maximum of active R_ACC lanes seeded with the current destination slot value "
                     "(running cross-cycle max). "
-                    "``full_xmem_row=1`` always uses 128 lanes; ``full_xmem_row=0`` uses CR15.valid_elements."
+                    "The active lane count and partition come from ``cr_idx``'s dstructure configuration "
+                    "(defaults to CR15 when omitted)."
                 ),
-                syntax="AGG.MAX dest_slot, full_xmem_row",
+                syntax="AGG.MAX dest_slot[, cr_idx]",
                 operands=[
                     "dest_slot: LR register whose value gives the destination slot in R_ACC (0–127)",
-                    "full_xmem_row: 1 = always 128 lanes; 0 = use CR15.valid_elements",
+                    "cr_idx: CR0…CR15 supplying valid_elements (default CR15)",
                 ],
                 operation=(
-                    "Let n = 128 if full_xmem_row else min(CR15.valid_elements, 128). "
+                    "Let n = min(CR[cr_idx].valid_elements, 128). "
                     "dest = LR[dest_slot] % 128. "
                     "R_ACC[dest] = max(R_ACC[0..n-1], R_ACC[dest])."
                 ),
-                example="AGG.MAX LR0, 0;;",
+                example="AGG.MAX LR0, CR3;;",
             ),
             "execute_fn": "execute_agg_max",
         },
@@ -806,7 +810,7 @@ INSTRUCTION_SPEC = {
         },
         "AAQ": {
             "operands": [
-                {"name": "full_xmem_row", "type": "FullXmemRow"},
+                {"name": "cr_idx", "type": "DstructureCrIdx"},
             ],
             "doc": InstructionDoc(
                 title="AAQ Quantize",
@@ -815,57 +819,57 @@ INSTRUCTION_SPEC = {
                     "to INT8, storing clamped bytes in the **leading 128 bytes** of **`POST_AAQ_REG`** "
                     "and clearing the rest of the register. Wide lanes are normally produced by "
                     "**`ACTIVATE`** (from ``r_acc``). Requires INT8 mode. "
-                    "``full_xmem_row=1`` always processes all 128 lanes; "
-                    "``full_xmem_row=0`` uses ``CR15.valid_elements`` as the active lane count."
+                    "The active lane count comes from ``cr_idx``'s dstructure configuration "
+                    "(defaults to CR15 when omitted)."
                 ),
-                syntax="AAQ full_xmem_row",
+                syntax="AAQ[ cr_idx]",
                 operands=[
-                    "full_xmem_row: 1 = always 128 lanes (full XMEM row); 0 = use CR15.valid_elements lane count",
+                    "cr_idx: CR0…CR15 supplying valid_elements (default CR15)",
                 ],
                 operation=(
                     "Requires INT8 mode (IpuState.dtype == DType.INT8 in the Python emulator). "
-                    "Let n = 128 if full_xmem_row else min(CR15.valid_elements, 128). "
+                    "Let n = min(CR[cr_idx].valid_elements, 128). "
                     "For i in [0, n): POST_AAQ_REG[i] = clamp(POST_AAQ_REG wide lane i, -128, 127) "
                     "(interim direct INT8 clamp of the post-ACTIVATE lane; a future per-128-element "
                     "requantize will scale lanes into INT8 range before this step and supersede the clamp). "
                     "POST_AAQ_REG[n..511] = 0."
                 ),
-                example="AAQ 1;;",
+                example="AAQ CR3;;",
             ),
             "execute_fn": "execute_aaq",
         },
         "ACTIVATE": {
             "operands": [
                 {"name": "activation_fn", "type": "ActivationFn"},
-                {"name": "full_xmem_row", "type": "FullXmemRow"},
+                {"name": "cr_idx", "type": "DstructureCrIdx"},
             ],
             "doc": InstructionDoc(
                 title="Accumulator Activation",
                 summary=(
                     "Read active lanes from ``r_acc``, apply the selected element-wise activation, "
                     "and write results into the same lane indices of ``POST_AAQ_REG`` (``r_acc`` is unchanged). "
-                    "``full_xmem_row=1`` always activates all 128 lanes; ``full_xmem_row=0`` uses CR15.valid_elements. "
+                    "The active lane count comes from ``cr_idx``'s dstructure configuration "
+                    "(defaults to CR15 when omitted). "
                     "The activation is selected by keyword (see ACTIVATION_FN_NAMES). The available "
                     "activation functions are: ``identity`` (0), ``relu`` (1), ``relu6`` (2), "
                     "``sigmoid`` (3), ``tanh`` (4), ``gelu`` (5), ``softplus`` (6), ``elu`` (7), "
                     "``exp2`` (8), ``reciprocal`` (9), ``rsqrt`` (10). For Python emulator calibration (virtual α), see "
                     "docs/content/building-applications.md#activations-emulator."
                 ),
-                syntax="ACTIVATE activation_fn, full_xmem_row",
+                syntax="ACTIVATE activation_fn[, cr_idx]",
                 operands=[
                     "activation_fn: keyword naming the activation (one of identity, relu, relu6, sigmoid, tanh, gelu, softplus, elu, exp2; see ACTIVATION_FN_NAMES)",
-                    "full_xmem_row: 1 = always 128 lanes; 0 = use CR15.valid_elements (default 0)",
+                    "cr_idx: CR0…CR15 supplying valid_elements (default CR15)",
                 ],
                 operation=(
-                    "Let n = 128 if full_xmem_row else min(CR15.valid_elements, 128) "
-                    "and k = encoded activation index. "
+                    "Let n = min(CR[cr_idx].valid_elements, 128) and k = encoded activation index. "
                     "For i in [0, n): POST_AAQ_REG[i] = activation_k(R_ACC[i]) (same 32-bit lane format as R_ACC). "
                     "R_ACC is not modified. The selector uses four bits; encodings outside the eleven named "
                     "activations behave as identity. "
                     "α for elu is not an ISA operand; see "
                     "docs/content/building-applications.md#activations-emulator."
                 ),
-                example="ACTIVATE relu, 0;;",
+                example="ACTIVATE relu, CR3;;",
             ),
             "execute_fn": "execute_activate",
         },
@@ -1267,7 +1271,7 @@ VALID_OPERAND_TYPES: frozenset[str] = frozenset(
         "ActivationFn",
         "BreakImmediate",
         "Label",
-        "FullXmemRow",
+        "DstructureCrIdx",
     }
 )
 

--- a/src/tools/ipu-common/src/ipu_common/instruction_spec.py
+++ b/src/tools/ipu-common/src/ipu_common/instruction_spec.py
@@ -693,12 +693,12 @@ INSTRUCTION_SPEC = {
                     "Sum active R_ACC lanes and write the result into R_ACC at the slot given by LR. "
                     "The current value at the destination slot is NOT included in the sum (clean initialisation). "
                     "The active lane count and partition come from ``cr_idx``'s dstructure configuration "
-                    "(defaults to CR15 when omitted)."
+                    "(any CR0-CR15; must be named explicitly)."
                 ),
-                syntax="AGG.SUM.FIRST dest_slot[, cr_idx]",
+                syntax="AGG.SUM.FIRST dest_slot, cr_idx",
                 operands=[
                     "dest_slot: LR register whose value gives the destination slot in R_ACC (0–127)",
-                    "cr_idx: CR0…CR15 supplying valid_elements (default CR15)",
+                    "cr_idx: CR0…CR15 supplying valid_elements (must be given explicitly)",
                 ],
                 operation=(
                     "Let n = min(CR[cr_idx].valid_elements, 128). "
@@ -720,12 +720,12 @@ INSTRUCTION_SPEC = {
                     "Sum active R_ACC lanes and ADD the result to R_ACC at the slot given by LR "
                     "(running cross-cycle accumulation). "
                     "The active lane count and partition come from ``cr_idx``'s dstructure configuration "
-                    "(defaults to CR15 when omitted)."
+                    "(any CR0-CR15; must be named explicitly)."
                 ),
-                syntax="AGG.SUM dest_slot[, cr_idx]",
+                syntax="AGG.SUM dest_slot, cr_idx",
                 operands=[
                     "dest_slot: LR register whose value gives the destination slot in R_ACC (0–127)",
-                    "cr_idx: CR0…CR15 supplying valid_elements (default CR15)",
+                    "cr_idx: CR0…CR15 supplying valid_elements (must be given explicitly)",
                 ],
                 operation=(
                     "Let n = min(CR[cr_idx].valid_elements, 128). "
@@ -747,12 +747,12 @@ INSTRUCTION_SPEC = {
                     "Find the maximum of active R_ACC lanes and write it into R_ACC at the slot given by LR. "
                     "The current value at the destination slot is NOT used as a seed (clean initialisation). "
                     "The active lane count and partition come from ``cr_idx``'s dstructure configuration "
-                    "(defaults to CR15 when omitted)."
+                    "(any CR0-CR15; must be named explicitly)."
                 ),
-                syntax="AGG.MAX.FIRST dest_slot[, cr_idx]",
+                syntax="AGG.MAX.FIRST dest_slot, cr_idx",
                 operands=[
                     "dest_slot: LR register whose value gives the destination slot in R_ACC (0–127)",
-                    "cr_idx: CR0…CR15 supplying valid_elements (default CR15)",
+                    "cr_idx: CR0…CR15 supplying valid_elements (must be given explicitly)",
                 ],
                 operation=(
                     "Let n = min(CR[cr_idx].valid_elements, 128). "
@@ -775,12 +775,12 @@ INSTRUCTION_SPEC = {
                     "Find the maximum of active R_ACC lanes seeded with the current destination slot value "
                     "(running cross-cycle max). "
                     "The active lane count and partition come from ``cr_idx``'s dstructure configuration "
-                    "(defaults to CR15 when omitted)."
+                    "(any CR0-CR15; must be named explicitly)."
                 ),
-                syntax="AGG.MAX dest_slot[, cr_idx]",
+                syntax="AGG.MAX dest_slot, cr_idx",
                 operands=[
                     "dest_slot: LR register whose value gives the destination slot in R_ACC (0–127)",
-                    "cr_idx: CR0…CR15 supplying valid_elements (default CR15)",
+                    "cr_idx: CR0…CR15 supplying valid_elements (must be given explicitly)",
                 ],
                 operation=(
                     "Let n = min(CR[cr_idx].valid_elements, 128). "
@@ -820,11 +820,11 @@ INSTRUCTION_SPEC = {
                     "and clearing the rest of the register. Wide lanes are normally produced by "
                     "**`ACTIVATE`** (from ``r_acc``). Requires INT8 mode. "
                     "The active lane count comes from ``cr_idx``'s dstructure configuration "
-                    "(defaults to CR15 when omitted)."
+                    "(any CR0-CR15; must be named explicitly)."
                 ),
-                syntax="AAQ[ cr_idx]",
+                syntax="AAQ cr_idx",
                 operands=[
-                    "cr_idx: CR0…CR15 supplying valid_elements (default CR15)",
+                    "cr_idx: CR0…CR15 supplying valid_elements (must be given explicitly)",
                 ],
                 operation=(
                     "Requires INT8 mode (IpuState.dtype == DType.INT8 in the Python emulator). "
@@ -849,17 +849,17 @@ INSTRUCTION_SPEC = {
                     "Read active lanes from ``r_acc``, apply the selected element-wise activation, "
                     "and write results into the same lane indices of ``POST_AAQ_REG`` (``r_acc`` is unchanged). "
                     "The active lane count comes from ``cr_idx``'s dstructure configuration "
-                    "(defaults to CR15 when omitted). "
+                    "(any CR0-CR15; must be named explicitly). "
                     "The activation is selected by keyword (see ACTIVATION_FN_NAMES). The available "
                     "activation functions are: ``identity`` (0), ``relu`` (1), ``relu6`` (2), "
                     "``sigmoid`` (3), ``tanh`` (4), ``gelu`` (5), ``softplus`` (6), ``elu`` (7), "
                     "``exp2`` (8), ``reciprocal`` (9), ``rsqrt`` (10). For Python emulator calibration (virtual α), see "
                     "docs/content/building-applications.md#activations-emulator."
                 ),
-                syntax="ACTIVATE activation_fn[, cr_idx]",
+                syntax="ACTIVATE activation_fn, cr_idx",
                 operands=[
                     "activation_fn: keyword naming the activation (one of identity, relu, relu6, sigmoid, tanh, gelu, softplus, elu, exp2; see ACTIVATION_FN_NAMES)",
-                    "cr_idx: CR0…CR15 supplying valid_elements (default CR15)",
+                    "cr_idx: CR0…CR15 supplying valid_elements (must be given explicitly)",
                 ],
                 operation=(
                     "Let n = min(CR[cr_idx].valid_elements, 128) and k = encoded activation index. "

--- a/src/tools/ipu-common/src/ipu_common/union_layout.py
+++ b/src/tools/ipu-common/src/ipu_common/union_layout.py
@@ -57,6 +57,7 @@ def get_operand_type_bits() -> dict[str, int]:
         "MultStageReg": 2,  # MultStageRegField overrides bits() → 2
         "LrIdx": (lr_count - 1).bit_length(),
         "CrIdx": (cr_count - 1).bit_length(),
+        "DstructureCrIdx": (cr_count - 1).bit_length(),
         "LcrIdx": (lr_count + cr_count - 1).bit_length(),
         # Width 0 at layout time — the shared union field width is set in
         # finalize_derived_operand_bits() after packing.
@@ -69,7 +70,6 @@ def get_operand_type_bits() -> dict[str, int]:
         "HorizontalStride": _enum_bits(HORIZONTAL_STRIDE_NAMES),
         "VerticalStride": _enum_bits(VERTICAL_STRIDE_NAMES),
         "ActivationFn": _enum_bits(ACTIVATION_FN_NAMES),
-        "FullXmemRow": 1,
     }
 
 

--- a/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
@@ -92,7 +92,7 @@ _TYPE_FIELD_SUFFIX = {
     "ActivationFn": "activation_fn_field",
     "BreakImmediate": "break_immediate_type",
     "Label": "label_token",
-    "FullXmemRow": "full_xmem_row_field",
+    "DstructureCrIdx": "dstructure_cr_reg_field",
 }
 
 # Field prefix for each slot type (matches compound_inst naming)
@@ -892,9 +892,9 @@ class Ipu:
                 best = v
         return best
 
-    def execute_agg_sum_first(self, *, dest_slot: int, full_xmem_row: int) -> None:
+    def execute_agg_sum_first(self, *, dest_slot: int, cr_idx: int) -> None:
         """Execute AGG.SUM.FIRST: sum active MULT_RES lanes, write to R_ACC[dest] (clean init)."""
-        valid_elements = 128 if full_xmem_row else self.state.get_config_valid_elements()
+        valid_elements = self.state.get_dstructure_for(cr_idx).valid_elements
         fmt = self._acc_agg_lane_fmt()
         mult_res = self.state.regfile.raw("mult_res")
         active = self._agg_active_lane_count(valid_elements)
@@ -904,9 +904,9 @@ class Ipu:
             result = self._to_int32(result)
         struct.pack_into(fmt, self.state.regfile.raw("r_acc"), dest * 4, result)
 
-    def execute_agg_sum(self, *, dest_slot: int, full_xmem_row: int) -> None:
+    def execute_agg_sum(self, *, dest_slot: int, cr_idx: int) -> None:
         """Execute AGG.SUM: sum active MULT_RES lanes and add to R_ACC[dest] (running accumulation)."""
-        valid_elements = 128 if full_xmem_row else self.state.get_config_valid_elements()
+        valid_elements = self.state.get_dstructure_for(cr_idx).valid_elements
         fmt = self._acc_agg_lane_fmt()
         mult_res = self.state.regfile.raw("mult_res")
         active = self._agg_active_lane_count(valid_elements)
@@ -919,13 +919,13 @@ class Ipu:
             result = ipu_add(self._to_int32(partial), int(snap_dest), DType.INT8)
         struct.pack_into(fmt, self.state.regfile.raw("r_acc"), dest * 4, result)
 
-    def execute_agg_max_first(self, *, dest_slot: int, full_xmem_row: int) -> None:
+    def execute_agg_max_first(self, *, dest_slot: int, cr_idx: int) -> None:
         """Execute AGG.MAX.FIRST: max of active MULT_RES lanes, write to R_ACC[dest] (no seed).
 
         When no lanes are active (valid_elements=0) the identity seed
         (INT32_MIN / -inf) is written, so the destination is always defined.
         """
-        valid_elements = 128 if full_xmem_row else self.state.get_config_valid_elements()
+        valid_elements = self.state.get_dstructure_for(cr_idx).valid_elements
         fmt = self._acc_agg_lane_fmt()
         mult_res = self.state.regfile.raw("mult_res")
         active = self._agg_active_lane_count(valid_elements)
@@ -934,9 +934,9 @@ class Ipu:
         dest = int(dest_slot) % (R_ACC_SIZE // 4)
         struct.pack_into(fmt, self.state.regfile.raw("r_acc"), dest * 4, result)
 
-    def execute_agg_max(self, *, dest_slot: int, full_xmem_row: int) -> None:
+    def execute_agg_max(self, *, dest_slot: int, cr_idx: int) -> None:
         """Execute AGG.MAX: max of active MULT_RES lanes seeded with R_ACC[dest] (running max)."""
-        valid_elements = 128 if full_xmem_row else self.state.get_config_valid_elements()
+        valid_elements = self.state.get_dstructure_for(cr_idx).valid_elements
         fmt = self._acc_agg_lane_fmt()
         mult_res = self.state.regfile.raw("mult_res")
         active = self._agg_active_lane_count(valid_elements)
@@ -945,7 +945,7 @@ class Ipu:
         result = self._agg_max_lanes(fmt, mult_res, active, snap_dest)
         struct.pack_into(fmt, self.state.regfile.raw("r_acc"), dest * 4, result)
 
-    def execute_aaq(self, *, full_xmem_row: int) -> None:
+    def execute_aaq(self, *, cr_idx: int) -> None:
         """Execute AAQ: Quantize wide lanes in ``POST_AAQ_REG`` (128 × 32-bit) → leading bytes.
 
         Source is the **512-byte** ``post_aaq_reg`` buffer (same lane layout as
@@ -968,8 +968,8 @@ class Ipu:
         the ``ACTIVATE`` -> ``AAQ`` path producing usable INT8 output instead of
         all zeros.
 
-        ``full_xmem_row=1``: always process all 128 lanes.
-        ``full_xmem_row=0``: process only ``CR15.valid_elements`` lanes (clamped to 128).
+        Active lane count is taken from ``cr_idx``'s ``valid_elements``
+        (clamped to 128); ``cr_idx`` defaults to ``CR15``.
 
         Requires INT8 mode.
 
@@ -981,8 +981,8 @@ class Ipu:
         if dtype != DType.INT8:
             raise EmulatorError("AAQ instruction requires INT8 mode")
 
-        active = 128 if full_xmem_row else self._agg_active_lane_count(
-            self.state.get_config_valid_elements()
+        active = self._agg_active_lane_count(
+            self.state.get_dstructure_for(cr_idx).valid_elements
         )
 
         if self._wide_vector_active():
@@ -1011,7 +1011,7 @@ class Ipu:
             result[i] = clamped & 0xFF
         self.state.regfile.set_post_aaq_reg(result + bytearray(384))
 
-    def execute_activate(self, *, activation_fn: int, full_xmem_row: int) -> None:
+    def execute_activate(self, *, activation_fn: int, cr_idx: int) -> None:
         """Apply element-wise activation to active lanes.
 
         Reads each active lane from ``r_acc`` and writes the result into the same
@@ -1020,10 +1020,10 @@ class Ipu:
         unchanged.
 
         ``activation_fn`` is the encoded enum index (0–8) from the instruction word.
-        full_xmem_row=1: always use 128 lanes. full_xmem_row=0: lane count from CR15.valid_elements.
+        Lane count is taken from ``cr_idx``'s ``valid_elements`` (defaults to CR15).
         """
         fn_id = int(activation_fn) & REGISTER_WORD_VALUE_MASK
-        valid_elements = 128 if full_xmem_row else self.state.get_config_valid_elements()
+        valid_elements = self.state.get_dstructure_for(cr_idx).valid_elements
         active = self._agg_active_lane_count(valid_elements)
         fmt = self._acc_agg_lane_fmt()
         acc_buf = self.snapshot.raw("r_acc")

--- a/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
@@ -969,7 +969,7 @@ class Ipu:
         all zeros.
 
         Active lane count is taken from ``cr_idx``'s ``valid_elements``
-        (clamped to 128); ``cr_idx`` defaults to ``CR15``.
+        (clamped to 128); the caller must name a CR register explicitly.
 
         Requires INT8 mode.
 
@@ -1020,7 +1020,8 @@ class Ipu:
         unchanged.
 
         ``activation_fn`` is the encoded enum index (0–8) from the instruction word.
-        Lane count is taken from ``cr_idx``'s ``valid_elements`` (defaults to CR15).
+        Lane count is taken from ``cr_idx``'s ``valid_elements``; the caller
+        must name a CR register explicitly.
         """
         fn_id = int(activation_fn) & REGISTER_WORD_VALUE_MASK
         valid_elements = self.state.get_dstructure_for(cr_idx).valid_elements

--- a/src/tools/ipu-emu-py/src/ipu_emu/ipu_state.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/ipu_state.py
@@ -97,6 +97,14 @@ class IpuState:
         """Return the partition field from the CR15 dstructure register."""
         return self.get_cr_dstructure().partition
 
+    def get_dstructure_for(self, cr_idx: int) -> DStructureConfig:
+        """Decode the dstructure configuration from an arbitrary CR register.
+
+        Lets mult/acc/aaq stage instructions select which CR supplies their
+        valid element mask and dstructure info, instead of being hard-coded to CR15.
+        """
+        return decode_dstructure(self.regfile.get_cr(cr_idx))
+
     def set_cr_dstructure(
         self,
         valid_elements: int = DEFAULT_DSTRUCTURE.valid_elements,

--- a/src/tools/ipu-emu-py/test/test_execute.py
+++ b/src/tools/ipu-emu-py/test/test_execute.py
@@ -21,6 +21,7 @@ from ipu_emu.emulator import (
 )
 from ipu_emu.ipu_state import IpuState, INST_MEM_SIZE
 from ipu_emu.ipu_math import DType
+from ipu_emu.ipu_config import encode_dstructure
 
 from ipu_as.lark_tree import assemble, parse
 
@@ -888,7 +889,7 @@ BKPT;;
         """AGG.SUM.FIRST: sum all 128 MULT_RES lanes and write to R_ACC[dest] (clean init)."""
         state = _make_state(
             """\
-AGG.SUM.FIRST LR0 1;;
+AGG.SUM.FIRST LR0;;
 BKPT;;
 """
         )
@@ -910,7 +911,7 @@ BKPT;;
         """
         state = _make_state(
             """\
-AGG.SUM.FIRST LR0 0;;
+AGG.SUM.FIRST LR0;;
 BKPT;;
 """
         )
@@ -930,7 +931,7 @@ BKPT;;
         """AGG.SUM.FIRST: only active MULT_RES prefix contributes; tail is excluded."""
         state = _make_state(
             """\
-AGG.SUM.FIRST LR0 0;;
+AGG.SUM.FIRST LR0;;
 BKPT;;
 """
         )
@@ -945,16 +946,17 @@ BKPT;;
         result = struct.unpack("<i", struct.pack("<I", raw))[0]
         assert result == 40, f"expected sum of 4 tens = 40, got {result}"
 
-    def test_agg_sum_first_full_xmem_row_overrides_valid_elements(self):
-        """AGG.SUM.FIRST with full_xmem_row=1 uses all 128 MULT_RES lanes regardless of CR15."""
+    def test_agg_sum_first_explicit_cr_idx_overrides_default(self):
+        """AGG.SUM.FIRST with explicit CR3 uses CR3.valid_elements=128, ignoring CR15=4."""
         state = _make_state(
             """\
-AGG.SUM.FIRST LR0 1;;
+AGG.SUM.FIRST LR0 cr3;;
 BKPT;;
 """
         )
         state.dtype = DType.INT8
         state.set_cr_dstructure(valid_elements=4)
+        state.regfile.set_cr(3, encode_dstructure(valid_elements=128, partition=0))
         state.regfile.set_lr(0, 127)
         for i in range(128):
             state.regfile.set_mult_res_word(i, struct.unpack("<I", struct.pack("<i", 1))[0])
@@ -971,7 +973,7 @@ BKPT;;
         """
         state = _make_state(
             """\
-AGG.SUM LR0 0;;
+AGG.SUM LR0;;
 BKPT;;
 """
         )
@@ -991,7 +993,7 @@ BKPT;;
         """AGG.MAX.FIRST: max of all 128 MULT_RES lanes, no seed from dest."""
         state = _make_state(
             """\
-AGG.MAX.FIRST LR0 1;;
+AGG.MAX.FIRST LR0;;
 BKPT;;
 """
         )
@@ -1015,7 +1017,7 @@ BKPT;;
         """
         state = _make_state(
             """\
-AGG.MAX.FIRST LR0 0;;
+AGG.MAX.FIRST LR0;;
 BKPT;;
 """
         )
@@ -1034,7 +1036,7 @@ BKPT;;
         """AGG.MAX.FIRST with valid_elements=0: dest gets the identity seed (INT32_MIN)."""
         state = _make_state(
             """\
-AGG.MAX.FIRST LR0 0;;
+AGG.MAX.FIRST LR0;;
 BKPT;;
 """
         )
@@ -1051,7 +1053,7 @@ BKPT;;
         """AGG.MAX.FIRST: MULT_RES tail lanes beyond valid_elements are excluded."""
         state = _make_state(
             """\
-AGG.MAX.FIRST LR0 0;;
+AGG.MAX.FIRST LR0;;
 BKPT;;
 """
         )
@@ -1070,7 +1072,7 @@ BKPT;;
         """AGG.MAX: existing R_ACC[dest] seed beats all active MULT_RES lanes — dest unchanged."""
         state = _make_state(
             """\
-AGG.MAX LR0 1;;
+AGG.MAX LR0;;
 BKPT;;
 """
         )
@@ -1089,7 +1091,7 @@ BKPT;;
         """AGG.MAX: an active MULT_RES lane beats the existing R_ACC[dest] seed — dest updated."""
         state = _make_state(
             """\
-AGG.MAX LR0 0;;
+AGG.MAX LR0;;
 BKPT;;
 """
         )
@@ -1114,7 +1116,7 @@ BKPT;;
         """
         state = _make_state(
             """\
-AGG.SUM.FIRST LR0 1; ACTIVATE relu 1;;
+AGG.SUM.FIRST LR0; ACTIVATE relu;;
 BKPT;;
 """
         )
@@ -1818,7 +1820,7 @@ class TestAaqQuantize:
         # Lanes 0..127 hold the signed value (i - 64): -64..63, all in range.
         self._set_acc_words(state, [i - 64 for i in range(128)])
 
-        encoded = assemble("aaq 0;;\nBKPT;;")
+        encoded = assemble("aaq;;\nBKPT;;")
         from ipu_emu.execute import decode_instruction_word
         from ipu_emu.emulator import load_program, run_until_complete
         decoded = [decode_instruction_word(w) for w in encoded]
@@ -1837,7 +1839,7 @@ class TestAaqQuantize:
         state.dtype = DType.INT8
         self._set_acc_words(state, [0] * 128)
 
-        encoded = assemble("aaq 0;;\nBKPT;;")
+        encoded = assemble("aaq;;\nBKPT;;")
         from ipu_emu.execute import decode_instruction_word
         from ipu_emu.emulator import load_program, run_until_complete
         decoded = [decode_instruction_word(w) for w in encoded]
@@ -1854,7 +1856,7 @@ class TestAaqQuantize:
         values = [127] * 64 + [0x7FFFFFFF] * 64
         self._set_acc_words(state, values)
 
-        encoded = assemble("aaq 0;;\nBKPT;;")
+        encoded = assemble("aaq;;\nBKPT;;")
         from ipu_emu.execute import decode_instruction_word
         from ipu_emu.emulator import load_program, run_until_complete
         decoded = [decode_instruction_word(w) for w in encoded]
@@ -1874,7 +1876,7 @@ class TestAaqQuantize:
         values = [-1] * 64 + [-(1 << 30)] * 64
         self._set_acc_words(state, values)
 
-        encoded = assemble("aaq 0;;\nBKPT;;")
+        encoded = assemble("aaq;;\nBKPT;;")
         from ipu_emu.execute import decode_instruction_word
         from ipu_emu.emulator import load_program, run_until_complete
         decoded = [decode_instruction_word(w) for w in encoded]
@@ -1891,19 +1893,20 @@ class TestAaqQuantize:
     def test_aaq_requires_int8_mode(self):
         """aaq raises EmulatorError when not in INT8 mode."""
         from ipu_emu.ipu import EmulatorError
-        state = _make_state("aaq 0;;\nBKPT;;")
+        state = _make_state("aaq;;\nBKPT;;")
         state.dtype = DType.E4
         with pytest.raises(EmulatorError, match="INT8 mode"):
             run_until_complete(state)
 
-    def test_aaq_full_xmem_row_1_ignores_valid_elements(self):
-        """full_xmem_row=1 always quantizes all 128 lanes even if CR15.valid_elements < 128."""
+    def test_aaq_explicit_cr_idx_overrides_default(self):
+        """AAQ with explicit CR3 quantizes all 128 lanes from CR3, ignoring CR15.valid_elements < 128."""
         state = IpuState()
         state.dtype = DType.INT8
         state.set_cr_dstructure(valid_elements=64)
+        state.regfile.set_cr(3, encode_dstructure(valid_elements=128, partition=0))
         self._set_acc_words(state, [1] * 128)  # in-range; direct clamp leaves 1 -> 1
 
-        encoded = assemble("aaq 1;;\nBKPT;;")
+        encoded = assemble("aaq cr3;;\nBKPT;;")
         from ipu_emu.execute import decode_instruction_word
         from ipu_emu.emulator import load_program, run_until_complete
         decoded = [decode_instruction_word(w) for w in encoded]
@@ -1914,14 +1917,14 @@ class TestAaqQuantize:
         assert result[:128] == bytearray([1] * 128), "all 128 lanes should be quantized"
         assert result[128:] == bytearray(384)
 
-    def test_aaq_full_xmem_row_0_uses_valid_elements(self):
-        """full_xmem_row=0 quantizes only CR15.valid_elements lanes; rest are zeroed."""
+    def test_aaq_default_cr15_uses_valid_elements(self):
+        """AAQ with no cr_idx defaults to CR15.valid_elements lanes; rest are zeroed."""
         state = IpuState()
         state.dtype = DType.INT8
         state.set_cr_dstructure(valid_elements=48)
         self._set_acc_words(state, [1] * 128)  # in-range; direct clamp leaves 1 -> 1
 
-        encoded = assemble("aaq 0;;\nBKPT;;")
+        encoded = assemble("aaq;;\nBKPT;;")
         from ipu_emu.execute import decode_instruction_word
         from ipu_emu.emulator import load_program, run_until_complete
         decoded = [decode_instruction_word(w) for w in encoded]
@@ -1993,7 +1996,7 @@ class TestActivate:
     def test_activate_relu_int32(self):
         state = _make_state(
             """\
-ACTIVATE relu 0;;
+ACTIVATE relu;;
 BKPT;;
 """
         )
@@ -2012,7 +2015,7 @@ BKPT;;
     def test_activate_masks_inactive_lanes(self):
         state = _make_state(
             """\
-ACTIVATE relu 0;;
+ACTIVATE relu;;
 BKPT;;
 """
         )
@@ -2050,7 +2053,7 @@ BKPT;;
     def test_activate_identity_keyword_is_noop(self):
         state = _make_state(
             """\
-ACTIVATE identity 0;;
+ACTIVATE identity;;
 BKPT;;
 """
         )
@@ -2065,7 +2068,7 @@ BKPT;;
     def test_activate_sigmoid_float_lane(self):
         state = _make_state(
             """\
-ACTIVATE sigmoid 0;;
+ACTIVATE sigmoid;;
 BKPT;;
 """
         )
@@ -2083,7 +2086,7 @@ BKPT;;
         for fid, name in enumerate(ACTIVATION_FN_NAMES):
             state = _make_state(
                 f"""\
-ACTIVATE {name} 0;;
+ACTIVATE {name};;
 BKPT;;
 """
             )
@@ -2100,7 +2103,7 @@ BKPT;;
     def test_activate_exp2_float(self):
         state = _make_state(
             """\
-ACTIVATE exp2 0;;
+ACTIVATE exp2;;
 BKPT;;
 """
         )
@@ -2116,7 +2119,7 @@ BKPT;;
     def test_activate_gelu_float(self):
         state = _make_state(
             """\
-ACTIVATE gelu 0;;
+ACTIVATE gelu;;
 BKPT;;
 """
         )
@@ -2136,7 +2139,7 @@ BKPT;;
         alpha = 0.5
         state = _make_state(
             """\
-ACTIVATE elu 0;;
+ACTIVATE elu;;
 BKPT;;
 """,
             elu_alpha=alpha,
@@ -2156,7 +2159,7 @@ BKPT;;
         alpha = 0.125
         state = _make_state(
             """\
-ACTIVATE elu 0;;
+ACTIVATE elu;;
 BKPT;;
 """
         )
@@ -2174,7 +2177,7 @@ BKPT;;
     def test_activate_valid_elements_from_cr15(self):
         state = _make_state(
             """\
-ACTIVATE relu 0;;
+ACTIVATE relu;;
 BKPT;;
 """
         )
@@ -2197,7 +2200,7 @@ BKPT;;
     def test_activate_reciprocal_float(self):
         state = _make_state(
             """\
-ACTIVATE reciprocal 0;;
+ACTIVATE reciprocal;;
 BKPT;;
 """
         )
@@ -2214,7 +2217,7 @@ BKPT;;
     def test_activate_reciprocal_zero_input(self):
         state = _make_state(
             """\
-ACTIVATE reciprocal 0;;
+ACTIVATE reciprocal;;
 BKPT;;
 """
         )
@@ -2230,7 +2233,7 @@ BKPT;;
     def test_activate_rsqrt_float(self):
         state = _make_state(
             """\
-ACTIVATE rsqrt 0;;
+ACTIVATE rsqrt;;
 BKPT;;
 """
         )
@@ -2247,7 +2250,7 @@ BKPT;;
     def test_activate_rsqrt_nonpositive_input(self):
         state = _make_state(
             """\
-ACTIVATE rsqrt 0;;
+ACTIVATE rsqrt;;
 BKPT;;
 """
         )
@@ -2260,27 +2263,28 @@ BKPT;;
         out = _post_aaq_lane_f32(state, 0)
         assert out == 0.0
 
-    def test_activate_full_xmem_row_1_ignores_valid_elements(self):
-        """ACTIVATE full_xmem_row=1: activates all 128 lanes even when CR15.valid_elements < 128."""
+    def test_activate_explicit_cr_idx_overrides_default(self):
+        """ACTIVATE with explicit CR3 activates all 128 lanes from CR3, ignoring CR15.valid_elements < 128."""
         state = _make_state(
             """\
-ACTIVATE relu 1;;
+ACTIVATE relu cr3;;
 BKPT;;
 """
         )
         state.dtype = DType.INT8
         state.set_cr_dstructure(valid_elements=4)
+        state.regfile.set_cr(3, encode_dstructure(valid_elements=128, partition=0))
         for i in range(128):
             state.regfile.set_r_acc_word(i, struct.unpack("<I", struct.pack("<i", i + 1))[0])
         run_until_complete(state)
         for i in range(128):
             assert _post_aaq_lane_i32(state, i) == i + 1, f"lane {i} should be activated"
 
-    def test_activate_full_xmem_row_0_uses_valid_elements(self):
-        """ACTIVATE full_xmem_row=0: activates only CR15.valid_elements lanes; rest unchanged."""
+    def test_activate_default_cr15_uses_valid_elements(self):
+        """ACTIVATE with no cr_idx defaults to CR15.valid_elements lanes; rest unchanged."""
         state = _make_state(
             """\
-ACTIVATE relu 0;;
+ACTIVATE relu;;
 BKPT;;
 """
         )

--- a/src/tools/ipu-emu-py/test/test_execute.py
+++ b/src/tools/ipu-emu-py/test/test_execute.py
@@ -889,7 +889,7 @@ BKPT;;
         """AGG.SUM.FIRST: sum all 128 MULT_RES lanes and write to R_ACC[dest] (clean init)."""
         state = _make_state(
             """\
-AGG.SUM.FIRST LR0;;
+AGG.SUM.FIRST LR0 cr15;;
 BKPT;;
 """
         )
@@ -911,7 +911,7 @@ BKPT;;
         """
         state = _make_state(
             """\
-AGG.SUM.FIRST LR0;;
+AGG.SUM.FIRST LR0 cr15;;
 BKPT;;
 """
         )
@@ -931,7 +931,7 @@ BKPT;;
         """AGG.SUM.FIRST: only active MULT_RES prefix contributes; tail is excluded."""
         state = _make_state(
             """\
-AGG.SUM.FIRST LR0;;
+AGG.SUM.FIRST LR0 cr15;;
 BKPT;;
 """
         )
@@ -946,8 +946,8 @@ BKPT;;
         result = struct.unpack("<i", struct.pack("<I", raw))[0]
         assert result == 40, f"expected sum of 4 tens = 40, got {result}"
 
-    def test_agg_sum_first_explicit_cr_idx_overrides_default(self):
-        """AGG.SUM.FIRST with explicit CR3 uses CR3.valid_elements=128, ignoring CR15=4."""
+    def test_agg_sum_first_uses_named_cr_register(self):
+        """AGG.SUM.FIRST naming CR3 uses CR3.valid_elements=128, ignoring CR15=4."""
         state = _make_state(
             """\
 AGG.SUM.FIRST LR0 cr3;;
@@ -973,7 +973,7 @@ BKPT;;
         """
         state = _make_state(
             """\
-AGG.SUM LR0;;
+AGG.SUM LR0 cr15;;
 BKPT;;
 """
         )
@@ -993,7 +993,7 @@ BKPT;;
         """AGG.MAX.FIRST: max of all 128 MULT_RES lanes, no seed from dest."""
         state = _make_state(
             """\
-AGG.MAX.FIRST LR0;;
+AGG.MAX.FIRST LR0 cr15;;
 BKPT;;
 """
         )
@@ -1017,7 +1017,7 @@ BKPT;;
         """
         state = _make_state(
             """\
-AGG.MAX.FIRST LR0;;
+AGG.MAX.FIRST LR0 cr15;;
 BKPT;;
 """
         )
@@ -1036,7 +1036,7 @@ BKPT;;
         """AGG.MAX.FIRST with valid_elements=0: dest gets the identity seed (INT32_MIN)."""
         state = _make_state(
             """\
-AGG.MAX.FIRST LR0;;
+AGG.MAX.FIRST LR0 cr15;;
 BKPT;;
 """
         )
@@ -1053,7 +1053,7 @@ BKPT;;
         """AGG.MAX.FIRST: MULT_RES tail lanes beyond valid_elements are excluded."""
         state = _make_state(
             """\
-AGG.MAX.FIRST LR0;;
+AGG.MAX.FIRST LR0 cr15;;
 BKPT;;
 """
         )
@@ -1072,7 +1072,7 @@ BKPT;;
         """AGG.MAX: existing R_ACC[dest] seed beats all active MULT_RES lanes — dest unchanged."""
         state = _make_state(
             """\
-AGG.MAX LR0;;
+AGG.MAX LR0 cr15;;
 BKPT;;
 """
         )
@@ -1091,7 +1091,7 @@ BKPT;;
         """AGG.MAX: an active MULT_RES lane beats the existing R_ACC[dest] seed — dest updated."""
         state = _make_state(
             """\
-AGG.MAX LR0;;
+AGG.MAX LR0 cr15;;
 BKPT;;
 """
         )
@@ -1116,7 +1116,7 @@ BKPT;;
         """
         state = _make_state(
             """\
-AGG.SUM.FIRST LR0; ACTIVATE relu;;
+AGG.SUM.FIRST LR0 cr15; ACTIVATE relu cr15;;
 BKPT;;
 """
         )
@@ -1820,7 +1820,7 @@ class TestAaqQuantize:
         # Lanes 0..127 hold the signed value (i - 64): -64..63, all in range.
         self._set_acc_words(state, [i - 64 for i in range(128)])
 
-        encoded = assemble("aaq;;\nBKPT;;")
+        encoded = assemble("aaq cr15;;\nBKPT;;")
         from ipu_emu.execute import decode_instruction_word
         from ipu_emu.emulator import load_program, run_until_complete
         decoded = [decode_instruction_word(w) for w in encoded]
@@ -1839,7 +1839,7 @@ class TestAaqQuantize:
         state.dtype = DType.INT8
         self._set_acc_words(state, [0] * 128)
 
-        encoded = assemble("aaq;;\nBKPT;;")
+        encoded = assemble("aaq cr15;;\nBKPT;;")
         from ipu_emu.execute import decode_instruction_word
         from ipu_emu.emulator import load_program, run_until_complete
         decoded = [decode_instruction_word(w) for w in encoded]
@@ -1856,7 +1856,7 @@ class TestAaqQuantize:
         values = [127] * 64 + [0x7FFFFFFF] * 64
         self._set_acc_words(state, values)
 
-        encoded = assemble("aaq;;\nBKPT;;")
+        encoded = assemble("aaq cr15;;\nBKPT;;")
         from ipu_emu.execute import decode_instruction_word
         from ipu_emu.emulator import load_program, run_until_complete
         decoded = [decode_instruction_word(w) for w in encoded]
@@ -1876,7 +1876,7 @@ class TestAaqQuantize:
         values = [-1] * 64 + [-(1 << 30)] * 64
         self._set_acc_words(state, values)
 
-        encoded = assemble("aaq;;\nBKPT;;")
+        encoded = assemble("aaq cr15;;\nBKPT;;")
         from ipu_emu.execute import decode_instruction_word
         from ipu_emu.emulator import load_program, run_until_complete
         decoded = [decode_instruction_word(w) for w in encoded]
@@ -1893,13 +1893,13 @@ class TestAaqQuantize:
     def test_aaq_requires_int8_mode(self):
         """aaq raises EmulatorError when not in INT8 mode."""
         from ipu_emu.ipu import EmulatorError
-        state = _make_state("aaq;;\nBKPT;;")
+        state = _make_state("aaq cr15;;\nBKPT;;")
         state.dtype = DType.E4
         with pytest.raises(EmulatorError, match="INT8 mode"):
             run_until_complete(state)
 
-    def test_aaq_explicit_cr_idx_overrides_default(self):
-        """AAQ with explicit CR3 quantizes all 128 lanes from CR3, ignoring CR15.valid_elements < 128."""
+    def test_aaq_uses_named_cr_register(self):
+        """AAQ naming CR3 quantizes all 128 lanes from CR3, ignoring CR15.valid_elements < 128."""
         state = IpuState()
         state.dtype = DType.INT8
         state.set_cr_dstructure(valid_elements=64)
@@ -1917,14 +1917,14 @@ class TestAaqQuantize:
         assert result[:128] == bytearray([1] * 128), "all 128 lanes should be quantized"
         assert result[128:] == bytearray(384)
 
-    def test_aaq_default_cr15_uses_valid_elements(self):
-        """AAQ with no cr_idx defaults to CR15.valid_elements lanes; rest are zeroed."""
+    def test_aaq_cr15_uses_valid_elements(self):
+        """AAQ naming CR15 reads CR15.valid_elements lanes; rest are zeroed."""
         state = IpuState()
         state.dtype = DType.INT8
         state.set_cr_dstructure(valid_elements=48)
         self._set_acc_words(state, [1] * 128)  # in-range; direct clamp leaves 1 -> 1
 
-        encoded = assemble("aaq;;\nBKPT;;")
+        encoded = assemble("aaq cr15;;\nBKPT;;")
         from ipu_emu.execute import decode_instruction_word
         from ipu_emu.emulator import load_program, run_until_complete
         decoded = [decode_instruction_word(w) for w in encoded]
@@ -1996,7 +1996,7 @@ class TestActivate:
     def test_activate_relu_int32(self):
         state = _make_state(
             """\
-ACTIVATE relu;;
+ACTIVATE relu cr15;;
 BKPT;;
 """
         )
@@ -2015,7 +2015,7 @@ BKPT;;
     def test_activate_masks_inactive_lanes(self):
         state = _make_state(
             """\
-ACTIVATE relu;;
+ACTIVATE relu cr15;;
 BKPT;;
 """
         )
@@ -2053,7 +2053,7 @@ BKPT;;
     def test_activate_identity_keyword_is_noop(self):
         state = _make_state(
             """\
-ACTIVATE identity;;
+ACTIVATE identity cr15;;
 BKPT;;
 """
         )
@@ -2068,7 +2068,7 @@ BKPT;;
     def test_activate_sigmoid_float_lane(self):
         state = _make_state(
             """\
-ACTIVATE sigmoid;;
+ACTIVATE sigmoid cr15;;
 BKPT;;
 """
         )
@@ -2086,7 +2086,7 @@ BKPT;;
         for fid, name in enumerate(ACTIVATION_FN_NAMES):
             state = _make_state(
                 f"""\
-ACTIVATE {name};;
+ACTIVATE {name} cr15;;
 BKPT;;
 """
             )
@@ -2103,7 +2103,7 @@ BKPT;;
     def test_activate_exp2_float(self):
         state = _make_state(
             """\
-ACTIVATE exp2;;
+ACTIVATE exp2 cr15;;
 BKPT;;
 """
         )
@@ -2119,7 +2119,7 @@ BKPT;;
     def test_activate_gelu_float(self):
         state = _make_state(
             """\
-ACTIVATE gelu;;
+ACTIVATE gelu cr15;;
 BKPT;;
 """
         )
@@ -2139,7 +2139,7 @@ BKPT;;
         alpha = 0.5
         state = _make_state(
             """\
-ACTIVATE elu;;
+ACTIVATE elu cr15;;
 BKPT;;
 """,
             elu_alpha=alpha,
@@ -2159,7 +2159,7 @@ BKPT;;
         alpha = 0.125
         state = _make_state(
             """\
-ACTIVATE elu;;
+ACTIVATE elu cr15;;
 BKPT;;
 """
         )
@@ -2177,7 +2177,7 @@ BKPT;;
     def test_activate_valid_elements_from_cr15(self):
         state = _make_state(
             """\
-ACTIVATE relu;;
+ACTIVATE relu cr15;;
 BKPT;;
 """
         )
@@ -2200,7 +2200,7 @@ BKPT;;
     def test_activate_reciprocal_float(self):
         state = _make_state(
             """\
-ACTIVATE reciprocal;;
+ACTIVATE reciprocal cr15;;
 BKPT;;
 """
         )
@@ -2217,7 +2217,7 @@ BKPT;;
     def test_activate_reciprocal_zero_input(self):
         state = _make_state(
             """\
-ACTIVATE reciprocal;;
+ACTIVATE reciprocal cr15;;
 BKPT;;
 """
         )
@@ -2233,7 +2233,7 @@ BKPT;;
     def test_activate_rsqrt_float(self):
         state = _make_state(
             """\
-ACTIVATE rsqrt;;
+ACTIVATE rsqrt cr15;;
 BKPT;;
 """
         )
@@ -2250,7 +2250,7 @@ BKPT;;
     def test_activate_rsqrt_nonpositive_input(self):
         state = _make_state(
             """\
-ACTIVATE rsqrt;;
+ACTIVATE rsqrt cr15;;
 BKPT;;
 """
         )
@@ -2263,8 +2263,8 @@ BKPT;;
         out = _post_aaq_lane_f32(state, 0)
         assert out == 0.0
 
-    def test_activate_explicit_cr_idx_overrides_default(self):
-        """ACTIVATE with explicit CR3 activates all 128 lanes from CR3, ignoring CR15.valid_elements < 128."""
+    def test_activate_uses_named_cr_register(self):
+        """ACTIVATE naming CR3 activates all 128 lanes from CR3, ignoring CR15.valid_elements < 128."""
         state = _make_state(
             """\
 ACTIVATE relu cr3;;
@@ -2280,11 +2280,11 @@ BKPT;;
         for i in range(128):
             assert _post_aaq_lane_i32(state, i) == i + 1, f"lane {i} should be activated"
 
-    def test_activate_default_cr15_uses_valid_elements(self):
-        """ACTIVATE with no cr_idx defaults to CR15.valid_elements lanes; rest unchanged."""
+    def test_activate_cr15_uses_valid_elements(self):
+        """ACTIVATE naming CR15 reads CR15.valid_elements lanes; rest unchanged."""
         state = _make_state(
             """\
-ACTIVATE relu;;
+ACTIVATE relu cr15;;
 BKPT;;
 """
         )

--- a/src/tools/ipu-emu-py/test/test_wide_vector_debug.py
+++ b/src/tools/ipu-emu-py/test/test_wide_vector_debug.py
@@ -84,8 +84,8 @@ LDR_CYCLIC_MULT_REG lr1 cr0 lr2;;
 MULT.RC.VV lr2 r0 0 lr2;;
 acc.first;;
 SET lr0 cr9;;
-ACTIVATE identity;;
-aaq;;
+ACTIVATE identity cr15;;
+aaq cr15;;
 BKPT;;
 """,
             cr={6: 0x1000, 7: 0x2000, 8: 0, 9: 128},
@@ -113,8 +113,8 @@ LDR_CYCLIC_MULT_REG lr1 cr0 lr2;;
 MULT.RC.VV lr2 r0 0 lr2;;
 acc.first;;
 SET lr0 cr9;;
-ACTIVATE identity;;
-aaq;;
+ACTIVATE identity cr15;;
+aaq cr15;;
 BKPT;;
 """
         state.regfile.set_cr(6, 0x1000)
@@ -313,7 +313,7 @@ class TestWideVectorAgg:
         mult_res = bytearray(512)
         struct.pack_into("<128i", mult_res, 0, *([4] * 128))
         st = self._run_agg(
-            "AGG.SUM.FIRST LR0;;\nBKPT;;\n", WideVectorArithmetic.INT32, mult_res
+            "AGG.SUM.FIRST LR0 cr15;;\nBKPT;;\n", WideVectorArithmetic.INT32, mult_res
         )
         raw = st.regfile.raw("r_acc")
         assert struct.unpack_from("<i", raw, 127 * 4)[0] == 512
@@ -323,7 +323,7 @@ class TestWideVectorAgg:
         mult_res = bytearray(512)
         struct.pack_into("<128f", mult_res, 0, *([0.5] * 128))
         st = self._run_agg(
-            "AGG.SUM.FIRST LR0;;\nBKPT;;\n", WideVectorArithmetic.FP32, mult_res
+            "AGG.SUM.FIRST LR0 cr15;;\nBKPT;;\n", WideVectorArithmetic.FP32, mult_res
         )
         raw = st.regfile.raw("r_acc")
         assert struct.unpack_from("<f", raw, 127 * 4)[0] == pytest.approx(64.0)
@@ -334,7 +334,7 @@ class TestWideVectorAgg:
         struct.pack_into("<128f", mult_res, 0, *([1.0] * 128))
         struct.pack_into("<f", mult_res, 3 * 4, 7.5)
         st = self._run_agg(
-            "AGG.MAX.FIRST LR0;;\nBKPT;;\n", WideVectorArithmetic.FP32, mult_res
+            "AGG.MAX.FIRST LR0 cr15;;\nBKPT;;\n", WideVectorArithmetic.FP32, mult_res
         )
         raw = st.regfile.raw("r_acc")
         assert struct.unpack_from("<f", raw, 127 * 4)[0] == pytest.approx(7.5)

--- a/src/tools/ipu-emu-py/test/test_wide_vector_debug.py
+++ b/src/tools/ipu-emu-py/test/test_wide_vector_debug.py
@@ -84,8 +84,8 @@ LDR_CYCLIC_MULT_REG lr1 cr0 lr2;;
 MULT.RC.VV lr2 r0 0 lr2;;
 acc.first;;
 SET lr0 cr9;;
-ACTIVATE identity 0;;
-aaq 0;;
+ACTIVATE identity;;
+aaq;;
 BKPT;;
 """,
             cr={6: 0x1000, 7: 0x2000, 8: 0, 9: 128},
@@ -113,8 +113,8 @@ LDR_CYCLIC_MULT_REG lr1 cr0 lr2;;
 MULT.RC.VV lr2 r0 0 lr2;;
 acc.first;;
 SET lr0 cr9;;
-ACTIVATE identity 0;;
-aaq 0;;
+ACTIVATE identity;;
+aaq;;
 BKPT;;
 """
         state.regfile.set_cr(6, 0x1000)
@@ -313,7 +313,7 @@ class TestWideVectorAgg:
         mult_res = bytearray(512)
         struct.pack_into("<128i", mult_res, 0, *([4] * 128))
         st = self._run_agg(
-            "AGG.SUM.FIRST LR0 0;;\nBKPT;;\n", WideVectorArithmetic.INT32, mult_res
+            "AGG.SUM.FIRST LR0;;\nBKPT;;\n", WideVectorArithmetic.INT32, mult_res
         )
         raw = st.regfile.raw("r_acc")
         assert struct.unpack_from("<i", raw, 127 * 4)[0] == 512
@@ -323,7 +323,7 @@ class TestWideVectorAgg:
         mult_res = bytearray(512)
         struct.pack_into("<128f", mult_res, 0, *([0.5] * 128))
         st = self._run_agg(
-            "AGG.SUM.FIRST LR0 0;;\nBKPT;;\n", WideVectorArithmetic.FP32, mult_res
+            "AGG.SUM.FIRST LR0;;\nBKPT;;\n", WideVectorArithmetic.FP32, mult_res
         )
         raw = st.regfile.raw("r_acc")
         assert struct.unpack_from("<f", raw, 127 * 4)[0] == pytest.approx(64.0)
@@ -334,7 +334,7 @@ class TestWideVectorAgg:
         struct.pack_into("<128f", mult_res, 0, *([1.0] * 128))
         struct.pack_into("<f", mult_res, 3 * 4, 7.5)
         st = self._run_agg(
-            "AGG.MAX.FIRST LR0 0;;\nBKPT;;\n", WideVectorArithmetic.FP32, mult_res
+            "AGG.MAX.FIRST LR0;;\nBKPT;;\n", WideVectorArithmetic.FP32, mult_res
         )
         raw = st.regfile.raw("r_acc")
         assert struct.unpack_from("<f", raw, 127 * 4)[0] == pytest.approx(7.5)


### PR DESCRIPTION
AGG.SUM[.FIRST], AGG.MAX[.FIRST], AAQ, and ACTIVATE now take an optional
trailing cr_idx operand (any CR0-CR15) supplying the valid-element mask
instead of being hard-coded to CR15. Omitting the operand still defaults
to CR15. The unused full_xmem_row operand is removed from these
instructions' specs and handlers.