### PR TITLE
Add support for Sigmoid Linear Unit (SiLU) activation function

### DIFF
--- a/docs/content/specs/stage-aaq.md
+++ b/docs/content/specs/stage-aaq.md
@@ -140,6 +140,7 @@ Supported activation functions:
 | 8 | `exp2` | `f(x) = 2^x` | Used for dequantization, softmax and attention scaling. |
 | 9 | `reciprocal` | `f(x) = 1/x` (0 if x = 0) | Multiplicative inverse; useful for normalization. |
 | 10 | `rsqrt` | `f(x) = 1/√x` (0 if x ≤ 0) | Reciprocal square root; used in layer normalization. |
+| 11 | `silu` | `f(x) = x · σ(x)` | Sigmoid Linear Unit; used in SwiGLU/Swish activations. |
 
 ### 7.1 Aggregation (moved to the ACC stage)
 
@@ -233,7 +234,7 @@ but is never assumed).
 - **Summary:** Apply an element-wise activation function to the active lanes of `r_acc` and write the activated 32-bit lanes into `POST_AAQ_REG`. `r_acc` is not modified.
 - **Syntax:** `ACTIVATE activation_fn, cr_idx`
 - **Operands:**
-  - `activation_fn` — activation keyword (see §7.0): `identity`, `relu`, `relu6`, `sigmoid`, `tanh`, `gelu`, `softplus`, `elu`, `exp2`, `reciprocal`, `rsqrt`.
+  - `activation_fn` — activation keyword (see §7.0): `identity`, `relu`, `relu6`, `sigmoid`, `tanh`, `gelu`, `softplus`, `elu`, `exp2`, `reciprocal`, `rsqrt`, `silu`.
   - `cr_idx` — `CR0`…`CR15` — dstructure register supplying `valid_elements` (must be given explicitly; no implicit default).
 - **Operation:**
   ```text

--- a/src/tools/ipu-as-py/src/ipu_as/gen_docs.py
+++ b/src/tools/ipu-as-py/src/ipu_as/gen_docs.py
@@ -60,7 +60,7 @@ OPERAND_TYPE_DETAILS: dict[str, str] = {
     ),
     "ActivationFn": (
         "AAQ-slot keyword on **`ACTIVATE`**: one of **identity**, **relu**, **relu6**, "
-        "**sigmoid**, **tanh**, **gelu**, **softplus**, **elu**, **exp2** "
+        "**sigmoid**, **tanh**, **gelu**, **softplus**, **elu**, **exp2**, **reciprocal**, **rsqrt**, **silu** "
         "(see ``ACTIVATION_FN_NAMES`` in ``ipu_common.activations``). Emulator-only calibration (including α) "
         "and how **`POST_AAQ_REG`** (interim **512 B**) and **`STR_POST_AAQ_REG`** (store to XMEM) "
         "are described in **Building Applications** "

--- a/src/tools/ipu-common/src/ipu_common/activations.py
+++ b/src/tools/ipu-common/src/ipu_common/activations.py
@@ -5,7 +5,7 @@ Encodings match ``docs/content/specs/stage-aaq.md`` section 7.0. α for
 :class:`ipu_emu.ipu_state.IpuState` constructor or
 :meth:`IpuState.set_activation_alphas` (not CR-visible). Assembly uses
 ``ACTIVATE … <name>`` where ``<name>`` is one of the strings in
-``ACTIVATION_FN_NAMES`` (same order as ids **0**–**10**); the emulator writes
+``ACTIVATION_FN_NAMES`` (same order as ids **0**–**11**); the emulator writes
 activated lanes into ``POST_AAQ_REG``. See
 ``docs/content/building-applications.md#activations-emulator`` for calibration,
 ``STR_POST_AAQ_REG`` (store that register to XMEM), and pipeline notes.
@@ -26,8 +26,9 @@ ACTIVATION_ELU = 7
 ACTIVATION_EXP2 = 8
 ACTIVATION_RECIPROCAL = 9
 ACTIVATION_RSQRT = 10
+ACTIVATION_SILU = 11
 
-ACTIVATION_COUNT = 11
+ACTIVATION_COUNT = 12
 
 # Assembly / encoding order (id = index); must match ACTIVATION_* constants above.
 ACTIVATION_FN_NAMES: tuple[str, ...] = (
@@ -42,6 +43,7 @@ ACTIVATION_FN_NAMES: tuple[str, ...] = (
     "exp2",
     "reciprocal",
     "rsqrt",
+    "silu",
 )
 
 # Default α value — virtual configuration outside the ISA (issue #77).
@@ -79,7 +81,7 @@ def apply_activation(
     *,
     elu_alpha: float | None = None,
 ) -> float:
-    """Apply activation ``fn_id`` (0–10) to scalar ``x``. Unknown ids → identity.
+    """Apply activation ``fn_id`` (0–11) to scalar ``x``. Unknown ids → identity.
 
     If ``elu_alpha`` is omitted, the value comes from the module
     ``DEFAULT_ELU_ALPHA`` constant (snapshotted onto
@@ -114,4 +116,6 @@ def apply_activation(
         return 1.0 / x if x != 0.0 else 0.0
     if k == ACTIVATION_RSQRT:
         return 1.0 / math.sqrt(x) if x > 0.0 else 0.0
+    if k == ACTIVATION_SILU:
+        return x * _sigmoid(x)
     return x

--- a/src/tools/ipu-common/src/ipu_common/instruction_spec.py
+++ b/src/tools/ipu-common/src/ipu_common/instruction_spec.py
@@ -932,18 +932,18 @@ INSTRUCTION_SPEC = {
                     "The activation is selected by keyword (see ACTIVATION_FN_NAMES). The available "
                     "activation functions are: ``identity`` (0), ``relu`` (1), ``relu6`` (2), "
                     "``sigmoid`` (3), ``tanh`` (4), ``gelu`` (5), ``softplus`` (6), ``elu`` (7), "
-                    "``exp2`` (8), ``reciprocal`` (9), ``rsqrt`` (10). For Python emulator calibration (virtual α), see "
+                    "``exp2`` (8), ``reciprocal`` (9), ``rsqrt`` (10), ``silu`` (11). For Python emulator calibration (virtual α), see "
                     "docs/content/building-applications.md#activations-emulator."
                 ),
                 syntax="ACTIVATE activation_fn, cr_idx",
                 operands=[
-                    "activation_fn: keyword naming the activation (one of identity, relu, relu6, sigmoid, tanh, gelu, softplus, elu, exp2; see ACTIVATION_FN_NAMES)",
+                    "activation_fn: keyword naming the activation (one of identity, relu, relu6, sigmoid, tanh, gelu, softplus, elu, exp2, reciprocal, rsqrt, silu; see ACTIVATION_FN_NAMES)",
                     "cr_idx: CR0…CR15 supplying valid_elements (must be given explicitly)",
                 ],
                 operation=(
                     "Let n = min(CR[cr_idx].valid_elements, 128) and k = encoded activation index. "
                     "For i in [0, n): POST_AAQ_REG[i] = activation_k(R_ACC[i]) (same 32-bit lane format as R_ACC). "
-                    "R_ACC is not modified. The selector uses four bits; encodings outside the eleven named "
+                    "R_ACC is not modified. The selector uses four bits; encodings outside the twelve named "
                     "activations behave as identity. "
                     "α for elu is not an ISA operand; see "
                     "docs/content/building-applications.md#activations-emulator."

--- a/src/tools/ipu-emu-py/test/test_execute.py
+++ b/src/tools/ipu-emu-py/test/test_execute.py
@@ -7,6 +7,7 @@ inline assembly into encoded instruction words, load them into an
 
 from __future__ import annotations
 
+import math
 import struct
 
 import numpy as np
@@ -2359,6 +2360,42 @@ BKPT;;
         run_until_complete(state)
         out = _post_aaq_lane_f32(state, 0)
         assert out == 0.0
+
+    def test_activate_silu_float(self):
+        state = _make_state(
+            """\
+ACTIVATE silu cr15;;
+BKPT;;
+"""
+        )
+        state.dtype = DType.E4
+        state.set_cr_dstructure(1)
+        x = 2.0
+        state.regfile.set_r_acc_word(
+            0, struct.unpack("<I", struct.pack("<f", x))[0]
+        )
+        run_until_complete(state)
+        out = _post_aaq_lane_f32(state, 0)
+        expected = x / (1.0 + math.exp(-x))
+        assert abs(out - expected) < 1e-5
+
+    def test_activate_silu_negative_input(self):
+        state = _make_state(
+            """\
+ACTIVATE silu cr15;;
+BKPT;;
+"""
+        )
+        state.dtype = DType.E4
+        state.set_cr_dstructure(1)
+        x = -1.0
+        state.regfile.set_r_acc_word(
+            0, struct.unpack("<I", struct.pack("<f", x))[0]
+        )
+        run_until_complete(state)
+        out = _post_aaq_lane_f32(state, 0)
+        expected = x / (1.0 + math.exp(-x))
+        assert abs(out - expected) < 1e-5
 
     def test_activate_uses_named_cr_register(self):
         """ACTIVATE naming CR3 activates all 128 lanes from CR3, ignoring CR15.valid_elements < 128."""


### PR DESCRIPTION
## Changes

- **`activations.py`** — adds `ACTIVATION_SILU = 11`, increments `ACTIVATION_COUNT` to 12, appends `"silu"` to `ACTIVATION_FN_NAMES`, and adds the `silu` branch in `apply_activation` (reuses the existing `_sigmoid` helper).
- **`instruction_spec.py`** — updates the `ACTIVATE` doc to list `silu` (11) among available activation functions; corrects "eleven named" → "twelve named".
- **`gen_docs.py`** — adds `silu` (and the previously missing `reciprocal`/`rsqrt`) to the `ActivationFn` operand description.
- **`docs/content/specs/stage-aaq.md`** — adds `silu` row to the §7.0 activation encoding table and updates the `ACTIVATE` operand list.
- **Generated docs** — regenerated `instructions.md` and `operand-types.md` via `bazel run //docs:gen_docs`.
- **`test_execute.py`** — adds `test_activate_silu_float` (x = 2.0) and `test_activate_silu_negative_input` (x = −1.0); both verify output against the reference formula within 1e-5.