### PR TITLE
Refactor AAQ instruction to ACTIVATE.QUANTIZE with INT8 quantization

### DIFF
--- a/src/tools/ipu-as-py/src/ipu_as/gen_docs.py
+++ b/src/tools/ipu-as-py/src/ipu_as/gen_docs.py
@@ -59,12 +59,11 @@ OPERAND_TYPE_DETAILS: dict[str, str] = {
         "`acc_stride_enums`)."
     ),
     "ActivationFn": (
-        "AAQ-slot keyword on **`ACTIVATE`**: one of **identity**, **relu**, **relu6**, "
-        "**sigmoid**, **tanh**, **gelu**, **softplus**, **elu**, **exp2** "
+        "AAQ-slot keyword on **`ACTIVATE.QUANTIZE`**: one of **identity**, **relu**, **relu6**, "
+        "**sigmoid**, **tanh**, **gelu**, **softplus**, **elu**, **exp2**, **reciprocal**, **rsqrt** "
         "(see ``ACTIVATION_FN_NAMES`` in ``ipu_common.activations``). Emulator-only calibration (including α) "
-        "and how **`POST_AAQ_REG`** (interim **512 B**) and **`STR_POST_AAQ_REG`** (store to XMEM) "
-        "are described in **Building Applications** "
-        "(`docs/content/building-applications.md#activations-emulator`)."
+        "is described in **Building Applications** "
+        "(`docs/content/building-applications.md`)."
     ),
     "LrModPow2KImmediate": (
         "Four-bit immediate for **`INCR_MOD_POW2`**: encodes exponent **k** with semantic "
@@ -79,7 +78,7 @@ OPERAND_TYPE_DETAILS: dict[str, str] = {
     "DstructureCrIdx": (
         "Constant-register index: **`cr0`** … **`cr15`**, selecting which CR supplies the "
         "**valid element mask** / dstructure configuration (`valid_elements`, `partition`) for "
-        "`AGG.SUM`, `AGG.SUM.FIRST`, `AGG.MAX`, `AGG.MAX.FIRST`, `AAQ`, `ACTIVATE`, and the "
+        "`AGG.SUM`, `AGG.SUM.FIRST`, `AGG.MAX`, `AGG.MAX.FIRST`, `ACTIVATE.QUANTIZE`, and the "
         "masking multiply instructions (`MULT.RC.VV`, `MULT.RC.VE`, `MULT.RC.VS`, `MULT.VE`, "
         "`MULT.EE`). Unlike **`CrIdx`**, **`cr15`** is allowed here — it's the conventional "
         "dstructure register — but the operand is always mandatory; there is no implicit "

--- a/src/tools/ipu-as-py/src/ipu_as/inst.py
+++ b/src/tools/ipu-as-py/src/ipu_as/inst.py
@@ -574,7 +574,7 @@ class AaqInst(Inst):
     def description(cls) -> str:
         return cls._render_instruction_docs(
             heading="AAQ Instructions",
-            intro="Activation and quantization: aggregate r_acc into AAQ registers; ACTIVATE writes activated lanes from r_acc into POST_AAQ_REG; AAQ quantizes POST_AAQ_REG.",
+            intro="Activation and quantization: apply activation to R_ACC lanes and write quantized INT8 bytes to POST_AAQ_REG.",
             slot_type="aaq",
         )
 

--- a/src/tools/ipu-common/src/ipu_common/instruction_spec.py
+++ b/src/tools/ipu-common/src/ipu_common/instruction_spec.py
@@ -29,7 +29,7 @@ OPERAND TYPE NAMES (resolved by ipu_as into actual token classes):
   - "LrIncDecImmediate": unsigned immediate for INC/DEC; bit width derived from LR slot union layout
   - "LrModPow2KImmediate": k operand for INCR_MOD_POW2 (semantic k ∈ [1, 9]; encoded as k−1 in 4 bits)
   - "MultMaskOffsetImmediate": mask slot index for mult masking (0–7; eight 128-bit slots in R_MASK)
-  - "ActivationFn": keyword on `ACTIVATE` (see ``ACTIVATION_FN_NAMES`` in ``activations.py``)
+  - "ActivationFn": keyword on `ACTIVATE.QUANTIZE` (see ``ACTIVATION_FN_NAMES`` in ``activations.py``)
   - "BreakImmediate": 16-bit BREAK condition value (BreakImmediateType)
   - "Label": Branch target label (LabelToken)
 
@@ -173,7 +173,7 @@ SLOT_METADATA: dict[str, dict] = {
     "acc_store": {"hardware": False, "description": "Simulation-only stores of R_ACC to external memory (STR_ACC_REG). Not implemented in real IPU hardware."},
     "mult":      {"description": "Multiply-stage instructions: element-wise and vector multiply operations."},
     "acc":       {"description": "Accumulation instructions for combining multiply results into R_ACC."},
-    "aaq":       {"description": "Activation and quantization: aggregate R_ACC into AAQ registers; quantize POST_AAQ_REG."},
+    "aaq":       {"description": "Activation and quantization: apply activation to R_ACC and write quantized INT8 bytes to POST_AAQ_REG."},
     "lr":        {"description": "Loop register instructions for controlling addresses, counters, and scalars. Three independent sub-slots per cycle."},
     "cond":      {"description": "Conditional and unconditional branches; control flow based on register comparisons."},
     "break":     {"description": "Debug break: halts execution or enters debug mode."},
@@ -887,70 +887,40 @@ INSTRUCTION_SPEC = {
             ),
             "execute_fn": "execute_aaq_nop",
         },
-        "AAQ": {
-            "operands": [
-                {"name": "cr_idx", "type": "DstructureCrIdx"},
-            ],
-            "doc": InstructionDoc(
-                title="AAQ Quantize",
-                summary=(
-                    "Quantize wide lanes in **`POST_AAQ_REG`** (INT32 per lane in INT8 mode) "
-                    "to INT8, storing clamped bytes in the **leading 128 bytes** of **`POST_AAQ_REG`** "
-                    "and clearing the rest of the register. Wide lanes are normally produced by "
-                    "**`ACTIVATE`** (from ``r_acc``). Requires INT8 mode. "
-                    "The active lane count comes from ``cr_idx``'s dstructure configuration "
-                    "(any CR0-CR15; must be named explicitly)."
-                ),
-                syntax="AAQ cr_idx",
-                operands=[
-                    "cr_idx: CR0…CR15 supplying valid_elements (must be given explicitly)",
-                ],
-                operation=(
-                    "Requires INT8 mode (IpuState.dtype == DType.INT8 in the Python emulator). "
-                    "Let n = min(CR[cr_idx].valid_elements, 128). "
-                    "For i in [0, n): POST_AAQ_REG[i] = clamp(POST_AAQ_REG wide lane i, -128, 127) "
-                    "(interim direct INT8 clamp of the post-ACTIVATE lane; a future per-128-element "
-                    "requantize will scale lanes into INT8 range before this step and supersede the clamp). "
-                    "POST_AAQ_REG[n..511] = 0."
-                ),
-                example="AAQ CR3;;",
-            ),
-            "execute_fn": "execute_aaq",
-        },
-        "ACTIVATE": {
+        "ACTIVATE.QUANTIZE": {
             "operands": [
                 {"name": "activation_fn", "type": "ActivationFn"},
                 {"name": "cr_idx", "type": "DstructureCrIdx"},
             ],
             "doc": InstructionDoc(
-                title="Accumulator Activation",
+                title="Activate and Quantize",
                 summary=(
-                    "Read active lanes from ``r_acc``, apply the selected element-wise activation, "
-                    "and write results into the same lane indices of ``POST_AAQ_REG`` (``r_acc`` is unchanged). "
-                    "The active lane count comes from ``cr_idx``'s dstructure configuration "
-                    "(any CR0-CR15; must be named explicitly). "
-                    "The activation is selected by keyword (see ACTIVATION_FN_NAMES). The available "
-                    "activation functions are: ``identity`` (0), ``relu`` (1), ``relu6`` (2), "
+                    "Read active lanes from ``r_acc`` (snapshot), apply the selected element-wise activation, "
+                    "clamp the results to the INT8 range ``[-128, 127]``, and write the resulting bytes to "
+                    "the leading active-lane positions of **``POST_AAQ_REG``**; all remaining bytes are zeroed. "
+                    "``r_acc`` is not modified. Requires INT8 mode. "
+                    "The active lane count is taken from ``cr_idx``'s dstructure ``valid_elements`` field "
+                    "(any CR0–CR15; must be named explicitly). "
+                    "Available activation functions: ``identity`` (0), ``relu`` (1), ``relu6`` (2), "
                     "``sigmoid`` (3), ``tanh`` (4), ``gelu`` (5), ``softplus`` (6), ``elu`` (7), "
-                    "``exp2`` (8), ``reciprocal`` (9), ``rsqrt`` (10). For Python emulator calibration (virtual α), see "
-                    "docs/content/building-applications.md#activations-emulator."
+                    "``exp2`` (8), ``reciprocal`` (9), ``rsqrt`` (10)."
                 ),
-                syntax="ACTIVATE activation_fn, cr_idx",
+                syntax="ACTIVATE.QUANTIZE activation_fn, cr_idx",
                 operands=[
-                    "activation_fn: keyword naming the activation (one of identity, relu, relu6, sigmoid, tanh, gelu, softplus, elu, exp2; see ACTIVATION_FN_NAMES)",
+                    "activation_fn: keyword naming the activation (see ACTIVATION_FN_NAMES)",
                     "cr_idx: CR0…CR15 supplying valid_elements (must be given explicitly)",
                 ],
                 operation=(
+                    "Requires INT8 mode (IpuState.dtype == DType.INT8). "
                     "Let n = min(CR[cr_idx].valid_elements, 128) and k = encoded activation index. "
-                    "For i in [0, n): POST_AAQ_REG[i] = activation_k(R_ACC[i]) (same 32-bit lane format as R_ACC). "
-                    "R_ACC is not modified. The selector uses four bits; encodings outside the eleven named "
-                    "activations behave as identity. "
-                    "α for elu is not an ISA operand; see "
-                    "docs/content/building-applications.md#activations-emulator."
+                    "For i in [0, n): POST_AAQ_REG[i] = clamp(round(activation_k(R_ACC[i])), -128, 127). "
+                    "POST_AAQ_REG[n..511] = 0. R_ACC is not modified. "
+                    "Clamping is a placeholder until a full per-lane requantize is implemented. "
+                    "α for elu is not an ISA operand; see docs/content/building-applications.md."
                 ),
-                example="ACTIVATE relu, CR3;;",
+                example="ACTIVATE.QUANTIZE relu, CR15;;",
             ),
-            "execute_fn": "execute_activate",
+            "execute_fn": "execute_activate_quantize",
         },
     },
 

--- a/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
+++ b/src/tools/ipu-emu-py/src/ipu_emu/ipu.py
@@ -1000,83 +1000,20 @@ class Ipu:
         result = self._agg_max_lanes(fmt, mult_res, active, snap_dest)
         struct.pack_into(fmt, self.state.regfile.raw("r_acc"), dest * 4, result)
 
-    def execute_aaq(self, *, cr_idx: int) -> None:
-        """Execute AAQ: Quantize wide lanes in ``POST_AAQ_REG`` (128 × 32-bit) → leading bytes.
+    def execute_activate_quantize(self, *, activation_fn: int, cr_idx: int) -> None:
+        """Apply element-wise activation then quantize to INT8.
 
-        Source is the **512-byte** ``post_aaq_reg`` buffer (same lane layout as
-        ``r_acc``), typically filled by ``ACTIVATE``. Each active 32-bit lane is
-        clamped to the INT8 range ``[-128, 127]`` and stored in the leading bytes
-        of ``post_aaq_reg``; the remainder is zeroed.
+        Reads each active lane from the cycle-start snapshot of ``r_acc``, applies
+        the selected activation, clamps to the INT8 range ``[-128, 127]``, and stores
+        the resulting bytes in the leading active-lane positions of ``post_aaq_reg``;
+        all remaining bytes are zeroed. ``r_acc`` is not modified.
 
-        Quantization is an **interim direct clamp** of the post-``ACTIVATE``
-        accumulator lane: ``out[i] = clamp(lane[i], -128, 127)``.  The previous
-        ``lane >> 24`` truncation was the shift half of a fixed-point requantize
-        whose per-lane multiply half is not implemented, so on a real INT8
-        convolution accumulator (magnitudes well below ``2**24``) it produced an
-        all-zero result.
+        The active lane count comes from ``cr_idx``'s decoded dstructure
+        ``valid_elements`` field; the caller must name a CR register explicitly.
 
-        This clamp is a placeholder, not the final design.  The intended future
-        quantization is a full per-128-element (per-lane) requantize — applied
-        after ``ACTIVATE`` and before write-back to memory — that scales each
-        lane so the result is guaranteed to land in INT8 range; that stage
-        subsumes (and will replace) this clamp.  Until it lands, clamping keeps
-        the ``ACTIVATE`` -> ``AAQ`` path producing usable INT8 output instead of
-        all zeros.
-
-        Active lane count is taken from ``cr_idx``'s ``valid_elements``
-        (clamped to 128); the caller must name a CR register explicitly.
-
-        Requires INT8 mode.
-
-        In wide-vector debug mode, ``aaq`` is normally a no-op (use
-        ``STR_ACC_REG`` to dump ``r_acc``). Set ``state.wide_vector_quantize_output``
-        to quantize from ``post_aaq_reg`` wide lanes for comparison with the real path.
-        """
-        dtype = self.state.dtype
-        if dtype != DType.INT8:
-            raise EmulatorError("AAQ instruction requires INT8 mode")
-
-        active = self._agg_active_lane_count(
-            self.state.get_dstructure_for(cr_idx).valid_elements
-        )
-
-        if self._wide_vector_active():
-            if not self.state.wide_vector_quantize_output:
-                return
-            src_buf = self.state.regfile.raw("post_aaq_reg")
-            result = bytearray(128)
-            if self.state.wide_vector_arithmetic == WideVectorArithmetic.FP32:
-                for i in range(active):
-                    val = struct.unpack_from("<f", src_buf, i * 4)[0]
-                    clamped = max(-128, min(127, int(round(val))))
-                    result[i] = clamped & 0xFF
-            else:
-                for i in range(active):
-                    val = struct.unpack_from("<i", src_buf, i * 4)[0]
-                    clamped = max(-128, min(127, val))
-                    result[i] = clamped & 0xFF
-            self.state.regfile.set_post_aaq_reg(result + bytearray(384))
-            return
-
-        src_buf = self.state.regfile.raw("post_aaq_reg")
-        result = bytearray(128)
-        for i in range(active):
-            val = struct.unpack_from("<i", src_buf, i * 4)[0]
-            clamped = max(-128, min(127, val))  # direct INT8 clamp (no >>24 truncation)
-            result[i] = clamped & 0xFF
-        self.state.regfile.set_post_aaq_reg(result + bytearray(384))
-
-    def execute_activate(self, *, activation_fn: int, cr_idx: int) -> None:
-        """Apply element-wise activation to active lanes.
-
-        Reads each active lane from ``r_acc`` and writes the result into the same
-        lane of ``post_aaq_reg`` (512-byte wide staging). ``r_acc`` is not modified.
-        Lanes at indices ``>=`` the active lane count in ``post_aaq_reg`` are left
-        unchanged.
-
-        ``activation_fn`` is the encoded enum index (0–8) from the instruction word.
-        Lane count is taken from ``cr_idx``'s ``valid_elements``; the caller
-        must name a CR register explicitly.
+        Requires INT8 mode in normal operation. In wide-vector debug mode, activation
+        is always applied; quantization only occurs when ``state.wide_vector_quantize_output``
+        is set (enabling comparison with the real INT8 path).
         """
         fn_id = int(activation_fn) & REGISTER_WORD_VALUE_MASK
         valid_elements = self.state.get_dstructure_for(cr_idx).valid_elements
@@ -1085,22 +1022,44 @@ class Ipu:
         acc_buf = self.snapshot.raw("r_acc")
         post_buf = self.state.regfile.raw("post_aaq_reg")
 
+        if self._wide_vector_active():
+            for i in range(active):
+                raw = struct.unpack_from(fmt, acc_buf, i * 4)[0]
+                y = apply_activation(fn_id, float(raw), elu_alpha=self.state.elu_alpha)
+                if fmt == "<i":
+                    yi = int(round(y))
+                    if yi < -2147483648:
+                        yi = -2147483648
+                    elif yi > 2147483647:
+                        yi = 2147483647
+                    struct.pack_into("<i", post_buf, i * 4, yi)
+                else:
+                    struct.pack_into("<f", post_buf, i * 4, float(y))
+
+            if not self.state.wide_vector_quantize_output:
+                return
+
+            result = bytearray(128)
+            if self.state.wide_vector_arithmetic == WideVectorArithmetic.FP32:
+                for i in range(active):
+                    val = struct.unpack_from("<f", post_buf, i * 4)[0]
+                    result[i] = max(-128, min(127, int(round(val)))) & 0xFF
+            else:
+                for i in range(active):
+                    val = struct.unpack_from("<i", post_buf, i * 4)[0]
+                    result[i] = max(-128, min(127, val)) & 0xFF
+            self.state.regfile.set_post_aaq_reg(result + bytearray(384))
+            return
+
+        if self.state.dtype != DType.INT8:
+            raise EmulatorError("ACTIVATE.QUANTIZE instruction requires INT8 mode")
+
+        result = bytearray(128)
         for i in range(active):
             raw = struct.unpack_from(fmt, acc_buf, i * 4)[0]
-            y = apply_activation(
-                fn_id,
-                float(raw),
-                elu_alpha=self.state.elu_alpha,
-            )
-            if fmt == "<i":
-                yi = int(round(y))
-                if yi < -2147483648:
-                    yi = -2147483648
-                elif yi > 2147483647:
-                    yi = 2147483647
-                struct.pack_into("<i", post_buf, i * 4, yi)
-            else:
-                struct.pack_into("<f", post_buf, i * 4, float(y))
+            y = apply_activation(fn_id, float(raw), elu_alpha=self.state.elu_alpha)
+            result[i] = max(-128, min(127, int(round(y)))) & 0xFF
+        self.state.regfile.set_post_aaq_reg(result + bytearray(384))
 
     def execute_str_post_aaq_reg(self, *, offset: int, base: int) -> None:
         """Store **POST_AAQ_REG** (512 bytes) to XMEM."""

--- a/src/tools/ipu-emu-py/test/test_execute.py
+++ b/src/tools/ipu-emu-py/test/test_execute.py
@@ -1205,15 +1205,15 @@ BKPT;;
         result = struct.unpack("<i", struct.pack("<I", raw))[0]
         assert result == 77, f"expected max=77, got {result}"
 
-    def test_agg_and_activate_same_cycle_use_snapshot(self):
-        """AGG.SUM.FIRST in ACC slot and ACTIVATE in AAQ slot issued together.
+    def test_agg_and_activate_quantize_same_cycle_use_snapshot(self):
+        """AGG.SUM.FIRST in ACC slot and ACTIVATE.QUANTIZE in AAQ slot issued together.
 
         AGG reads from MULT_RES (live) and writes r_acc[dest].
-        ACTIVATE reads from the cycle-start snapshot of r_acc (not the AGG write).
+        ACTIVATE.QUANTIZE reads from the cycle-start snapshot of r_acc (not the AGG write).
         """
         state = _make_state(
             """\
-AGG.SUM.FIRST LR0 cr15; ACTIVATE relu cr15;;
+AGG.SUM.FIRST LR0 cr15; ACTIVATE.QUANTIZE relu cr15;;
 BKPT;;
 """
         )
@@ -1223,7 +1223,7 @@ BKPT;;
         for i in range(128):
             # MULT_RES lanes = 3 (source for AGG.SUM.FIRST)
             state.regfile.set_mult_res_word(i, _struct.unpack("<I", _struct.pack("<i", 3))[0])
-            # r_acc lanes = 3 (source for ACTIVATE snapshot)
+            # r_acc lanes = 3 (source for ACTIVATE.QUANTIZE snapshot)
             state.regfile.set_r_acc_word(i, _struct.unpack("<I", _struct.pack("<i", 3))[0])
 
         run_until_complete(state)
@@ -1233,13 +1233,13 @@ BKPT;;
         agg_result = _struct.unpack("<i", _struct.pack("<I", raw_agg))[0]
         assert agg_result == 384, f"AGG saw wrong mult_res: expected 384, got {agg_result}"
 
-        # ACTIVATE relu must have applied relu to the snapshot r_acc (all lanes 3 → 3)
+        # ACTIVATE.QUANTIZE relu must have applied relu to the snapshot r_acc (lane 0 = 3)
         # NOT the post-AGG r_acc where lane 0 = 384.
-        # In INT8 mode ACTIVATE writes int32 to post_aaq_reg.
+        # relu(3) = 3, clamped to INT8 byte = 3. Bytes [3, 0, 0, 0] read as int32 = 3.
         post = state.regfile.raw("post_aaq_reg")
-        lane0_post = _struct.unpack_from("<i", post, 0)[0]
-        assert lane0_post == 3, (
-            f"ACTIVATE saw wrong r_acc lane 0: expected 3, got {lane0_post}"
+        lane0_byte = post[0]
+        assert lane0_byte == 3, (
+            f"ACTIVATE.QUANTIZE saw wrong r_acc lane 0: expected byte 3, got {lane0_byte}"
         )
 
 
@@ -1895,149 +1895,189 @@ BKPT;;
 
 
 # ============================================================================
-# AAQ Quantization (aaq instruction + str_post_aaq_reg)
+# ACTIVATE.QUANTIZE (combined activation + INT8 quantize: r_acc → POST_AAQ_REG bytes)
 # ============================================================================
 
 
-class TestAaqQuantize:
-    """Tests for the aaq quantization instruction and STR_POST_AAQ_REG."""
+class TestActivateQuantize:
+    """ACTIVATE.QUANTIZE applies activation to r_acc and quantizes to INT8 bytes in POST_AAQ_REG."""
 
-    def _set_acc_words(self, state: IpuState, values: list[int]) -> None:
-        """Write a list of 128 signed INT32 values into r_acc."""
-        assert len(values) == 128
+    def test_relu_zeroes_negative_lane(self):
+        """relu(-9) = 0 → byte 0; r_acc is unchanged."""
+        state = _make_state(
+            """\
+ACTIVATE.QUANTIZE relu cr15;;
+BKPT;;
+"""
+        )
+        state.dtype = DType.INT8
+        state.set_cr_dstructure(128)
+        state.regfile.set_r_acc_word(0, struct.unpack("<I", struct.pack("<i", -9))[0])
+        run_until_complete(state)
+        assert struct.unpack("<i", struct.pack("<I", state.regfile.get_r_acc_word(0)))[0] == -9
+        assert state.regfile.get_post_aaq_reg()[0] == 0
+
+    def test_relu_passes_positive_lane(self):
+        """relu(5) = 5 → byte 5."""
+        state = _make_state(
+            """\
+ACTIVATE.QUANTIZE relu cr15;;
+BKPT;;
+"""
+        )
+        state.dtype = DType.INT8
+        state.set_cr_dstructure(128)
+        state.regfile.set_r_acc_word(0, struct.unpack("<I", struct.pack("<i", 5))[0])
+        run_until_complete(state)
+        assert state.regfile.get_post_aaq_reg()[0] == 5
+
+    def test_identity_clamp_positive(self):
+        """identity(200) saturates to 127 byte; identity(-200) saturates to 0x80 byte."""
+        state = _make_state(
+            """\
+ACTIVATE.QUANTIZE identity cr15;;
+BKPT;;
+"""
+        )
+        state.dtype = DType.INT8
+        state.set_cr_dstructure(128)
+        state.regfile.set_r_acc_word(0, struct.unpack("<I", struct.pack("<i", 200))[0])
+        state.regfile.set_r_acc_word(1, struct.unpack("<I", struct.pack("<i", -200))[0])
+        run_until_complete(state)
+        result = state.regfile.get_post_aaq_reg()
+        assert result[0] == 127, f"expected 127, got {result[0]}"
+        assert result[1] == 0x80, f"expected 0x80 (-128), got {result[1]}"
+
+    def test_in_range_values_pass_through(self):
+        """Values in [-128, 127] are stored unchanged as bytes."""
+        state = _make_state(
+            """\
+ACTIVATE.QUANTIZE identity cr15;;
+BKPT;;
+"""
+        )
+        state.dtype = DType.INT8
+        state.set_cr_dstructure(128)
         buf = bytearray(512)
-        struct.pack_into("<128i", buf, 0, *values)
+        struct.pack_into("<128i", buf, 0, *[i - 64 for i in range(128)])
         state.regfile.set_r_acc_bytes(buf)
-        state.regfile.set_post_aaq_reg(bytearray(buf))
-
-    def test_aaq_basic_clamp(self):
-        """Direct clamp: values already in [-128, 127] pass through unchanged."""
-        state = IpuState()
-        state.dtype = DType.INT8
-        # Lanes 0..127 hold the signed value (i - 64): -64..63, all in range.
-        self._set_acc_words(state, [i - 64 for i in range(128)])
-
-        encoded = assemble("aaq cr15;;\nBKPT;;")
-        from ipu_emu.execute import decode_instruction_word
-        from ipu_emu.emulator import load_program, run_until_complete
-        decoded = [decode_instruction_word(w) for w in encoded]
-        load_program(state, decoded)
         run_until_complete(state)
-
         result = state.regfile.get_post_aaq_reg()
         for i in range(128):
-            expected = i - 64
-            assert result[i] == (expected & 0xFF), f"byte {i}: expected {expected & 0xFF}, got {result[i]}"
-        assert result[128:] == bytearray(384), "tail of POST_AAQ_REG should be cleared"
-
-    def test_aaq_all_zeros(self):
-        """All-zero accumulator quantizes to all-zero bytes."""
-        state = IpuState()
-        state.dtype = DType.INT8
-        self._set_acc_words(state, [0] * 128)
-
-        encoded = assemble("aaq cr15;;\nBKPT;;")
-        from ipu_emu.execute import decode_instruction_word
-        from ipu_emu.emulator import load_program, run_until_complete
-        decoded = [decode_instruction_word(w) for w in encoded]
-        load_program(state, decoded)
-        run_until_complete(state)
-
-        assert state.regfile.get_post_aaq_reg() == bytearray(512)
-
-    def test_aaq_positive_clamp(self):
-        """Direct clamp: values above 127 saturate to 127."""
-        state = IpuState()
-        state.dtype = DType.INT8
-        # 127 stays 127; large positive int32 saturates to 127.
-        values = [127] * 64 + [0x7FFFFFFF] * 64
-        self._set_acc_words(state, values)
-
-        encoded = assemble("aaq cr15;;\nBKPT;;")
-        from ipu_emu.execute import decode_instruction_word
-        from ipu_emu.emulator import load_program, run_until_complete
-        decoded = [decode_instruction_word(w) for w in encoded]
-        load_program(state, decoded)
-        run_until_complete(state)
-
-        result = state.regfile.get_post_aaq_reg()
-        for i in range(128):
-            assert result[i] == 127, f"byte {i}: expected 127, got {result[i]}"
+            expected = (i - 64) & 0xFF
+            assert result[i] == expected, f"byte {i}: expected {expected}, got {result[i]}"
         assert result[128:] == bytearray(384)
 
-    def test_aaq_negative_values(self):
-        """Direct clamp: in-range negatives pass through; below -128 saturates to -128."""
-        state = IpuState()
-        state.dtype = DType.INT8
-        # -1 stays -1 (0xFF); large negative int32 saturates to -128 (0x80).
-        values = [-1] * 64 + [-(1 << 30)] * 64
-        self._set_acc_words(state, values)
-
-        encoded = assemble("aaq cr15;;\nBKPT;;")
-        from ipu_emu.execute import decode_instruction_word
-        from ipu_emu.emulator import load_program, run_until_complete
-        decoded = [decode_instruction_word(w) for w in encoded]
-        load_program(state, decoded)
-        run_until_complete(state)
-
-        result = state.regfile.get_post_aaq_reg()
-        for i in range(64):
-            assert result[i] == 0xFF, f"byte {i}: expected 0xFF (-1), got {result[i]}"
-        for i in range(64, 128):
-            assert result[i] == 0x80, f"byte {i}: expected 0x80 (-128), got {result[i]}"
-        assert result[128:] == bytearray(384)
-
-    def test_aaq_requires_int8_mode(self):
-        """aaq raises EmulatorError when not in INT8 mode."""
+    def test_requires_int8_mode(self):
+        """Raises EmulatorError when not in INT8 mode."""
         from ipu_emu.ipu import EmulatorError
-        state = _make_state("aaq cr15;;\nBKPT;;")
+        state = _make_state("ACTIVATE.QUANTIZE relu cr15;;\nBKPT;;")
         state.dtype = DType.E4
         with pytest.raises(EmulatorError, match="INT8 mode"):
             run_until_complete(state)
 
-    def test_aaq_uses_named_cr_register(self):
-        """AAQ naming CR3 quantizes all 128 lanes from CR3, ignoring CR15.valid_elements < 128."""
-        state = IpuState()
+    def test_inactive_lanes_zeroed(self):
+        """Inactive lanes (beyond valid_elements) are zeroed in POST_AAQ_REG."""
+        state = _make_state(
+            """\
+ACTIVATE.QUANTIZE relu cr15;;
+BKPT;;
+"""
+        )
         state.dtype = DType.INT8
-        state.set_cr_dstructure(valid_elements=64)
+        state.set_cr_dstructure(valid_elements=2)
+        state.regfile.set_r_acc_word(0, struct.unpack("<I", struct.pack("<i", -5))[0])
+        state.regfile.set_r_acc_word(1, struct.unpack("<I", struct.pack("<i", -3))[0])
+        for i in range(2, 128):
+            state.regfile.set_r_acc_word(i, struct.unpack("<I", struct.pack("<i", 99))[0])
+        run_until_complete(state)
+        result = state.regfile.get_post_aaq_reg()
+        assert result[0] == 0, "relu(-5) = 0"
+        assert result[1] == 0, "relu(-3) = 0"
+        assert result[2:] == bytearray(510), "inactive lanes must be zeroed"
+
+    def test_uses_named_cr_register(self):
+        """CR3 with valid_elements=128 overrides CR15 with valid_elements=4."""
+        state = _make_state(
+            """\
+ACTIVATE.QUANTIZE relu cr3;;
+BKPT;;
+"""
+        )
+        state.dtype = DType.INT8
+        state.set_cr_dstructure(valid_elements=4)
         state.regfile.set_cr(3, encode_dstructure(valid_elements=128, partition=0))
-        self._set_acc_words(state, [1] * 128)  # in-range; direct clamp leaves 1 -> 1
-
-        encoded = assemble("aaq cr3;;\nBKPT;;")
-        from ipu_emu.execute import decode_instruction_word
-        from ipu_emu.emulator import load_program, run_until_complete
-        decoded = [decode_instruction_word(w) for w in encoded]
-        load_program(state, decoded)
+        # use values 1..127 (fit in INT8 after relu; value 0 maps to lane 127)
+        vals = [(i % 127) + 1 for i in range(128)]
+        for i, v in enumerate(vals):
+            state.regfile.set_r_acc_word(i, struct.unpack("<I", struct.pack("<i", v))[0])
         run_until_complete(state)
-
         result = state.regfile.get_post_aaq_reg()
-        assert result[:128] == bytearray([1] * 128), "all 128 lanes should be quantized"
-        assert result[128:] == bytearray(384)
+        for i, v in enumerate(vals):
+            assert result[i] == v, f"lane {i}: expected {v}, got {result[i]}"
 
-    def test_aaq_cr15_uses_valid_elements(self):
-        """AAQ naming CR15 reads CR15.valid_elements lanes; rest are zeroed."""
-        state = IpuState()
+    def test_cr15_uses_valid_elements(self):
+        """CR15.valid_elements=4 → only 4 active lanes; rest zeroed."""
+        state = _make_state(
+            """\
+ACTIVATE.QUANTIZE relu cr15;;
+BKPT;;
+"""
+        )
         state.dtype = DType.INT8
-        state.set_cr_dstructure(valid_elements=48)
-        self._set_acc_words(state, [1] * 128)  # in-range; direct clamp leaves 1 -> 1
-
-        encoded = assemble("aaq cr15;;\nBKPT;;")
-        from ipu_emu.execute import decode_instruction_word
-        from ipu_emu.emulator import load_program, run_until_complete
-        decoded = [decode_instruction_word(w) for w in encoded]
-        load_program(state, decoded)
+        state.set_cr_dstructure(valid_elements=4)
+        for i in range(128):
+            state.regfile.set_r_acc_word(i, struct.unpack("<I", struct.pack("<i", i + 1))[0])
         run_until_complete(state)
-
         result = state.regfile.get_post_aaq_reg()
-        assert result[:48] == bytearray([1] * 48), "first 48 lanes should be quantized"
-        assert result[48:] == bytearray(464), "remaining bytes should be zero"
+        for i in range(4):
+            assert result[i] == i + 1, f"lane {i}: expected {i+1}"
+        assert result[4:] == bytearray(508), "inactive lanes must be zeroed"
+
+    def test_elu_respects_ipu_state_alpha(self):
+        """elu with IpuState alpha: elu(-1, alpha=0.5) quantized."""
+        x = -1
+        alpha = 0.5
+        state = _make_state(
+            """\
+ACTIVATE.QUANTIZE elu cr15;;
+BKPT;;
+""",
+            elu_alpha=alpha,
+        )
+        state.dtype = DType.INT8
+        state.set_cr_dstructure(1)
+        state.regfile.set_r_acc_word(0, struct.unpack("<I", struct.pack("<i", x))[0])
+        run_until_complete(state)
+        expected = max(-128, min(127, int(round(apply_activation(7, float(x), elu_alpha=alpha)))))
+        assert state.regfile.get_post_aaq_reg()[0] == expected & 0xFF
+
+    def test_r_acc_not_modified(self):
+        """ACTIVATE.QUANTIZE does not modify r_acc."""
+        state = _make_state(
+            """\
+ACTIVATE.QUANTIZE relu cr15;;
+BKPT;;
+"""
+        )
+        state.dtype = DType.INT8
+        state.set_cr_dstructure(128)
+        raw = struct.unpack("<I", struct.pack("<i", -42))[0]
+        state.regfile.set_r_acc_word(0, raw)
+        run_until_complete(state)
+        assert state.regfile.get_r_acc_word(0) == raw
+
+
+class TestPostAaqReg:
+    """Tests for STR_POST_AAQ_REG and STR_ACC_REG (store instructions)."""
 
     def test_str_post_aaq_reg_writes_post_aaq_reg_512_to_xmem(self):
         """STR_POST_AAQ_REG stores POST_AAQ_REG (512 B) to XMEM."""
         state = IpuState()
         state.dtype = DType.INT8
-        self._set_acc_words(state, [i << 24 for i in range(128)])
         state.regfile.set_cr(8, 0x4000)
+        data = bytearray(range(256)) * 2
+        state.regfile.set_post_aaq_reg(data)
 
         encoded = assemble(
             """\
@@ -2068,329 +2108,3 @@ BKPT;;
 
         with pytest.warns(UserWarning, match="DEBUG ONLY"):
             run_until_complete(state)
-
-
-# ============================================================================
-# ACTIVATE (element-wise: r_acc → POST_AAQ_REG, issue #77)
-# ============================================================================
-
-
-def _post_aaq_lane_i32(state: IpuState, lane: int) -> int:
-    buf = state.regfile.get_post_aaq_reg()
-    word = struct.unpack_from("<I", buf, lane * 4)[0]
-    return struct.unpack("<i", struct.pack("<I", word))[0]
-
-
-def _post_aaq_lane_f32(state: IpuState, lane: int) -> float:
-    buf = state.regfile.get_post_aaq_reg()
-    word = struct.unpack_from("<I", buf, lane * 4)[0]
-    return struct.unpack("<f", struct.pack("<I", word))[0]
-
-
-class TestActivate:
-    """ACTIVATE applies ipu_common.activations to r_acc lanes; results go to POST_AAQ_REG."""
-
-    def test_activate_relu_int32(self):
-        state = _make_state(
-            """\
-ACTIVATE relu cr15;;
-BKPT;;
-"""
-        )
-        state.dtype = DType.INT8
-        state.set_cr_dstructure(128)
-        state.regfile.set_r_acc_word(
-            0, struct.unpack("<I", struct.pack("<i", -9))[0]
-        )
-        run_until_complete(state)
-        assert (
-            struct.unpack("<i", struct.pack("<I", state.regfile.get_r_acc_word(0)))[0]
-            == -9
-        )
-        assert _post_aaq_lane_i32(state, 0) == 0
-
-    def test_activate_masks_inactive_lanes(self):
-        state = _make_state(
-            """\
-ACTIVATE relu cr15;;
-BKPT;;
-"""
-        )
-        state.dtype = DType.INT8
-        state.set_cr_dstructure(2)
-        state.regfile.set_r_acc_word(
-            0, struct.unpack("<I", struct.pack("<i", -5))[0]
-        )
-        state.regfile.set_r_acc_word(
-            1, struct.unpack("<I", struct.pack("<i", -3))[0]
-        )
-        sentinel = struct.unpack("<I", struct.pack("<i", 99_999))[0]
-        for i in range(2, 128):
-            state.regfile.set_r_acc_word(i, sentinel)
-        post = bytearray(512)
-        for i in range(2, 128):
-            struct.pack_into("<i", post, i * 4, 99_999)
-        state.regfile.set_post_aaq_reg(post)
-        run_until_complete(state)
-        assert (
-            struct.unpack("<i", struct.pack("<I", state.regfile.get_r_acc_word(0)))[0]
-            == -5
-        )
-        assert (
-            struct.unpack("<i", struct.pack("<I", state.regfile.get_r_acc_word(1)))[0]
-            == -3
-        )
-        for i in range(2, 128):
-            assert state.regfile.get_r_acc_word(i) == sentinel
-        assert _post_aaq_lane_i32(state, 0) == 0
-        assert _post_aaq_lane_i32(state, 1) == 0
-        for i in range(2, 128):
-            assert _post_aaq_lane_i32(state, i) == 99_999
-
-    def test_activate_identity_keyword_is_noop(self):
-        state = _make_state(
-            """\
-ACTIVATE identity cr15;;
-BKPT;;
-"""
-        )
-        state.dtype = DType.INT8
-        state.set_cr_dstructure(1)
-        raw = struct.unpack("<I", struct.pack("<i", -42))[0]
-        state.regfile.set_r_acc_word(0, raw)
-        run_until_complete(state)
-        assert state.regfile.get_r_acc_word(0) == raw
-        assert _post_aaq_lane_i32(state, 0) == struct.unpack("<i", struct.pack("<I", raw))[0]
-
-    def test_activate_sigmoid_float_lane(self):
-        state = _make_state(
-            """\
-ACTIVATE sigmoid cr15;;
-BKPT;;
-"""
-        )
-        state.dtype = DType.E4
-        state.set_cr_dstructure(1)
-        state.regfile.set_r_acc_word(
-            0, struct.unpack("<I", struct.pack("<f", 0.0))[0]
-        )
-        run_until_complete(state)
-        out = _post_aaq_lane_f32(state, 0)
-        assert abs(out - 0.5) < 1e-6
-
-    def test_activate_matches_reference_all_ids_float(self):
-        x = 0.25
-        for fid, name in enumerate(ACTIVATION_FN_NAMES):
-            state = _make_state(
-                f"""\
-ACTIVATE {name} cr15;;
-BKPT;;
-"""
-            )
-            state.dtype = DType.E4
-            state.set_cr_dstructure(1)
-            state.regfile.set_r_acc_word(
-                0, struct.unpack("<I", struct.pack("<f", x))[0]
-            )
-            run_until_complete(state)
-            got = _post_aaq_lane_f32(state, 0)
-            exp = apply_activation(fid, x)
-            assert abs(got - exp) < 1e-5, f"id={fid} got={got} exp={exp}"
-
-    def test_activate_exp2_float(self):
-        state = _make_state(
-            """\
-ACTIVATE exp2 cr15;;
-BKPT;;
-"""
-        )
-        state.dtype = DType.E4
-        state.set_cr_dstructure(1)
-        state.regfile.set_r_acc_word(
-            0, struct.unpack("<I", struct.pack("<f", 3.0))[0]
-        )
-        run_until_complete(state)
-        out = _post_aaq_lane_f32(state, 0)
-        assert abs(out - 8.0) < 1e-5
-
-    def test_activate_gelu_float(self):
-        state = _make_state(
-            """\
-ACTIVATE gelu cr15;;
-BKPT;;
-"""
-        )
-        state.dtype = DType.E4
-        state.set_cr_dstructure(1)
-        x = 1.0
-        state.regfile.set_r_acc_word(
-            0, struct.unpack("<I", struct.pack("<f", x))[0]
-        )
-        run_until_complete(state)
-        out = _post_aaq_lane_f32(state, 0)
-        assert abs(out - apply_activation(5, x)) < 1e-5
-
-    def test_activate_elu_respects_ipu_state_alpha(self):
-        """``IpuState`` α overrides module defaults for ``ACTIVATE`` (not CR)."""
-        x = -1.0
-        alpha = 0.5
-        state = _make_state(
-            """\
-ACTIVATE elu cr15;;
-BKPT;;
-""",
-            elu_alpha=alpha,
-        )
-        state.dtype = DType.E4
-        state.set_cr_dstructure(1)
-        state.regfile.set_r_acc_word(
-            0, struct.unpack("<I", struct.pack("<f", x))[0]
-        )
-        run_until_complete(state)
-        out = _post_aaq_lane_f32(state, 0)
-        exp = apply_activation(7, x, elu_alpha=alpha)
-        assert abs(out - exp) < 1e-5
-
-    def test_activate_elu_after_set_activation_alphas(self):
-        x = -2.0
-        alpha = 0.125
-        state = _make_state(
-            """\
-ACTIVATE elu cr15;;
-BKPT;;
-"""
-        )
-        state.set_activation_alphas(elu_alpha=alpha)
-        state.dtype = DType.E4
-        state.set_cr_dstructure(1)
-        state.regfile.set_r_acc_word(
-            0, struct.unpack("<I", struct.pack("<f", x))[0]
-        )
-        run_until_complete(state)
-        out = _post_aaq_lane_f32(state, 0)
-        exp = apply_activation(7, x, elu_alpha=alpha)
-        assert abs(out - exp) < 1e-5
-
-    def test_activate_valid_elements_from_cr15(self):
-        state = _make_state(
-            """\
-ACTIVATE relu cr15;;
-BKPT;;
-"""
-        )
-        state.dtype = DType.INT8
-        state.set_cr_dstructure(1)
-        state.regfile.set_r_acc_word(
-            0, struct.unpack("<I", struct.pack("<i", -8))[0]
-        )
-        tail = struct.unpack("<I", struct.pack("<i", 123))[0]
-        state.regfile.set_r_acc_word(1, tail)
-        run_until_complete(state)
-        assert (
-            struct.unpack("<i", struct.pack("<I", state.regfile.get_r_acc_word(0)))[0]
-            == -8
-        )
-        assert state.regfile.get_r_acc_word(1) == tail
-        assert _post_aaq_lane_i32(state, 0) == 0
-        assert _post_aaq_lane_i32(state, 1) == 0
-
-    def test_activate_reciprocal_float(self):
-        state = _make_state(
-            """\
-ACTIVATE reciprocal cr15;;
-BKPT;;
-"""
-        )
-        state.dtype = DType.E4
-        state.set_cr_dstructure(1)
-        x = 4.0
-        state.regfile.set_r_acc_word(
-            0, struct.unpack("<I", struct.pack("<f", x))[0]
-        )
-        run_until_complete(state)
-        out = _post_aaq_lane_f32(state, 0)
-        assert abs(out - 0.25) < 1e-6
-
-    def test_activate_reciprocal_zero_input(self):
-        state = _make_state(
-            """\
-ACTIVATE reciprocal cr15;;
-BKPT;;
-"""
-        )
-        state.dtype = DType.E4
-        state.set_cr_dstructure(1)
-        state.regfile.set_r_acc_word(
-            0, struct.unpack("<I", struct.pack("<f", 0.0))[0]
-        )
-        run_until_complete(state)
-        out = _post_aaq_lane_f32(state, 0)
-        assert out == 0.0
-
-    def test_activate_rsqrt_float(self):
-        state = _make_state(
-            """\
-ACTIVATE rsqrt cr15;;
-BKPT;;
-"""
-        )
-        state.dtype = DType.E4
-        state.set_cr_dstructure(1)
-        x = 4.0
-        state.regfile.set_r_acc_word(
-            0, struct.unpack("<I", struct.pack("<f", x))[0]
-        )
-        run_until_complete(state)
-        out = _post_aaq_lane_f32(state, 0)
-        assert abs(out - 0.5) < 1e-6
-
-    def test_activate_rsqrt_nonpositive_input(self):
-        state = _make_state(
-            """\
-ACTIVATE rsqrt cr15;;
-BKPT;;
-"""
-        )
-        state.dtype = DType.E4
-        state.set_cr_dstructure(1)
-        state.regfile.set_r_acc_word(
-            0, struct.unpack("<I", struct.pack("<f", 0.0))[0]
-        )
-        run_until_complete(state)
-        out = _post_aaq_lane_f32(state, 0)
-        assert out == 0.0
-
-    def test_activate_uses_named_cr_register(self):
-        """ACTIVATE naming CR3 activates all 128 lanes from CR3, ignoring CR15.valid_elements < 128."""
-        state = _make_state(
-            """\
-ACTIVATE relu cr3;;
-BKPT;;
-"""
-        )
-        state.dtype = DType.INT8
-        state.set_cr_dstructure(valid_elements=4)
-        state.regfile.set_cr(3, encode_dstructure(valid_elements=128, partition=0))
-        for i in range(128):
-            state.regfile.set_r_acc_word(i, struct.unpack("<I", struct.pack("<i", i + 1))[0])
-        run_until_complete(state)
-        for i in range(128):
-            assert _post_aaq_lane_i32(state, i) == i + 1, f"lane {i} should be activated"
-
-    def test_activate_cr15_uses_valid_elements(self):
-        """ACTIVATE naming CR15 reads CR15.valid_elements lanes; rest unchanged."""
-        state = _make_state(
-            """\
-ACTIVATE relu cr15;;
-BKPT;;
-"""
-        )
-        state.dtype = DType.INT8
-        state.set_cr_dstructure(valid_elements=4)
-        for i in range(128):
-            state.regfile.set_r_acc_word(i, struct.unpack("<I", struct.pack("<i", i + 1))[0])
-        run_until_complete(state)
-        for i in range(4):
-            assert _post_aaq_lane_i32(state, i) == i + 1, f"lane {i} should be activated"
-        for i in range(4, 128):
-            assert _post_aaq_lane_i32(state, i) == 0, f"lane {i} should be untouched (zero)"

--- a/src/tools/ipu-emu-py/test/test_wide_vector_debug.py
+++ b/src/tools/ipu-emu-py/test/test_wide_vector_debug.py
@@ -73,7 +73,8 @@ BKPT;;
             v = struct.unpack_from("<f", acc, i * 4)[0]
             assert v == pytest.approx(6.0), f"lane {i}"
 
-    def test_aaq_noop_unless_quantize_flag(self) -> None:
+    def test_activate_quantize_noop_unless_quantize_flag(self) -> None:
+        """ACTIVATE.QUANTIZE without wide_vector_quantize_output leaves POST_AAQ_REG all zero."""
         state = _run_wide(
             """\
 SET lr0 cr6;;
@@ -84,15 +85,15 @@ LDR_CYCLIC_MULT_REG lr1 cr0 lr2;;
 MULT.RC.VV lr2 r0 0 lr2 cr15;;
 acc.add.first;;
 SET lr0 cr9;;
-ACTIVATE identity cr15;;
-aaq cr15;;
+ACTIVATE.QUANTIZE identity cr15;;
 BKPT;;
 """,
             cr={6: 0x1000, 7: 0x2000, 8: 0, 9: 128},
         )
         assert state.regfile.get_post_aaq_reg() == bytearray(512)
 
-    def test_aaq_quantize_fp32_acc_for_comparison(self) -> None:
+    def test_activate_quantize_fp32_acc_for_comparison(self) -> None:
+        """ACTIVATE.QUANTIZE with wide_vector_quantize_output quantizes FP32 acc lanes to INT8."""
         # Use exact float product 3.0 so rounding is unambiguous (round-half-even).
         r0 = struct.pack("<128f", *([1.5] * 128))
         rc = struct.pack("<128f", *([2.0] * 128))
@@ -113,8 +114,7 @@ LDR_CYCLIC_MULT_REG lr1 cr0 lr2;;
 MULT.RC.VV lr2 r0 0 lr2 cr15;;
 acc.add.first;;
 SET lr0 cr9;;
-ACTIVATE identity cr15;;
-aaq cr15;;
+ACTIVATE.QUANTIZE identity cr15;;
 BKPT;;
 """
         state.regfile.set_cr(6, 0x1000)


### PR DESCRIPTION
- Renamed `execute_aaq` to `execute_activate_quantize` to reflect the new functionality.
- Updated the method to apply element-wise activation followed by INT8 quantization.
- Adjusted the handling of active lanes based on the `valid_elements` from the specified CR register.
- Implemented clamping to the INT8 range during quantization.
- Modified tests to reflect the changes in the instruction name and behavior.
- Ensured that the `ACTIVATE.QUANTIZE` instruction does not modify the `r_acc` register.
- Added checks for INT8 mode requirements and zeroing of inactive lanes in the output.
- Updated wide vector debug tests to accommodate the new instruction and its behavior.